### PR TITLE
feat: add winter 2025 event tasks

### DIFF
--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -35,6 +35,16 @@ async function fetchOverlay() {
       "map": { "id": "...", "name": "Customs" }
     }
   },
+  "tasksAdd": {
+    "<added-task-id>": {
+      "id": "<added-task-id>",
+      "name": "Missing in Action",
+      "wikiLink": "https://escapefromtarkov.fandom.com/wiki/Missing_in_Action",
+      "trader": { "id": "...", "name": "Prapor" },
+      "maps": [{ "id": "...", "name": "Woods" }],
+      "objectives": [{ "id": "...", "description": "Stash ..." }]
+    }
+  },
   "editions": {
     "standard": { "id": "standard", "title": "Standard Edition", ... },
     "unheard": { "id": "unheard", "title": "The Unheard Edition", ... }
@@ -143,6 +153,16 @@ const unheardEdition = editions?.unheard;
 console.log(unheardEdition?.stashLevel); // 5
 ```
 
+### Task Additions (Event-Only / Missing from API)
+
+Tasks that are not present in tarkov.dev are provided under `tasksAdd`. Consumers
+should treat these as new tasks and append them to the API task list.
+
+```typescript
+const addedTasks = Object.values(overlay.tasksAdd ?? {});
+const allTasks = [...tasksFromApi, ...addedTasks];
+```
+
 ---
 
 ## Full Integration Example
@@ -196,6 +216,7 @@ async function getTasksWithOverlay(): Promise<Task[]> {
 ```typescript
 interface Overlay {
   tasks?: Record<string, TaskOverride>;
+  tasksAdd?: Record<string, TaskAddition>;
   items?: Record<string, ItemOverride>;
   editions?: Record<string, Edition>;
   $meta: {
@@ -214,6 +235,26 @@ interface TaskOverride {
   objectives?: Record<string, ObjectiveOverride>;
   objectivesAdd?: ObjectiveAdd[];
   // ... other fields
+}
+
+interface TaskAddition {
+  id: string;
+  name: string;
+  wikiLink: string;
+  trader: { id?: string; name: string };
+  map?: { id: string; name: string } | null;
+  maps?: Array<{ id: string; name: string }>;
+  objectives: TaskObjectiveAdd[];
+  // ... other fields
+}
+
+interface TaskObjectiveAdd {
+  id: string;
+  description: string;
+  count?: number;
+  maps?: Array<{ id: string; name: string }>;
+  item?: { id: string; name: string; shortName?: string };
+  markerItem?: { id: string; name: string; shortName?: string };
 }
 
 interface ObjectiveOverride {

--- a/src/additions/tasksAdd.json5
+++ b/src/additions/tasksAdd.json5
@@ -1,0 +1,468 @@
+{
+  // Winter 2025 event tasks not available in tarkov.dev.
+  // Proof: https://escapefromtarkov.fandom.com/wiki/Missing_in_Action
+  // Proof: https://escapefromtarkov.fandom.com/wiki/Clearing_the_Way
+  // Proof: https://escapefromtarkov.fandom.com/wiki/Come_by_the_Fire
+  // Proof: https://escapefromtarkov.fandom.com/wiki/Knuckle_Sandwich
+  // Proof: https://escapefromtarkov.fandom.com/wiki/A_Small_Celebration
+
+  "winter_2025_missing_in_action": {
+    "id": "winter_2025_missing_in_action",
+    "name": "Missing in Action",
+    "wikiLink": "https://escapefromtarkov.fandom.com/wiki/Missing_in_Action",
+    "trader": {
+      "id": "54cb50c76803fa8b248b4571",
+      "name": "Prapor"
+    },
+    "maps": [
+      { "id": "5704e3c2d2720bac5b8b4567", "name": "Woods" },
+      { "id": "5704e5fad2720bc05b8b4567", "name": "Reserve" },
+      { "id": "5714dbc024597771384a510d", "name": "Interchange" }
+    ],
+    "kappaRequired": false,
+    "objectives": [
+      {
+        "id": "winter_2025_missing_in_action_obj01",
+        "description": "Stash a Pack of Arseniy buckwheat at the Scav house on Woods",
+        "maps": [{ "id": "5704e3c2d2720bac5b8b4567", "name": "Woods" }],
+        "item": {
+          "id": "6389c6463485cf0eeb260715",
+          "name": "Pack of Arseniy buckwheat",
+          "shortName": "Buckwheat"
+        },
+        "count": 1
+      },
+      {
+        "id": "winter_2025_missing_in_action_obj02",
+        "description": "Stash a Bottle of Tarkovskaya vodka at the Scav house on Woods",
+        "maps": [{ "id": "5704e3c2d2720bac5b8b4567", "name": "Woods" }],
+        "item": {
+          "id": "5d40407c86f774318526545a",
+          "name": "Bottle of Tarkovskaya vodka",
+          "shortName": "Vodka"
+        },
+        "count": 1
+      },
+      {
+        "id": "winter_2025_missing_in_action_obj03",
+        "description": "Stash an Iskra ration pack at the Scav house on Woods",
+        "maps": [{ "id": "5704e3c2d2720bac5b8b4567", "name": "Woods" }],
+        "item": {
+          "id": "590c5d4b86f774784e1b9c45",
+          "name": "Iskra ration pack",
+          "shortName": "Iskra"
+        },
+        "count": 1
+      },
+      {
+        "id": "winter_2025_missing_in_action_obj04",
+        "description": "Stash a Pack of Arseniy buckwheat at the guard barrack on Reserve",
+        "maps": [{ "id": "5704e5fad2720bc05b8b4567", "name": "Reserve" }],
+        "item": {
+          "id": "6389c6463485cf0eeb260715",
+          "name": "Pack of Arseniy buckwheat",
+          "shortName": "Buckwheat"
+        },
+        "count": 1
+      },
+      {
+        "id": "winter_2025_missing_in_action_obj05",
+        "description": "Stash a Bottle of Tarkovskaya vodka at the guard barrack on Reserve",
+        "maps": [{ "id": "5704e5fad2720bc05b8b4567", "name": "Reserve" }],
+        "item": {
+          "id": "5d40407c86f774318526545a",
+          "name": "Bottle of Tarkovskaya vodka",
+          "shortName": "Vodka"
+        },
+        "count": 1
+      },
+      {
+        "id": "winter_2025_missing_in_action_obj06",
+        "description": "Stash an Iskra ration pack at the guard barrack on Reserve",
+        "maps": [{ "id": "5704e5fad2720bc05b8b4567", "name": "Reserve" }],
+        "item": {
+          "id": "590c5d4b86f774784e1b9c45",
+          "name": "Iskra ration pack",
+          "shortName": "Iskra"
+        },
+        "count": 1
+      },
+      {
+        "id": "winter_2025_missing_in_action_obj07",
+        "description": "Stash a Pack of Arseniy buckwheat at the Path to River shack on Interchange",
+        "maps": [{ "id": "5714dbc024597771384a510d", "name": "Interchange" }],
+        "item": {
+          "id": "6389c6463485cf0eeb260715",
+          "name": "Pack of Arseniy buckwheat",
+          "shortName": "Buckwheat"
+        },
+        "count": 1
+      },
+      {
+        "id": "winter_2025_missing_in_action_obj08",
+        "description": "Stash a Bottle of Tarkovskaya vodka at the Path to River shack on Interchange",
+        "maps": [{ "id": "5714dbc024597771384a510d", "name": "Interchange" }],
+        "item": {
+          "id": "5d40407c86f774318526545a",
+          "name": "Bottle of Tarkovskaya vodka",
+          "shortName": "Vodka"
+        },
+        "count": 1
+      },
+      {
+        "id": "winter_2025_missing_in_action_obj09",
+        "description": "Stash an Iskra ration pack at the Path to River shack on Interchange",
+        "maps": [{ "id": "5714dbc024597771384a510d", "name": "Interchange" }],
+        "item": {
+          "id": "590c5d4b86f774784e1b9c45",
+          "name": "Iskra ration pack",
+          "shortName": "Iskra"
+        },
+        "count": 1
+      }
+    ],
+    "experience": 5000,
+    "finishRewards": {
+      "items": [
+        {
+          "count": 21000,
+          "item": { "id": "5449016a4bdc2d6f028b456f", "name": "Roubles", "shortName": "RUB" }
+        },
+        {
+          "count": 1,
+          "item": {
+            "id": "6499849fc93611967b034949",
+            "name": "Kalashnikov AK-12 5.45x39 assault rifle",
+            "shortName": "AK-12"
+          }
+        },
+        {
+          "count": 3,
+          "item": {
+            "id": "649ec30cb013f04a700e60fb",
+            "name": "AK-12 5.45x39 early model 30-round magazine",
+            "shortName": "AK-12 old"
+          }
+        },
+        {
+          "count": 1,
+          "item": {
+            "id": "6570900858b315e8b70a8a98",
+            "name": "5.45x39mm 7N40 ammo pack (120 pcs)",
+            "shortName": "7N40"
+          }
+        }
+      ],
+      "traderStanding": [
+        {
+          "trader": { "id": "54cb50c76803fa8b248b4571", "name": "Prapor" },
+          "standing": 0.01
+        }
+      ]
+    }
+  },
+
+  "winter_2025_clearing_the_way": {
+    "id": "winter_2025_clearing_the_way",
+    "name": "Clearing the Way",
+    "wikiLink": "https://escapefromtarkov.fandom.com/wiki/Clearing_the_Way",
+    "trader": {
+      "id": "58330581ace78e27b8b10cee",
+      "name": "Skier"
+    },
+    "maps": [{ "id": "56f40101d2720b2a4d8b45d6", "name": "Customs" }],
+    "kappaRequired": false,
+    "taskRequirements": [
+      { "task": { "id": "winter_2025_missing_in_action", "name": "Missing in Action" } }
+    ],
+    "objectives": [
+      {
+        "id": "winter_2025_clearing_the_way_obj01",
+        "description": "Eliminate any 20 targets on Customs",
+        "maps": [{ "id": "56f40101d2720b2a4d8b45d6", "name": "Customs" }],
+        "count": 20
+      }
+    ],
+    "experience": 12000,
+    "finishRewards": {
+      "items": [
+        {
+          "count": 51000,
+          "item": { "id": "5449016a4bdc2d6f028b456f", "name": "Roubles", "shortName": "RUB" }
+        },
+        {
+          "count": 2,
+          "item": {
+            "id": "62a0a0bb621468534a797ad5",
+            "name": "Set of files \"Master\"",
+            "shortName": "Master"
+          }
+        },
+        {
+          "count": 2,
+          "item": {
+            "id": "5e2af00086f7746d3f3c33f7",
+            "name": "Smoked Chimney drain cleaner",
+            "shortName": "DCleaner"
+          }
+        }
+      ],
+      "traderStanding": [
+        {
+          "trader": { "id": "58330581ace78e27b8b10cee", "name": "Skier" },
+          "standing": 0.01
+        }
+      ]
+    }
+  },
+
+  "winter_2025_come_by_the_fire": {
+    "id": "winter_2025_come_by_the_fire",
+    "name": "Come by the Fire",
+    "wikiLink": "https://escapefromtarkov.fandom.com/wiki/Come_by_the_Fire",
+    "trader": {
+      "id": "58330581ace78e27b8b10cee",
+      "name": "Skier"
+    },
+    "maps": [{ "id": "5704e3c2d2720bac5b8b4567", "name": "Woods" }],
+    "kappaRequired": false,
+    "taskRequirements": [
+      { "task": { "id": "winter_2025_clearing_the_way", "name": "Clearing the Way" } }
+    ],
+    "objectives": [
+      {
+        "id": "winter_2025_come_by_the_fire_obj01",
+        "description": "Locate and mark the first spot from Skier's route with an MS2000 Marker",
+        "maps": [{ "id": "5704e3c2d2720bac5b8b4567", "name": "Woods" }],
+        "markerItem": { "id": "5991b51486f77447b112d44f", "name": "MS2000 Marker", "shortName": "MS2000" }
+      },
+      {
+        "id": "winter_2025_come_by_the_fire_obj02",
+        "description": "Locate and mark the second spot from Skier's route with an MS2000 Marker",
+        "maps": [{ "id": "5704e3c2d2720bac5b8b4567", "name": "Woods" }],
+        "markerItem": { "id": "5991b51486f77447b112d44f", "name": "MS2000 Marker", "shortName": "MS2000" }
+      },
+      {
+        "id": "winter_2025_come_by_the_fire_obj03",
+        "description": "Locate and mark the third spot from Skier's route with an MS2000 Marker",
+        "maps": [{ "id": "5704e3c2d2720bac5b8b4567", "name": "Woods" }],
+        "markerItem": { "id": "5991b51486f77447b112d44f", "name": "MS2000 Marker", "shortName": "MS2000" }
+      },
+      {
+        "id": "winter_2025_come_by_the_fire_obj04",
+        "description": "Locate and mark the fourth spot from Skier's route with an MS2000 Marker",
+        "maps": [{ "id": "5704e3c2d2720bac5b8b4567", "name": "Woods" }],
+        "markerItem": { "id": "5991b51486f77447b112d44f", "name": "MS2000 Marker", "shortName": "MS2000" }
+      },
+      {
+        "id": "winter_2025_come_by_the_fire_obj05",
+        "description": "Eliminate any 5 targets while wearing a Pompon hat on Woods",
+        "maps": [{ "id": "5704e3c2d2720bac5b8b4567", "name": "Woods" }],
+        "count": 5
+      }
+    ],
+    "experience": 10000,
+    "finishRewards": {
+      "items": [
+        {
+          "count": 42000,
+          "item": { "id": "5449016a4bdc2d6f028b456f", "name": "Roubles", "shortName": "RUB" }
+        },
+        {
+          "count": 1,
+          "item": {
+            "id": "5fc3f2d5900b1d5091531e57",
+            "name": "TDI KRISS Vector Gen.2 9x19 submachine gun",
+            "shortName": "Vector 9x19"
+          }
+        },
+        {
+          "count": 4,
+          "item": {
+            "id": "5a7ad2e851dfba0016153692",
+            "name": "Glock 9x19 \"Big Stick\" 33-round magazine",
+            "shortName": "Big Stick"
+          }
+        },
+        {
+          "count": 4,
+          "item": {
+            "id": "65702591c5d7d4cb4d07857c",
+            "name": "9x19mm AP 6.3 ammo pack (50 pcs)",
+            "shortName": "AP 6.3"
+          }
+        }
+      ],
+      "traderStanding": [
+        {
+          "trader": { "id": "58330581ace78e27b8b10cee", "name": "Skier" },
+          "standing": 0.01
+        }
+      ]
+    }
+  },
+
+  "winter_2025_knuckle_sandwich": {
+    "id": "winter_2025_knuckle_sandwich",
+    "name": "Knuckle Sandwich",
+    "wikiLink": "https://escapefromtarkov.fandom.com/wiki/Knuckle_Sandwich",
+    "trader": {
+      "id": "54cb50c76803fa8b248b4571",
+      "name": "Prapor"
+    },
+    "maps": [{ "id": "5704e3c2d2720bac5b8b4567", "name": "Woods" }],
+    "kappaRequired": false,
+    "taskRequirements": [
+      { "task": { "id": "winter_2025_come_by_the_fire", "name": "Come by the Fire" } }
+    ],
+    "objectives": [
+      {
+        "id": "winter_2025_knuckle_sandwich_obj01",
+        "description": "Stash a TP-200 TNT brick at the first spot from Skier's route",
+        "maps": [{ "id": "5704e3c2d2720bac5b8b4567", "name": "Woods" }],
+        "item": { "id": "60391b0fb847c71012789415", "name": "TP-200 TNT brick", "shortName": "TP-200" },
+        "count": 1
+      },
+      {
+        "id": "winter_2025_knuckle_sandwich_obj02",
+        "description": "Stash a TP-200 TNT brick at the second spot from Skier's route",
+        "maps": [{ "id": "5704e3c2d2720bac5b8b4567", "name": "Woods" }],
+        "item": { "id": "60391b0fb847c71012789415", "name": "TP-200 TNT brick", "shortName": "TP-200" },
+        "count": 1
+      },
+      {
+        "id": "winter_2025_knuckle_sandwich_obj03",
+        "description": "Stash a TP-200 TNT brick at the third spot from Skier's route",
+        "maps": [{ "id": "5704e3c2d2720bac5b8b4567", "name": "Woods" }],
+        "item": { "id": "60391b0fb847c71012789415", "name": "TP-200 TNT brick", "shortName": "TP-200" },
+        "count": 1
+      },
+      {
+        "id": "winter_2025_knuckle_sandwich_obj04",
+        "description": "Stash a TP-200 TNT brick at the fourth spot from Skier's route",
+        "maps": [{ "id": "5704e3c2d2720bac5b8b4567", "name": "Woods" }],
+        "item": { "id": "60391b0fb847c71012789415", "name": "TP-200 TNT brick", "shortName": "TP-200" },
+        "count": 1
+      },
+      {
+        "id": "winter_2025_knuckle_sandwich_obj05",
+        "description": "Eliminate any 15 targets while wearing a Ushanka ear flap hat on Woods",
+        "maps": [{ "id": "5704e3c2d2720bac5b8b4567", "name": "Woods" }],
+        "count": 15
+      }
+    ],
+    "experience": 15000,
+    "finishRewards": {
+      "items": [
+        {
+          "count": 63000,
+          "item": { "id": "5449016a4bdc2d6f028b456f", "name": "Roubles", "shortName": "RUB" }
+        },
+        {
+          "count": 2,
+          "item": { "id": "59e35de086f7741778269d84", "name": "Electric drill", "shortName": "Drill" }
+        },
+        {
+          "count": 2,
+          "item": { "id": "590a3c0a86f774385a33c450", "name": "Spark plug", "shortName": "SPlug" }
+        }
+      ],
+      "traderStanding": [
+        {
+          "trader": { "id": "54cb50c76803fa8b248b4571", "name": "Prapor" },
+          "standing": 0.01
+        }
+      ]
+    }
+  },
+
+  "winter_2025_a_small_celebration": {
+    "id": "winter_2025_a_small_celebration",
+    "name": "A Small Celebration",
+    "wikiLink": "https://escapefromtarkov.fandom.com/wiki/A_Small_Celebration",
+    "trader": {
+      "id": "5ac3b934156ae10c4430e83c",
+      "name": "Ragman"
+    },
+    "maps": [
+      { "id": "56f40101d2720b2a4d8b45d6", "name": "Customs" },
+      { "id": "5714dbc024597771384a510d", "name": "Interchange" },
+      { "id": "5704e4dad2720bb55b8b4567", "name": "Lighthouse" },
+      { "id": "5704e5fad2720bc05b8b4567", "name": "Reserve" },
+      { "id": "5704e554d2720bac5b8b456e", "name": "Shoreline" },
+      { "id": "5704e3c2d2720bac5b8b4567", "name": "Woods" }
+    ],
+    "kappaRequired": false,
+    "taskRequirements": [
+      { "task": { "id": "winter_2025_knuckle_sandwich", "name": "Knuckle Sandwich" } }
+    ],
+    "objectives": [
+      {
+        "id": "winter_2025_a_small_celebration_obj01",
+        "description": "Launch a firework in the appropriate spot",
+        "maps": [
+          { "id": "56f40101d2720b2a4d8b45d6", "name": "Customs" },
+          { "id": "5714dbc024597771384a510d", "name": "Interchange" },
+          { "id": "5704e4dad2720bb55b8b4567", "name": "Lighthouse" },
+          { "id": "5704e5fad2720bc05b8b4567", "name": "Reserve" },
+          { "id": "5704e554d2720bac5b8b456e", "name": "Shoreline" },
+          { "id": "5704e3c2d2720bac5b8b4567", "name": "Woods" }
+        ],
+        "item": {
+          "id": "675ea3d6312c0a5c4e04e317",
+          "name": "RSP-30 reactive signal cartridge (Firework)",
+          "shortName": "Firework"
+        },
+        "count": 1
+      },
+      {
+        "id": "winter_2025_a_small_celebration_obj02",
+        "description": "Eat some Olivier salad",
+        "item": {
+          "id": "67586b7e49c2fa592e0d8ed9",
+          "name": "Olivier salad box",
+          "shortName": "Salad"
+        },
+        "count": 1
+      },
+      {
+        "id": "winter_2025_a_small_celebration_obj03",
+        "description": "Drink some vodka",
+        "item": {
+          "id": "5d40407c86f774318526545a",
+          "name": "Bottle of Tarkovskaya vodka",
+          "shortName": "Vodka"
+        },
+        "count": 1
+      }
+    ],
+    "experience": 20000,
+    // Wiki lists Roubles as "???" and an achievement unlock (Whiteout).
+    "finishRewards": {
+      "items": [
+        {
+          "count": 2,
+          "item": {
+            "id": "544a5caa4bdc2d1a388b4568",
+            "name": "Crye Precision AVS plate carrier (Ranger Green)",
+            "shortName": "AVS"
+          }
+        },
+        {
+          "count": 1,
+          "item": {
+            "id": "67600929bd0a0549d70993f6",
+            "name": "Ballistic plate case",
+            "shortName": "Plates"
+          }
+        }
+      ],
+      "traderStanding": [
+        {
+          "trader": { "id": "5ac3b934156ae10c4430e83c", "name": "Ragman" },
+          "standing": 0.01
+        }
+      ]
+    }
+  }
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -78,6 +78,30 @@ export interface TaskRequirement {
   status?: string[];
 }
 
+/** Task addition structure for new tasks not in tarkov.dev */
+export interface TaskAddition {
+  id: string;
+  name: string;
+  wikiLink: string;
+  trader: { id?: string; name: string };
+  map?: { id: string; name: string } | null;
+  maps?: Array<{ id: string; name: string }>;
+  objectives: TaskObjectiveAdd[];
+  taskRequirements?: TaskRequirement[];
+  experience?: number;
+  finishRewards?: TaskFinishRewards;
+  kappaRequired?: boolean;
+  lightkeeperRequired?: boolean;
+  disabled?: boolean;
+}
+
+/** Objective definition for task additions */
+export interface TaskObjectiveAdd
+  extends Omit<Partial<TaskObjective>, "id" | "description"> {
+  id: string;
+  description: string;
+}
+
 /** Task data from tarkov.dev API */
 export interface TaskData {
   id: string;
@@ -117,6 +141,7 @@ export interface ValidationDetail {
 /** Built overlay output structure */
 export interface OverlayOutput {
   tasks?: Record<string, TaskOverride>;
+  tasksAdd?: Record<string, TaskAddition>;
   items?: Record<string, unknown>;
   traders?: Record<string, unknown>;
   hideout?: Record<string, unknown>;
@@ -149,5 +174,6 @@ export interface SchemaConfig {
 /** Default schema configurations */
 export const SCHEMA_CONFIGS: SchemaConfig[] = [
   { pattern: "tasks.json5", schemaFile: "task-override.schema.json" },
+  { pattern: "tasksAdd.json5", schemaFile: "task-additions.schema.json" },
   { pattern: "editions.json5", schemaFile: "edition.schema.json" },
 ];

--- a/src/schemas/overlay.schema.json
+++ b/src/schemas/overlay.schema.json
@@ -8,6 +8,9 @@
     "tasks": {
       "$ref": "task-override.schema.json"
     },
+    "tasksAdd": {
+      "$ref": "task-additions.schema.json"
+    },
     "items": {
       "type": "object",
       "description": "Item corrections"

--- a/src/schemas/task-additions.schema.json
+++ b/src/schemas/task-additions.schema.json
@@ -1,0 +1,286 @@
+{
+  "$id": "task-additions.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Task Additions",
+  "description": "Schema for new tasks not available in tarkov.dev",
+  "type": "object",
+  "additionalProperties": {
+    "type": "object",
+    "additionalProperties": true,
+    "properties": {
+      "id": {
+        "description": "Unique identifier for the added task",
+        "type": "string"
+      },
+      "name": {
+        "description": "Task name",
+        "type": "string"
+      },
+      "wikiLink": {
+        "description": "Quest wiki link",
+        "type": "string"
+      },
+      "disabled": {
+        "description": "Mark task as disabled/removed from standard gameplay",
+        "type": "boolean"
+      },
+      "kappaRequired": {
+        "description": "Whether task is required for Kappa container",
+        "type": "boolean"
+      },
+      "lightkeeperRequired": {
+        "description": "Whether task is required for Lightkeeper access",
+        "type": "boolean"
+      },
+      "trader": {
+        "description": "Trader who gives the task",
+        "additionalProperties": false,
+        "properties": {
+          "id": { "type": "string" },
+          "name": { "type": "string" }
+        },
+        "required": ["name"],
+        "type": "object"
+      },
+      "map": {
+        "description": "Primary map for the task",
+        "anyOf": [
+          {
+            "additionalProperties": false,
+            "properties": {
+              "id": { "type": "string" },
+              "name": { "type": "string" }
+            },
+            "required": ["id", "name"],
+            "type": "object"
+          },
+          { "type": "null" }
+        ]
+      },
+      "maps": {
+        "description": "Maps where the task takes place",
+        "type": "array",
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "id": { "type": "string" },
+            "name": { "type": "string" }
+          },
+          "required": ["id", "name"],
+          "type": "object"
+        }
+      },
+      "objectives": {
+        "description": "Task objectives",
+        "type": "array",
+        "items": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "id": { "type": "string" },
+            "type": { "type": "string" },
+            "description": { "type": "string" },
+            "count": { "type": "integer", "minimum": 1 },
+            "foundInRaid": { "type": "boolean" },
+            "maps": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "id": { "type": "string" },
+                  "name": { "type": "string" }
+                },
+                "required": ["id", "name"]
+              }
+            },
+            "item": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "id": { "type": "string" },
+                "name": { "type": "string" },
+                "shortName": { "type": "string" }
+              },
+              "required": ["id", "name"]
+            },
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "id": { "type": "string" },
+                  "name": { "type": "string" },
+                  "shortName": { "type": "string" }
+                },
+                "required": ["id", "name"]
+              }
+            },
+            "markerItem": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "id": { "type": "string" },
+                "name": { "type": "string" },
+                "shortName": { "type": "string" }
+              },
+              "required": ["id", "name"]
+            },
+            "questItem": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "id": { "type": "string" },
+                "name": { "type": "string" },
+                "shortName": { "type": "string" }
+              },
+              "required": ["id", "name"]
+            },
+            "containsAll": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "id": { "type": "string" },
+                  "name": { "type": "string" },
+                  "shortName": { "type": "string" }
+                },
+                "required": ["id", "name"]
+              }
+            },
+            "requiredKeys": {
+              "type": "array",
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "id": { "type": "string" },
+                    "name": { "type": "string" },
+                    "shortName": { "type": "string" }
+                  },
+                  "required": ["id", "name"]
+                }
+              }
+            },
+            "useAny": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "id": { "type": "string" },
+                  "name": { "type": "string" },
+                  "shortName": { "type": "string" }
+                },
+                "required": ["id", "name"]
+              }
+            },
+            "usingWeapon": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "id": { "type": "string" },
+                  "name": { "type": "string" },
+                  "shortName": { "type": "string" }
+                },
+                "required": ["id", "name"]
+              }
+            },
+            "usingWeaponMods": {
+              "type": "array",
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "id": { "type": "string" },
+                    "name": { "type": "string" },
+                    "shortName": { "type": "string" }
+                  },
+                  "required": ["id", "name"]
+                }
+              }
+            }
+          },
+          "required": ["id", "description"]
+        }
+      },
+      "taskRequirements": {
+        "description": "Task prerequisites/requirements",
+        "type": "array",
+        "items": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "task": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "id": { "type": "string" },
+                "name": { "type": "string" }
+              },
+              "required": ["id", "name"]
+            }
+          },
+          "required": ["task"]
+        }
+      },
+      "experience": {
+        "description": "Experience points rewarded on task completion",
+        "minimum": 0,
+        "type": "integer"
+      },
+      "finishRewards": {
+        "description": "Rewards given on task completion",
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "count": { "type": "integer", "minimum": 1 },
+                "item": {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "string" },
+                    "name": { "type": "string" },
+                    "shortName": { "type": "string" }
+                  },
+                  "required": ["id", "name"]
+                }
+              },
+              "required": ["item", "count"]
+            }
+          },
+          "traderStanding": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "standing": { "type": "number" },
+                "trader": {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "string" },
+                    "name": { "type": "string" }
+                  },
+                  "required": ["name"]
+                }
+              },
+              "required": ["trader", "standing"]
+            }
+          }
+        }
+      }
+    },
+    "required": ["id", "name", "wikiLink", "trader", "objectives"]
+  }
+}


### PR DESCRIPTION
## Description
  Add a new tasksAdd additions path (schema + types + docs) so we can include event-only quests not present in tarkov.dev. Populate it with the Winter 2025 task chain from Missing in Action through A Small Celebration, including objectives, rewards, and map/trader links. No dist/overlay.json update included.

## Type of Change
  - [ ] Data correction (fixing incorrect tarkov.dev data)
  - [x] New data addition (data not in tarkov.dev)
  - [x] Schema update
  - [x] Documentation update
  - [ ] Build/tooling update

## Proof of Correctness
  - https://escapefromtarkov.fandom.com/wiki/Missing_in_Action
  - https://escapefromtarkov.fandom.com/wiki/Clearing_the_Way
  - https://escapefromtarkov.fandom.com/wiki/Come_by_the_Fire
  - https://escapefromtarkov.fandom.com/wiki/Knuckle_Sandwich
  - https://escapefromtarkov.fandom.com/wiki/A_Small_Celebration

## Checklist
  - [x] I have included proof links in the JSON5 comments
  - [ ] I have noted the original incorrect value in inline comments (N/A for additions)
  - [ ] I have included the entity name as a comment above each ID (N/A for additions)
  - [x] Field names match tarkov.dev schema exactly (camelCase)
  - [x] Validation passes locally (npm run validate)

## Related Issues
  Closes #