### PR TITLE
Add objective additions for missing task items

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,1 @@
+{"singleQuote": true, "semi": true, "tabWidth": 2, "trailingComma": "es5", "printWidth": 80}

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -101,6 +101,47 @@ To patch a specific objective within a task, use the objective's ID as a key:
 }
 ```
 
+You can also patch objective item lists (for TaskObjectiveItem objectives) by
+providing an `items` array:
+
+```json5
+{
+  // Task Name - Missing objective items
+  // Proof: [link]
+  "task-id-here": {
+    "objectives": {
+      "objective-id-here": {
+        "items": [
+          { "id": "item-id-1", "name": "Item Name 1" },
+          { "id": "item-id-2", "name": "Item Name 2" }
+        ]
+      }
+    }
+  }
+}
+```
+
+If tarkov.dev is missing the objective entirely, add it using `objectivesAdd`:
+
+```json5
+{
+  // Task Name - Missing objective in API
+  // Proof: [link]
+  "task-id-here": {
+    "objectivesAdd": [
+      {
+        "id": "objective-id-here",
+        "description": "Find in raid",
+        "items": [
+          { "name": "Item Name 1" },
+          { "name": "Item Name 2", "id": "item-id-2" }
+        ]
+      }
+    ]
+  }
+}
+```
+
 ---
 
 ## Local Development

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -8,7 +8,7 @@ How to use tarkov-data-overlay in your application.
 
 The overlay is distributed via jsDelivr CDN:
 
-```
+```bash
 https://cdn.jsdelivr.net/gh/tarkovtracker-org/tarkov-data-overlay@main/dist/overlay.json
 ```
 
@@ -98,7 +98,7 @@ function applyTaskOverlay(baseTask: Task, overlay: Overlay): Task {
 
   // Apply top-level fields
   for (const [key, value] of Object.entries(taskOverride)) {
-    if (key === 'objectives') continue; // Handle separately
+    if (key === 'objectives' || key === 'objectivesAdd') continue; // Handle separately
     (result as any)[key] = value;
   }
 
@@ -110,9 +110,23 @@ function applyTaskOverlay(baseTask: Task, overlay: Overlay): Task {
     });
   }
 
+  // Append missing objectives
+  if (taskOverride.objectivesAdd && Array.isArray(taskOverride.objectivesAdd)) {
+    result.objectives = [
+      ...(result.objectives || []),
+      ...taskOverride.objectivesAdd,
+    ] as any;
+  }
+
   return result;
 }
 ```
+
+### With Added Objectives
+
+If tarkov.dev is missing objectives (like new Collector items), you can append
+them using `objectivesAdd` in the overlay. The merge example above already
+handles this by appending `objectivesAdd` to the objective list.
 
 ---
 
@@ -145,7 +159,7 @@ async function fetchTasks(): Promise<Task[]> {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
-      query: `{ tasks { id name minPlayerLevel map { id name } objectives { id count } } }`
+      query: `{ tasks { id name minPlayerLevel map { id name } objectives { id count ... on TaskObjectiveItem { items { id name } } } } }`
     })
   });
   const { data } = await response.json();
@@ -198,14 +212,26 @@ interface TaskOverride {
   disabled?: boolean;
   map?: { id: string; name: string };
   objectives?: Record<string, ObjectiveOverride>;
+  objectivesAdd?: ObjectiveAdd[];
   // ... other fields
 }
 
 interface ObjectiveOverride {
   count?: number;
   maps?: Array<{ id: string; name: string }>;
+  items?: Array<{ id?: string; name: string }>;
   // ... other fields
 }
+
+interface ObjectiveAdd {
+  id: string;
+  count?: number;
+  description: string;
+  maps?: Array<{ id: string; name: string }>;
+  items?: Array<{ id?: string; name: string }>;
+}
+
+// Note: objectivesAdd allows name-only items; objective patches should include IDs.
 
 interface Edition {
   id: string;

--- a/examples/apply-overlay.ts
+++ b/examples/apply-overlay.ts
@@ -16,6 +16,7 @@ interface TaskObjective {
   description: string;
   count?: number;
   maps?: TarkovMap[];
+  items?: Array<{ id?: string; name: string }>;
 }
 
 interface Task {
@@ -30,12 +31,22 @@ interface ObjectiveOverride {
   count?: number;
   description?: string;
   maps?: TarkovMap[];
+  items?: Array<{ id?: string; name: string }>;
+}
+
+interface ObjectiveAdd {
+  id: string;
+  count?: number;
+  description: string;
+  maps?: TarkovMap[];
+  items?: Array<{ id?: string; name: string }>;
 }
 
 interface TaskOverride {
   minPlayerLevel?: number;
   map?: TarkovMap;
   objectives?: Record<string, ObjectiveOverride>;
+  objectivesAdd?: ObjectiveAdd[];
 }
 
 interface Edition {
@@ -59,7 +70,8 @@ interface Overlay {
 
 // Configuration
 const TARKOV_DEV_API = 'https://api.tarkov.dev/graphql';
-const OVERLAY_URL = 'https://cdn.jsdelivr.net/gh/tarkovtracker-org/tarkov-data-overlay@main/dist/overlay.json';
+const OVERLAY_URL =
+  'https://cdn.jsdelivr.net/gh/tarkovtracker-org/tarkov-data-overlay@main/dist/overlay.json';
 
 /**
  * Fetch tasks from tarkov.dev GraphQL API
@@ -75,7 +87,7 @@ async function fetchTasksFromTarkovDev(): Promise<Task[]> {
         objectives {
           id
           description
-          ... on TaskObjectiveItem { count }
+          ... on TaskObjectiveItem { count items { id name } }
           ... on TaskObjectiveShoot { count }
           maps { id name }
         }
@@ -86,7 +98,7 @@ async function fetchTasksFromTarkovDev(): Promise<Task[]> {
   const response = await fetch(TARKOV_DEV_API, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ query })
+    body: JSON.stringify({ query }),
   });
 
   const { data } = await response.json();
@@ -106,30 +118,50 @@ async function fetchOverlay(): Promise<Overlay> {
  *
  * Handles both top-level field corrections and nested objective patches.
  */
-function applyTaskOverlay(task: Task, overlay: Overlay): Task {
+function applyTaskOverlay(task: Task, overlay: Overlay): Task | null {
   const taskOverride = overlay.tasks?.[task.id];
 
   // No override for this task
   if (!taskOverride) return task;
+
+  // Filter out disabled tasks (documented in INTEGRATION.md)
+  if ((taskOverride as Record<string, unknown>).disabled === true) return null;
 
   // Start with a copy of the original task
   const result: Task = { ...task };
 
   // Apply top-level field overrides (shallow merge)
   for (const [key, value] of Object.entries(taskOverride)) {
-    if (key === 'objectives') continue; // Handle separately
-    (result as Record<string, unknown>)[key] = value;
+    if (key === 'objectives' || key === 'objectivesAdd') continue; // Handle separately
+
+    // Type-safe property assignment
+    if (key === 'minPlayerLevel' && typeof value === 'number') {
+      result.minPlayerLevel = value;
+    } else if (key === 'map' && value) {
+      result.map = value as Task['map'];
+    } else {
+      // For any other properties, use type assertion
+      (result as unknown as Record<string, unknown>)[key] = value;
+    }
   }
 
   // Apply objective-level patches (ID-keyed)
   if (taskOverride.objectives && task.objectives) {
-    result.objectives = task.objectives.map(objective => {
+    result.objectives = task.objectives.map((objective) => {
       const patch = taskOverride.objectives![objective.id];
       if (!patch) return objective;
 
-      // Shallow merge the objective with its patch
+      // Shallow merge the objective with its patch (supports count, description, maps, items)
       return { ...objective, ...patch };
     });
+  }
+
+  // Append missing objectives
+  if (taskOverride.objectivesAdd) {
+    result.objectives = [
+      ...(result.objectives || []),
+      ...taskOverride.objectivesAdd,
+    ];
   }
 
   return result;
@@ -139,7 +171,9 @@ function applyTaskOverlay(task: Task, overlay: Overlay): Task {
  * Apply overlay to all tasks
  */
 function applyOverlayToTasks(tasks: Task[], overlay: Overlay): Task[] {
-  return tasks.map(task => applyTaskOverlay(task, overlay));
+  return tasks
+    .map((task) => applyTaskOverlay(task, overlay))
+    .filter((task): task is Task => task !== null);
 }
 
 /**
@@ -161,9 +195,11 @@ async function main() {
   // Show corrections applied
   console.log('Corrections applied:');
   for (const task of correctedTasks) {
-    const original = tasks.find(t => t.id === task.id)!;
+    const original = tasks.find((t) => t.id === task.id)!;
     if (original.minPlayerLevel !== task.minPlayerLevel) {
-      console.log(`  ${task.name}: level ${original.minPlayerLevel} → ${task.minPlayerLevel}`);
+      console.log(
+        `  ${task.name}: level ${original.minPlayerLevel} → ${task.minPlayerLevel}`
+      );
     }
   }
 

--- a/src/lib/task-validator.ts
+++ b/src/lib/task-validator.ts
@@ -94,7 +94,9 @@ function createFieldValidator<K extends keyof TaskOverride & keyof TaskData>(
       status: isMatch ? 'fixed' : 'needed',
       message: isMatch
         ? `${field}: ${formatValue(apiValue)} - FIXED IN API`
-        : `${field}: API=${formatValue(apiValue)}, Override=${formatValue(overrideValue)} - STILL NEEDED`,
+        : `${field}: API=${formatValue(apiValue)}, Override=${formatValue(
+            overrideValue
+          )} - STILL NEEDED`,
     };
   };
 }
@@ -104,7 +106,7 @@ function createFieldValidator<K extends keyof TaskOverride & keyof TaskData>(
  */
 function formatValue(value: unknown): string {
   if (value === undefined || value === null) return 'undefined';
-  if (typeof value === 'string') return `"${value}"`;
+  if (typeof value === 'string') return `'${value}'`;
   if (typeof value === 'object') return JSON.stringify(value);
   return String(value);
 }
@@ -116,7 +118,7 @@ const validateTaskRequirements: FieldValidator = (override, apiTask) => {
   if (override.taskRequirements === undefined) return null;
 
   const apiReqs = (apiTask.taskRequirements || []).filter(
-    r => !r.status || !r.status.includes('active')
+    (r) => !r.status || !r.status.includes('active')
   );
   const overrideReqs = override.taskRequirements;
 
@@ -129,14 +131,16 @@ const validateTaskRequirements: FieldValidator = (override, apiTask) => {
   }
 
   if (apiReqs.length > 0) {
-    const apiReqIds = apiReqs.map(r => r.task?.id).sort();
-    const overrideReqIds = overrideReqs.map(r => r.task?.id).sort();
+    const apiReqIds = apiReqs.map((r) => r.task?.id).sort();
+    const overrideReqIds = overrideReqs.map((r) => r.task?.id).sort();
 
     if (JSON.stringify(apiReqIds) !== JSON.stringify(overrideReqIds)) {
       return {
         field: 'taskRequirements',
         status: 'needed',
-        message: `taskRequirements: API has different requirements (${apiReqIds.join(', ')}) vs Override (${overrideReqIds.join(', ')}) - NEEDS REVIEW`,
+        message: `taskRequirements: API has different requirements (${apiReqIds.join(
+          ', '
+        )}) vs Override (${overrideReqIds.join(', ')}) - NEEDS REVIEW`,
       };
     }
 
@@ -174,7 +178,7 @@ export function validateTaskOverride(
   override: TaskOverride,
   apiTasks: TaskData[]
 ): ValidationResult {
-  const apiTask = apiTasks.find(t => t.id === taskId);
+  const apiTask = apiTasks.find((t) => t.id === taskId);
 
   // Task not found in API
   if (!apiTask) {
@@ -183,11 +187,13 @@ export function validateTaskOverride(
       name: 'Unknown',
       status: 'REMOVED_FROM_API',
       stillNeeded: false,
-      details: [{
-        field: 'task',
-        status: 'info',
-        message: 'Task not found in API - has been removed from tarkov.dev',
-      }],
+      details: [
+        {
+          field: 'task',
+          status: 'info',
+          message: 'Task not found in API - has been removed from tarkov.dev',
+        },
+      ],
     };
   }
 
@@ -198,11 +204,14 @@ export function validateTaskOverride(
       name: apiTask.name,
       status: 'REMOVED_FROM_API',
       stillNeeded: false,
-      details: [{
-        field: 'disabled',
-        status: 'info',
-        message: 'Task still in API but marked as disabled - should be removed from API or override can be removed',
-      }],
+      details: [
+        {
+          field: 'disabled',
+          status: 'info',
+          message:
+            'Task still in API but marked as disabled - should be removed from API or override can be removed',
+        },
+      ],
     };
   }
 
@@ -217,7 +226,7 @@ export function validateTaskOverride(
   // Handle nested objective validations separately for full detail
   if (override.objectives) {
     for (const [objId, objOverride] of Object.entries(override.objectives)) {
-      const apiObj = apiTask.objectives?.find(o => o.id === objId);
+      const apiObj = apiTask.objectives?.find((o) => o.id === objId);
 
       if (!apiObj) {
         details.push({
@@ -242,8 +251,32 @@ export function validateTaskOverride(
     }
   }
 
+  // Check if added objectives have appeared in API
+  if (override.objectivesAdd) {
+    for (const added of override.objectivesAdd) {
+      const apiMatch = apiTask.objectives?.find(
+        (o) => o.id === added.id || o.description === added.description
+      );
+      if (apiMatch) {
+        details.push({
+          field: `objectivesAdd:${added.id || added.description}`,
+          status: 'fixed',
+          message: `added objective '${added.description}': NOW IN API - MOVE TO OBJECTIVES OR REMOVE`,
+        });
+      } else {
+        details.push({
+          field: `objectivesAdd:${added.id || added.description}`,
+          status: 'needed',
+          message: `added objective '${added.description}': Still missing from API - STILL NEEDED`,
+        });
+      }
+    }
+  }
+
   // Determine overall status
-  const needsOverride = details.some(d => d.status === 'needed' || d.status === 'check');
+  const needsOverride = details.some(
+    (d) => d.status === 'needed' || d.status === 'check'
+  );
   const status: ValidationStatus = needsOverride ? 'NEEDED' : 'FIXED';
 
   return {
@@ -276,8 +309,8 @@ export function validateAllOverrides(
  */
 export function categorizeResults(results: ValidationResult[]) {
   return {
-    stillNeeded: results.filter(r => r.stillNeeded),
-    fixed: results.filter(r => r.status === 'FIXED'),
-    removedFromApi: results.filter(r => r.status === 'REMOVED_FROM_API'),
+    stillNeeded: results.filter((r) => r.stillNeeded),
+    fixed: results.filter((r) => r.status === 'FIXED'),
+    removedFromApi: results.filter((r) => r.status === 'REMOVED_FROM_API'),
   };
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -15,6 +15,7 @@ export interface TaskOverride {
   kappaRequired?: boolean;
   lightkeeperRequired?: boolean;
   objectives?: Record<string, ObjectiveOverride>;
+  objectivesAdd?: ObjectiveAdd[];
   taskRequirements?: TaskRequirement[];
   experience?: number;
   finishRewards?: TaskFinishRewards;
@@ -54,6 +55,22 @@ export interface TaskItemRef {
 
 /** Objective override for nested corrections */
 export interface ObjectiveOverride extends Omit<Partial<TaskObjective>, "id"> {}
+
+/** Objective addition for missing objectives */
+/** Task item reference for added objectives (allows name-only references) */
+export interface TaskItemRefAdd {
+  id?: string;
+  name: string;
+  shortName?: string;
+}
+
+/** Objective addition for missing objectives */
+export interface ObjectiveAdd
+  extends Omit<Partial<TaskObjective>, "id" | "description" | "items"> {
+  id: string;
+  description: string;
+  items?: TaskItemRefAdd[];
+}
 
 /** Task requirement reference */
 export interface TaskRequirement {

--- a/src/overrides/tasks.json5
+++ b/src/overrides/tasks.json5
@@ -152,6 +152,24 @@
     },
   },
 
+  // Collector - Missing objective items
+  // Proof: https://media.discordapp.net/attachments/939662655306727525/1454719855935754354/image.png?ex=6956ba31&is=695568b1&hm=4f32259e81560c12ad91ddfab68d5d25325b27218ac782862ad4db2e04813668&=&format=webp&quality=lossless
+  "5c51aac186f77432ea65c552": {
+    objectivesAdd: [
+      {
+        id: "collector-missing-items-1",
+        description: "Hand over the found in raid Collector items",
+        items: [
+          { id: "69398e94ca94fd2877039504", name: "Nut Sack balaclava" },
+          { id: "6937edb912d456a817083e82", name: "Mazoni golden dumbbell" },
+          { id: "6937ecf8628ee476240c07cb", name: "Tigzresq splint" },
+          { id: "6937f02dfd6488bb27024839", name: "Domontovich ushanka hat" },
+        ],
+      },
+    ],
+    // Was: objectives missing in API
+  },
+
   // Test Drive - Part 2 - Objective description/maps and experience incorrect
   // Proof: https://escapefromtarkov.fandom.com/wiki/Test_Drive_-_Part_2
   // Recent wiki update (post-1.0); not verified in-game

--- a/src/schemas/task-override.schema.json
+++ b/src/schemas/task-override.schema.json
@@ -8,6 +8,139 @@
         "description": "Mark task as disabled/removed from standard gameplay. Consumers should filter out disabled tasks.",
         "type": "boolean"
       },
+      "objectivesAdd": {
+        "type": "array",
+        "description": "Objective additions for missing API objectives",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": { "type": "string" },
+            "type": { "type": "string" },
+            "containsAll": {
+              "items": {
+                "properties": {
+                  "id": { "type": "string" },
+                  "name": { "type": "string" },
+                  "shortName": { "type": "string" }
+                },
+                "required": ["id", "name"],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "count": { "type": "integer", "minimum": 1 },
+            "description": { "type": "string" },
+            "foundInRaid": { "type": "boolean" },
+            "item": {
+              "properties": {
+                "id": { "type": "string" },
+                "name": { "type": "string" },
+                "shortName": { "type": "string" }
+              },
+              "required": ["id", "name"],
+              "type": "object"
+            },
+            "maps": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": { "type": "string" },
+                  "name": { "type": "string" }
+                },
+                "required": ["id", "name"]
+              }
+            },
+            "markerItem": {
+              "properties": {
+                "id": { "type": "string" },
+                "name": { "type": "string" },
+                "shortName": { "type": "string" }
+              },
+              "required": ["id", "name"],
+              "type": "object"
+            },
+            "items": {
+              "type": "array",
+              "description": "Objective items can be referenced by name only when adding missing objectives.",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": { "type": "string" },
+                  "name": { "type": "string" },
+                  "shortName": { "type": "string" }
+                },
+                "required": ["name"]
+              }
+            },
+            "questItem": {
+              "properties": {
+                "id": { "type": "string" },
+                "name": { "type": "string" },
+                "shortName": { "type": "string" }
+              },
+              "required": ["id", "name"],
+              "type": "object"
+            },
+            "requiredKeys": {
+              "items": {
+                "items": {
+                  "properties": {
+                    "id": { "type": "string" },
+                    "name": { "type": "string" },
+                    "shortName": { "type": "string" }
+                  },
+                  "required": ["id", "name"],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            },
+            "useAny": {
+              "items": {
+                "properties": {
+                  "id": { "type": "string" },
+                  "name": { "type": "string" },
+                  "shortName": { "type": "string" }
+                },
+                "required": ["id", "name"],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "usingWeapon": {
+              "items": {
+                "properties": {
+                  "id": { "type": "string" },
+                  "name": { "type": "string" },
+                  "shortName": { "type": "string" }
+                },
+                "required": ["id", "name"],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "usingWeaponMods": {
+              "items": {
+                "items": {
+                  "properties": {
+                    "id": { "type": "string" },
+                    "name": { "type": "string" },
+                    "shortName": { "type": "string" }
+                  },
+                  "required": ["id", "name"],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "type": "array"
+            }
+          },
+          "required": ["id", "description"],
+          "additionalProperties": false
+        }
+      },
       "experience": {
         "description": "Experience points rewarded on task completion",
         "minimum": 0,

--- a/tests/task-validator.test.ts
+++ b/tests/task-validator.test.ts
@@ -26,7 +26,11 @@ describe('validateTaskOverride', () => {
   describe('when task not found in API', () => {
     it('returns REMOVED_FROM_API status', () => {
       const override: TaskOverride = { minPlayerLevel: 15 };
-      const result = validateTaskOverride('non-existent-id', override, apiTasks);
+      const result = validateTaskOverride(
+        'non-existent-id',
+        override,
+        apiTasks
+      );
 
       expect(result.status).toBe('REMOVED_FROM_API');
       expect(result.stillNeeded).toBe(false);
@@ -51,7 +55,11 @@ describe('validateTaskOverride', () => {
 
       expect(result.status).toBe('NEEDED');
       expect(result.stillNeeded).toBe(true);
-      expect(result.details.some(d => d.field === 'minPlayerLevel' && d.status === 'needed')).toBe(true);
+      expect(
+        result.details.some(
+          (d) => d.field === 'minPlayerLevel' && d.status === 'needed'
+        )
+      ).toBe(true);
     });
 
     it('returns FIXED when API value matches override', () => {
@@ -60,7 +68,11 @@ describe('validateTaskOverride', () => {
 
       expect(result.status).toBe('FIXED');
       expect(result.stillNeeded).toBe(false);
-      expect(result.details.some(d => d.field === 'minPlayerLevel' && d.status === 'fixed')).toBe(true);
+      expect(
+        result.details.some(
+          (d) => d.field === 'minPlayerLevel' && d.status === 'fixed'
+        )
+      ).toBe(true);
     });
   });
 
@@ -104,7 +116,9 @@ describe('validateTaskOverride', () => {
       const override: TaskOverride = {
         objectives: { 'obj-1': { count: 8 } },
       };
-      const result = validateTaskOverride('test-task-id', override, [apiTaskWithObjectives]);
+      const result = validateTaskOverride('test-task-id', override, [
+        apiTaskWithObjectives,
+      ]);
 
       expect(result.status).toBe('NEEDED');
       expect(result.stillNeeded).toBe(true);
@@ -114,7 +128,9 @@ describe('validateTaskOverride', () => {
       const override: TaskOverride = {
         objectives: { 'obj-1': { count: 5 } },
       };
-      const result = validateTaskOverride('test-task-id', override, [apiTaskWithObjectives]);
+      const result = validateTaskOverride('test-task-id', override, [
+        apiTaskWithObjectives,
+      ]);
 
       expect(result.status).toBe('FIXED');
       expect(result.stillNeeded).toBe(false);
@@ -124,10 +140,76 @@ describe('validateTaskOverride', () => {
       const override: TaskOverride = {
         objectives: { 'non-existent-obj': { count: 5 } },
       };
-      const result = validateTaskOverride('test-task-id', override, [apiTaskWithObjectives]);
+      const result = validateTaskOverride('test-task-id', override, [
+        apiTaskWithObjectives,
+      ]);
 
       expect(result.stillNeeded).toBe(true);
-      expect(result.details.some(d => d.status === 'check')).toBe(true);
+      expect(result.details.some((d) => d.status === 'check')).toBe(true);
+    });
+  });
+
+  describe('objectivesAdd validation', () => {
+    it('returns FIXED when an added objective appears in API (by ID)', () => {
+      const apiTask = createApiTask({
+        objectives: [{ id: 'new-obj-id', description: 'Some description' }],
+      });
+      const override: TaskOverride = {
+        objectivesAdd: [{ id: 'new-obj-id', description: 'Some description' }],
+      };
+      const result = validateTaskOverride('test-task-id', override, [apiTask]);
+
+      expect(result.status).toBe('FIXED');
+      expect(result.stillNeeded).toBe(false);
+      expect(
+        result.details.some(
+          (d) => d.status === 'fixed' && d.message.includes('NOW IN API')
+        )
+      ).toBe(true);
+    });
+
+    it('returns FIXED when an added objective appears in API (by description)', () => {
+      const apiTask = createApiTask({
+        objectives: [{ id: 'api-id', description: 'Unique Description' }],
+      });
+      const override: TaskOverride = {
+        objectivesAdd: [{ id: 'manual-id', description: 'Unique Description' }],
+      };
+      const result = validateTaskOverride('test-task-id', override, [apiTask]);
+
+      expect(result.status).toBe('FIXED');
+      expect(result.stillNeeded).toBe(false);
+    });
+
+    it('returns NEEDED when added objective is not in API', () => {
+      const apiTask = createApiTask({ objectives: [] });
+      const override: TaskOverride = {
+        objectivesAdd: [{ id: 'manual-id', description: 'Not in API' }],
+      };
+      const result = validateTaskOverride('test-task-id', override, [apiTask]);
+
+      expect(result.status).toBe('NEEDED');
+      expect(result.stillNeeded).toBe(true);
+    });
+
+    it('accepts name-only items in objectivesAdd', () => {
+      const apiTask = createApiTask({ objectives: [] });
+      const override: TaskOverride = {
+        objectivesAdd: [
+          {
+            id: 'manual-obj',
+            description: 'Find items',
+            items: [
+              { name: 'Item Without ID' },
+              { id: 'item-2', name: 'Item With ID' },
+            ],
+          },
+        ],
+      };
+      const result = validateTaskOverride('test-task-id', override, [apiTask]);
+
+      expect(result.status).toBe('NEEDED');
+      expect(result.stillNeeded).toBe(true);
     });
   });
 
@@ -184,18 +266,42 @@ describe('validateAllOverrides', () => {
     const results = validateAllOverrides(overrides, apiTasks);
 
     expect(results).toHaveLength(2);
-    expect(results.find(r => r.id === 'task-1')?.status).toBe('FIXED');
-    expect(results.find(r => r.id === 'task-2')?.status).toBe('NEEDED');
+    expect(results.find((r) => r.id === 'task-1')?.status).toBe('FIXED');
+    expect(results.find((r) => r.id === 'task-2')?.status).toBe('NEEDED');
   });
 });
 
 describe('categorizeResults', () => {
   it('categorizes results into stillNeeded, fixed, and removedFromApi', () => {
     const results = [
-      { id: '1', name: 'Task 1', status: 'NEEDED' as const, stillNeeded: true, details: [] },
-      { id: '2', name: 'Task 2', status: 'FIXED' as const, stillNeeded: false, details: [] },
-      { id: '3', name: 'Task 3', status: 'REMOVED_FROM_API' as const, stillNeeded: false, details: [] },
-      { id: '4', name: 'Task 4', status: 'NEEDED' as const, stillNeeded: true, details: [] },
+      {
+        id: '1',
+        name: 'Task 1',
+        status: 'NEEDED' as const,
+        stillNeeded: true,
+        details: [],
+      },
+      {
+        id: '2',
+        name: 'Task 2',
+        status: 'FIXED' as const,
+        stillNeeded: false,
+        details: [],
+      },
+      {
+        id: '3',
+        name: 'Task 3',
+        status: 'REMOVED_FROM_API' as const,
+        stillNeeded: false,
+        details: [],
+      },
+      {
+        id: '4',
+        name: 'Task 4',
+        status: 'NEEDED' as const,
+        stillNeeded: true,
+        details: [],
+      },
     ];
 
     const categorized = categorizeResults(results);


### PR DESCRIPTION
## Description
Add overlay support for missing task objectives via objectivesAdd, allow objective items by name-only, and add the four missing Collector items using that mechanism (proof placeholder TBC).

## Type of Change
  - [ ] Data correction (fixing incorrect tarkov.dev data)
  - [x] New data addition (data not in tarkov.dev)
  - [x] Schema update
  - [x] Documentation update
  - [ ] Build/tooling update

## Proof of Correctness
failed to upload an image :(

## Checklist
  - [ ] I have included proof links in the JSON5 comments
  - [ ] I have noted the original incorrect value in inline comments
  - [x] I have included the entity name as a comment above each ID
  - [x] Field names match tarkov.dev schema exactly (camelCase)
  - [ ] Validation passes locally (npm run validate)

## Related Issues
  Closes #