### PR TITLE
Vacate The Premises [Temporary Fix]

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,1 +1,10 @@
-{"singleQuote": true, "semi": true, "tabWidth": 2, "trailingComma": "es5", "printWidth": 80}
+{
+  "bracketSpacing": true,
+  "endOfLine": "lf",
+  "printWidth": 100,
+  "proseWrap": "preserve",
+  "semi": true,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "es5"
+}

--- a/src/additions/tasksAdd.json5
+++ b/src/additions/tasksAdd.json5
@@ -5,600 +5,791 @@
   // Proof: https://escapefromtarkov.fandom.com/wiki/Come_by_the_Fire
   // Proof: https://escapefromtarkov.fandom.com/wiki/Knuckle_Sandwich
   // Proof: https://escapefromtarkov.fandom.com/wiki/A_Small_Celebration
-
-//  winter_2025_missing_in_action: {
-//    id: 'winter_2025_missing_in_action',
-//    name: 'Missing in Action',
-//    wikiLink: 'https://escapefromtarkov.fandom.com/wiki/Missing_in_Action',
-//    trader: {
-//      id: '54cb50c76803fa8b248b4571',
-//      name: 'Prapor',
-//    },
-//    maps: [
-//      { id: '5704e3c2d2720bac5b8b4567', name: 'Woods' },
-//      { id: '5704e5fad2720bc05b8b4567', name: 'Reserve' },
-//      { id: '5714dbc024597771384a510d', name: 'Interchange' },
-//    ],
-//    map: null,
-//    kappaRequired: false,
-//    factionName: 'Any',
-//    objectives: [
-//      {
-//        id: 'winter_2025_missing_in_action_obj01',
-//        description: 'Stash a Pack of Arseniy buckwheat at the Scav house on Woods',
-//        type: 'plantItem',
-//        maps: [{ id: '5704e3c2d2720bac5b8b4567', name: 'Woods' }],
-//        items: [
-//          {
-//            id: '6389c6463485cf0eeb260715',
-//            name: 'Pack of Arseniy buckwheat',
-//            shortName: 'Buckwheat',
-//          },
-//        ],
-//        count: 1,
-//      },
-//      {
-//        id: 'winter_2025_missing_in_action_obj02',
-//        description: 'Stash a Bottle of Tarkovskaya vodka at the Scav house on Woods',
-//        type: 'plantItem',
-//        maps: [{ id: '5704e3c2d2720bac5b8b4567', name: 'Woods' }],
-//        items: [
-//          {
-//            id: '5d40407c86f774318526545a',
-//            name: 'Bottle of Tarkovskaya vodka',
-//            shortName: 'Vodka',
-//          },
-//        ],
-//        count: 1,
-//      },
-//      {
-//        id: 'winter_2025_missing_in_action_obj03',
-//        description: 'Stash an Iskra ration pack at the Scav house on Woods',
-//        type: 'plantItem',
-//        maps: [{ id: '5704e3c2d2720bac5b8b4567', name: 'Woods' }],
-//        items: [
-//          {
-//            id: '590c5d4b86f774784e1b9c45',
-//            name: 'Iskra ration pack',
-//            shortName: 'Iskra',
-//          },
-//        ],
-//        count: 1,
-//      },
-//      {
-//        id: 'winter_2025_missing_in_action_obj04',
-//        description: 'Stash a Pack of Arseniy buckwheat at the guard barrack on Reserve',
-//        type: 'plantItem',
-//        maps: [{ id: '5704e5fad2720bc05b8b4567', name: 'Reserve' }],
-//        items: [
-//          {
-//            id: '6389c6463485cf0eeb260715',
-//            name: 'Pack of Arseniy buckwheat',
-//            shortName: 'Buckwheat',
-//          },
-//        ],
-//        count: 1,
-//      },
-//      {
-//        id: 'winter_2025_missing_in_action_obj05',
-//        description: 'Stash a Bottle of Tarkovskaya vodka at the guard barrack on Reserve',
-//        type: 'plantItem',
-//        maps: [{ id: '5704e5fad2720bc05b8b4567', name: 'Reserve' }],
-//        items: [
-//          {
-//            id: '5d40407c86f774318526545a',
-//            name: 'Bottle of Tarkovskaya vodka',
-//            shortName: 'Vodka',
-//          },
-//        ],
-//        count: 1,
-//      },
-//      {
-//        id: 'winter_2025_missing_in_action_obj06',
-//        description: 'Stash an Iskra ration pack at the guard barrack on Reserve',
-//        type: 'plantItem',
-//        maps: [{ id: '5704e5fad2720bc05b8b4567', name: 'Reserve' }],
-//        items: [
-//          {
-//            id: '590c5d4b86f774784e1b9c45',
-//            name: 'Iskra ration pack',
-//            shortName: 'Iskra',
-//          },
-//        ],
-//        count: 1,
-//      },
-//      {
-//        id: 'winter_2025_missing_in_action_obj07',
-//        description: 'Stash a Pack of Arseniy buckwheat at the Path to River shack on Interchange',
-//        type: 'plantItem',
-//        maps: [{ id: '5714dbc024597771384a510d', name: 'Interchange' }],
-//        items: [
-//          {
-//            id: '6389c6463485cf0eeb260715',
-//            name: 'Pack of Arseniy buckwheat',
-//            shortName: 'Buckwheat',
-//          },
-//        ],
-//        count: 1,
-//      },
-//      {
-//        id: 'winter_2025_missing_in_action_obj08',
-//        description: 'Stash a Bottle of Tarkovskaya vodka at the Path to River shack on Interchange',
-//        type: 'plantItem',
-//        maps: [{ id: '5714dbc024597771384a510d', name: 'Interchange' }],
-//        items: [
-//          {
-//            id: '5d40407c86f774318526545a',
-//            name: 'Bottle of Tarkovskaya vodka',
-//            shortName: 'Vodka',
-//          },
-//        ],
-//        count: 1,
-//      },
-//      {
-//        id: 'winter_2025_missing_in_action_obj09',
-//        description: 'Stash an Iskra ration pack at the Path to River shack on Interchange',
-//        type: 'plantItem',
-//        maps: [{ id: '5714dbc024597771384a510d', name: 'Interchange' }],
-//        items: [
-//          {
-//            id: '590c5d4b86f774784e1b9c45',
-//            name: 'Iskra ration pack',
-//            shortName: 'Iskra',
-//          },
-//        ],
-//        count: 1,
-//      },
-//    ],
-//    experience: 5000,
-//    finishRewards: {
-//      items: [
-//        {
-//          count: 21000,
-//          item: {
-//            id: '5449016a4bdc2d6f028b456f',
-//            name: 'Roubles',
-//            shortName: 'RUB',
-//          },
-//        },
-//        {
-//          count: 1,
-//          item: {
-//            id: '6499849fc93611967b034949',
-//            name: 'Kalashnikov AK-12 5.45x39 assault rifle',
-//            shortName: 'AK-12',
-//          },
-//        },
-//        {
-//          count: 3,
-//          item: {
-//            id: '649ec30cb013f04a700e60fb',
-//            name: 'AK-12 5.45x39 early model 30-round magazine',
-//            shortName: 'AK-12 old',
-//          },
-//        },
-//        {
-//          count: 1,
-//          item: {
-//            id: '6570900858b315e8b70a8a98',
-//            name: '5.45x39mm 7N40 ammo pack (120 pcs)',
-//            shortName: '7N40',
-//          },
-//        },
-//      ],
-//      traderStanding: [
-//        {
-//          trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
-//          standing: 0.01,
-//        },
-//      ],
-//    },
-//  },
-
-//  winter_2025_clearing_the_way: {
-//    id: 'winter_2025_clearing_the_way',
-//    name: 'Clearing the Way',
-//    wikiLink: 'https://escapefromtarkov.fandom.com/wiki/Clearing_the_Way',
-//    trader: {
-//      id: '58330581ace78e27b8b10cee',
-//      name: 'Skier',
-//    },
-//    maps: [{ id: '56f40101d2720b2a4d8b45d6', name: 'Customs' }],
-//    map: { id: '56f40101d2720b2a4d8b45d6', name: 'Customs' },
-//    kappaRequired: false,
-//    factionName: 'Any',
-//    taskRequirements: [
-//      {
-//        task: {
-//          id: 'winter_2025_missing_in_action',
-//          name: 'Missing in Action',
-//        },
-//      },
-//    ],
-//    objectives: [
-//      {
-//        id: 'winter_2025_clearing_the_way_obj01',
-//        description: 'Eliminate any 20 targets on Customs',
-//        type: 'shoot',
-//        maps: [{ id: '56f40101d2720b2a4d8b45d6', name: 'Customs' }],
-//        count: 20,
-//      },
-//    ],
-//    experience: 12000,
-//    finishRewards: {
-//      items: [
-//        {
-//          count: 51000,
-//          item: {
-//            id: '5449016a4bdc2d6f028b456f',
-//            name: 'Roubles',
-//            shortName: 'RUB',
-//          },
-//        },
-//        {
-//          count: 2,
-//          item: {
-//            id: '62a0a0bb621468534a797ad5',
-//            name: 'Set of files "Master"',
-//            shortName: 'Master',
-//          },
-//        },
-//        {
-//          count: 2,
-//          item: {
-//            id: '5e2af00086f7746d3f3c33f7',
-//            name: 'Smoked Chimney drain cleaner',
-//            shortName: 'DCleaner',
-//          },
-//        },
-//      ],
-//      traderStanding: [
-//        {
-//          trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' },
-//          standing: 0.01,
-//        },
-//      ],
-//    },
-//  },
-
-//  winter_2025_come_by_the_fire: {
-//    id: 'winter_2025_come_by_the_fire',
-//    name: 'Come by the Fire',
-//    wikiLink: 'https://escapefromtarkov.fandom.com/wiki/Come_by_the_Fire',
-//    trader: {
-//      id: '58330581ace78e27b8b10cee',
-//      name: 'Skier',
-//    },
-//    maps: [{ id: '5704e3c2d2720bac5b8b4567', name: 'Woods' }],
-//    map: { id: '5704e3c2d2720bac5b8b4567', name: 'Woods' },
-//    kappaRequired: false,
-//    factionName: 'Any',
-//    taskRequirements: [
-//      {
-//        task: { id: 'winter_2025_clearing_the_way', name: 'Clearing the Way' },
-//      },
-//    ],
-//    objectives: [
-//      {
-//        id: 'winter_2025_come_by_the_fire_obj01',
-//        description: "Locate and mark the first spot from Skier's route with an MS2000 Marker",
-//        type: 'mark',
-//        maps: [{ id: '5704e3c2d2720bac5b8b4567', name: 'Woods' }],
-//        markerItem: {
-//          id: '5991b51486f77447b112d44f',
-//          name: 'MS2000 Marker',
-//          shortName: 'MS2000',
-//        },
-//      },
-//      {
-//        id: 'winter_2025_come_by_the_fire_obj02',
-//        description: "Locate and mark the second spot from Skier's route with an MS2000 Marker",
-//        type: 'mark',
-//        maps: [{ id: '5704e3c2d2720bac5b8b4567', name: 'Woods' }],
-//        markerItem: {
-//          id: '5991b51486f77447b112d44f',
-//          name: 'MS2000 Marker',
-//          shortName: 'MS2000',
-//        },
-//      },
-//      {
-//        id: 'winter_2025_come_by_the_fire_obj03',
-//        description: "Locate and mark the third spot from Skier's route with an MS2000 Marker",
-//        type: 'mark',
-//        maps: [{ id: '5704e3c2d2720bac5b8b4567', name: 'Woods' }],
-//        markerItem: {
-//          id: '5991b51486f77447b112d44f',
-//          name: 'MS2000 Marker',
-//          shortName: 'MS2000',
-//        },
-//      },
-//      {
-//        id: 'winter_2025_come_by_the_fire_obj04',
-//        description: "Locate and mark the fourth spot from Skier's route with an MS2000 Marker",
-//        type: 'mark',
-//        maps: [{ id: '5704e3c2d2720bac5b8b4567', name: 'Woods' }],
-//        markerItem: {
-//          id: '5991b51486f77447b112d44f',
-//          name: 'MS2000 Marker',
-//          shortName: 'MS2000',
-//        },
-//      },
-//      {
-//        id: 'winter_2025_come_by_the_fire_obj05',
-//        description: 'Eliminate any 5 targets while wearing a Pompon hat on Woods',
-//        type: 'shoot',
-//        maps: [{ id: '5704e3c2d2720bac5b8b4567', name: 'Woods' }],
-//        wearing: [{ id: '5b4329075acfc400153b78ff' }],
-//        count: 5,
-//      },
-//    ],
-//    experience: 10000,
-//    finishRewards: {
-//      items: [
-//        {
-//          count: 42000,
-//          item: {
-//            id: '5449016a4bdc2d6f028b456f',
-//            name: 'Roubles',
-//            shortName: 'RUB',
-//          },
-//        },
-//        {
-//          count: 1,
-//          item: {
-//            id: '5fc3f2d5900b1d5091531e57',
-//            name: 'TDI KRISS Vector Gen.2 9x19 submachine gun',
-//            shortName: 'Vector 9x19',
-//          },
-//        },
-//        {
-//          count: 4,
-//          item: {
-//            id: '5a7ad2e851dfba0016153692',
-//            name: 'Glock 9x19 "Big Stick" 33-round magazine',
-//            shortName: 'Big Stick',
-//          },
-//        },
-//        {
-//          count: 4,
-//          item: {
-//            id: '65702591c5d7d4cb4d07857c',
-//            name: '9x19mm AP 6.3 ammo pack (50 pcs)',
-//            shortName: 'AP 6.3',
-//          },
-//        },
-//      ],
-//      traderStanding: [
-//        {
-//          trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' },
-//          standing: 0.01,
-//        },
-//      ],
-//    },
-//  },
-
-//  winter_2025_knuckle_sandwich: {
-//    id: 'winter_2025_knuckle_sandwich',
-//    name: 'Knuckle Sandwich',
-//    wikiLink: 'https://escapefromtarkov.fandom.com/wiki/Knuckle_Sandwich',
-//    trader: {
-//      id: '54cb50c76803fa8b248b4571',
-//      name: 'Prapor',
-//    },
-//    maps: [{ id: '5704e3c2d2720bac5b8b4567', name: 'Woods' }],
-//    map: { id: '5704e3c2d2720bac5b8b4567', name: 'Woods' },
-//    kappaRequired: false,
-//    factionName: 'Any',
-//    taskRequirements: [
-//      {
-//        task: { id: 'winter_2025_come_by_the_fire', name: 'Come by the Fire' },
-//      },
-//    ],
-//    objectives: [
-//      {
-//        id: 'winter_2025_knuckle_sandwich_obj01',
-//        description: "Stash a TP-200 TNT brick at the first spot from Skier's route",
-//        type: 'plantItem',
-//        maps: [{ id: '5704e3c2d2720bac5b8b4567', name: 'Woods' }],
-//        items: [
-//          {
-//            id: '60391b0fb847c71012789415',
-//            name: 'TP-200 TNT brick',
-//            shortName: 'TP-200',
-//          },
-//        ],
-//        count: 1,
-//      },
-//      {
-//        id: 'winter_2025_knuckle_sandwich_obj02',
-//        description: "Stash a TP-200 TNT brick at the second spot from Skier's route",
-//        type: 'plantItem',
-//        maps: [{ id: '5704e3c2d2720bac5b8b4567', name: 'Woods' }],
-//        items: [
-//          {
-//            id: '60391b0fb847c71012789415',
-//            name: 'TP-200 TNT brick',
-//            shortName: 'TP-200',
-//          },
-//        ],
-//        count: 1,
-//      },
-//      {
-//        id: 'winter_2025_knuckle_sandwich_obj03',
-//        description: "Stash a TP-200 TNT brick at the third spot from Skier's route",
-//        type: 'plantItem',
-//        maps: [{ id: '5704e3c2d2720bac5b8b4567', name: 'Woods' }],
-//        items: [
-//          {
-//            id: '60391b0fb847c71012789415',
-//            name: 'TP-200 TNT brick',
-//            shortName: 'TP-200',
-//          },
-//        ],
-//        count: 1,
-//      },
-//      {
-//        id: 'winter_2025_knuckle_sandwich_obj04',
-//        description: "Stash a TP-200 TNT brick at the fourth spot from Skier's route",
-//        type: 'plantItem',
-//        maps: [{ id: '5704e3c2d2720bac5b8b4567', name: 'Woods' }],
-//        items: [
-//          {
-//            id: '60391b0fb847c71012789415',
-//            name: 'TP-200 TNT brick',
-//            shortName: 'TP-200',
-//          },
-//        ],
-//        count: 1,
-//      },
-//      {
-//        id: 'winter_2025_knuckle_sandwich_obj05',
-//        description: 'Eliminate any 15 targets while wearing a Ushanka ear flap hat on Woods',
-//        type: 'shoot',
-//        maps: [{ id: '5704e3c2d2720bac5b8b4567', name: 'Woods' }],
-//        wearing: [{ id: '59e7708286f7742cbd762753' }],
-//        count: 15,
-//      },
-//    ],
-//    experience: 15000,
-//    finishRewards: {
-//      items: [
-//        {
-//          count: 63000,
-//          item: {
-//            id: '5449016a4bdc2d6f028b456f',
-//            name: 'Roubles',
-//            shortName: 'RUB',
-//          },
-//        },
-//        {
-//          count: 2,
-//          item: {
-//            id: '59e35de086f7741778269d84',
-//            name: 'Electric drill',
-//            shortName: 'Drill',
-//          },
-//        },
-//        {
-//          count: 2,
-//          item: {
-//            id: '590a3c0a86f774385a33c450',
-//            name: 'Spark plug',
-//            shortName: 'SPlug',
-//          },
-//        },
-//      ],
-//      traderStanding: [
-//        {
-//          trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
-//          standing: 0.01,
-//        },
-//      ],
-//    },
-//  },
-
-
-//  winter_2025_a_small_celebration: {
-//    id: 'winter_2025_a_small_celebration',
-//    name: 'A Small Celebration',
-//    wikiLink: 'https://escapefromtarkov.fandom.com/wiki/A_Small_Celebration',
-//    trader: {
-//      id: '5ac3b934156ae10c4430e83c',
-//      name: 'Ragman',
-//    },
-//    maps: [
-//      { id: '56f40101d2720b2a4d8b45d6', name: 'Customs' },
-//      { id: '5714dbc024597771384a510d', name: 'Interchange' },
-//      { id: '5704e4dad2720bb55b8b4567', name: 'Lighthouse' },
-//      { id: '5704e5fad2720bc05b8b4567', name: 'Reserve' },
-//      { id: '5704e554d2720bac5b8b456e', name: 'Shoreline' },
-//      { id: '5704e3c2d2720bac5b8b4567', name: 'Woods' },
-//    ],
-//    map: null,
-//    kappaRequired: false,
-//    factionName: 'Any',
-//    taskRequirements: [
-//      {
-//        task: { id: 'winter_2025_knuckle_sandwich', name: 'Knuckle Sandwich' },
-//      },
-//    ],
-//    objectives: [
-//      {
-//        id: 'winter_2025_a_small_celebration_obj01',
-//        description: 'Launch a firework in the appropriate spot',
-//        type: 'useItem',
-//        maps: [
-//          { id: '56f40101d2720b2a4d8b45d6', name: 'Customs' },
-//          { id: '5714dbc024597771384a510d', name: 'Interchange' },
-//          { id: '5704e4dad2720bb55b8b4567', name: 'Lighthouse' },
-//          { id: '5704e5fad2720bc05b8b4567', name: 'Reserve' },
-//          { id: '5704e554d2720bac5b8b456e', name: 'Shoreline' },
-//          { id: '5704e3c2d2720bac5b8b4567', name: 'Woods' },
-//        ],
-//        useAny: [
-//          {
-//            id: '675ea3d6312c0a5c4e04e317',
-//            name: 'RSP-30 reactive signal cartridge (Firework)',
-//            shortName: 'Firework',
-//          },
-//        ],
-//        count: 1,
-//      },
-//      {
-//        id: 'winter_2025_a_small_celebration_obj02',
-//        description: 'Eat some Olivier salad',
-//        type: 'useItem',
-//        useAny: [
-//          {
-//            id: '67586b7e49c2fa592e0d8ed9',
-//            name: 'Olivier salad box',
-//            shortName: 'Salad',
-//          },
-//        ],
-//        count: 1,
-//      },
-//      {
-//        id: 'winter_2025_a_small_celebration_obj03',
-//        description: 'Drink some vodka',
-//        type: 'useItem',
-//        useAny: [
-//          {
-//            id: '5d40407c86f774318526545a',
-//            name: 'Bottle of Tarkovskaya vodka',
-//            shortName: 'Vodka',
-//          },
-//        ],
-//        count: 1,
-//      },
-//    ],
-//    experience: 20000,
-//    finishRewards: {
-//      items: [
-//        {
-//          count: 2,
-//          item: {
-//            id: '544a5caa4bdc2d1a388b4568',
-//            name: 'Crye Precision AVS plate carrier (Ranger Green)',
-//            shortName: 'AVS',
-//          },
-//        },
-//        {
-//          count: 1,
-//          item: {
-//            id: '67600929bd0a0549d70993f6',
-//            name: 'Ballistic plate case',
-//            shortName: 'Plates',
-//          },
-//        },
-//      ],
-//      traderStanding: [
-//        {
-//          trader: { id: '5ac3b934156ae10c4430e83c', name: 'Ragman' },
-//          standing: 0.01,
-//        },
-//      ],
-//    },
-//  },
+  // winter_2025_missing_in_action: {
+  //   id: 'winter_2025_missing_in_action',
+  //   name: 'Missing in Action',
+  //   wikiLink: 'https://escapefromtarkov.fandom.com/wiki/Missing_in_Action',
+  //   trader: {
+  //     id: '54cb50c76803fa8b248b4571',
+  //     name: 'Prapor',
+  //   },
+  //   maps: [
+  //     {
+  //       id: '5704e3c2d2720bac5b8b4567',
+  //       name: 'Woods',
+  //     },
+  //     {
+  //       id: '5704e5fad2720bc05b8b4567',
+  //       name: 'Reserve',
+  //     },
+  //     {
+  //       id: '5714dbc024597771384a510d',
+  //       name: 'Interchange',
+  //     },
+  //   ],
+  //   map: null,
+  //   kappaRequired: false,
+  //   factionName: 'Any',
+  //   objectives: [
+  //     {
+  //       id: 'winter_2025_missing_in_action_obj01',
+  //       description: 'Stash a Pack of Arseniy buckwheat at the Scav house on Woods',
+  //       type: 'plantItem',
+  //       maps: [
+  //         {
+  //           id: '5704e3c2d2720bac5b8b4567',
+  //           name: 'Woods',
+  //         },
+  //       ],
+  //       items: [
+  //         {
+  //           id: '6389c6463485cf0eeb260715',
+  //           name: 'Pack of Arseniy buckwheat',
+  //           shortName: 'Buckwheat',
+  //         },
+  //       ],
+  //       count: 1,
+  //     },
+  //     {
+  //       id: 'winter_2025_missing_in_action_obj02',
+  //       description: 'Stash a Bottle of Tarkovskaya vodka at the Scav house on Woods',
+  //       type: 'plantItem',
+  //       maps: [
+  //         {
+  //           id: '5704e3c2d2720bac5b8b4567',
+  //           name: 'Woods',
+  //         },
+  //       ],
+  //       items: [
+  //         {
+  //           id: '5d40407c86f774318526545a',
+  //           name: 'Bottle of Tarkovskaya vodka',
+  //           shortName: 'Vodka',
+  //         },
+  //       ],
+  //       count: 1,
+  //     },
+  //     {
+  //       id: 'winter_2025_missing_in_action_obj03',
+  //       description: 'Stash an Iskra ration pack at the Scav house on Woods',
+  //       type: 'plantItem',
+  //       maps: [
+  //         {
+  //           id: '5704e3c2d2720bac5b8b4567',
+  //           name: 'Woods',
+  //         },
+  //       ],
+  //       items: [
+  //         {
+  //           id: '590c5d4b86f774784e1b9c45',
+  //           name: 'Iskra ration pack',
+  //           shortName: 'Iskra',
+  //         },
+  //       ],
+  //       count: 1,
+  //     },
+  //     {
+  //       id: 'winter_2025_missing_in_action_obj04',
+  //       description: 'Stash a Pack of Arseniy buckwheat at the guard barrack on Reserve',
+  //       type: 'plantItem',
+  //       maps: [
+  //         {
+  //           id: '5704e5fad2720bc05b8b4567',
+  //           name: 'Reserve',
+  //         },
+  //       ],
+  //       items: [
+  //         {
+  //           id: '6389c6463485cf0eeb260715',
+  //           name: 'Pack of Arseniy buckwheat',
+  //           shortName: 'Buckwheat',
+  //         },
+  //       ],
+  //       count: 1,
+  //     },
+  //     {
+  //       id: 'winter_2025_missing_in_action_obj05',
+  //       description: 'Stash a Bottle of Tarkovskaya vodka at the guard barrack on Reserve',
+  //       type: 'plantItem',
+  //       maps: [
+  //         {
+  //           id: '5704e5fad2720bc05b8b4567',
+  //           name: 'Reserve',
+  //         },
+  //       ],
+  //       items: [
+  //         {
+  //           id: '5d40407c86f774318526545a',
+  //           name: 'Bottle of Tarkovskaya vodka',
+  //           shortName: 'Vodka',
+  //         },
+  //       ],
+  //       count: 1,
+  //     },
+  //     {
+  //       id: 'winter_2025_missing_in_action_obj06',
+  //       description: 'Stash an Iskra ration pack at the guard barrack on Reserve',
+  //       type: 'plantItem',
+  //       maps: [
+  //         {
+  //           id: '5704e5fad2720bc05b8b4567',
+  //           name: 'Reserve',
+  //         },
+  //       ],
+  //       items: [
+  //         {
+  //           id: '590c5d4b86f774784e1b9c45',
+  //           name: 'Iskra ration pack',
+  //           shortName: 'Iskra',
+  //         },
+  //       ],
+  //       count: 1,
+  //     },
+  //     {
+  //       id: 'winter_2025_missing_in_action_obj07',
+  //       description: 'Stash a Pack of Arseniy buckwheat at the Path to River shack on Interchange',
+  //       type: 'plantItem',
+  //       maps: [
+  //         {
+  //           id: '5714dbc024597771384a510d',
+  //           name: 'Interchange',
+  //         },
+  //       ],
+  //       items: [
+  //         {
+  //           id: '6389c6463485cf0eeb260715',
+  //           name: 'Pack of Arseniy buckwheat',
+  //           shortName: 'Buckwheat',
+  //         },
+  //       ],
+  //       count: 1,
+  //     },
+  //     {
+  //       id: 'winter_2025_missing_in_action_obj08',
+  //       description: 'Stash a Bottle of Tarkovskaya vodka at the Path to River shack on Interchange',
+  //       type: 'plantItem',
+  //       maps: [
+  //         {
+  //           id: '5714dbc024597771384a510d',
+  //           name: 'Interchange',
+  //         },
+  //       ],
+  //       items: [
+  //         {
+  //           id: '5d40407c86f774318526545a',
+  //           name: 'Bottle of Tarkovskaya vodka',
+  //           shortName: 'Vodka',
+  //         },
+  //       ],
+  //       count: 1,
+  //     },
+  //     {
+  //       id: 'winter_2025_missing_in_action_obj09',
+  //       description: 'Stash an Iskra ration pack at the Path to River shack on Interchange',
+  //       type: 'plantItem',
+  //       maps: [
+  //         {
+  //           id: '5714dbc024597771384a510d',
+  //           name: 'Interchange',
+  //         },
+  //       ],
+  //       items: [
+  //         {
+  //           id: '590c5d4b86f774784e1b9c45',
+  //           name: 'Iskra ration pack',
+  //           shortName: 'Iskra',
+  //         },
+  //       ],
+  //       count: 1,
+  //     },
+  //   ],
+  //   experience: 5000,
+  //   finishRewards: {
+  //     items: [
+  //       {
+  //         count: 21000,
+  //         item: {
+  //           id: '5449016a4bdc2d6f028b456f',
+  //           name: 'Roubles',
+  //           shortName: 'RUB',
+  //         },
+  //       },
+  //       {
+  //         count: 1,
+  //         item: {
+  //           id: '6499849fc93611967b034949',
+  //           name: 'Kalashnikov AK-12 5.45x39 assault rifle',
+  //           shortName: 'AK-12',
+  //         },
+  //       },
+  //       {
+  //         count: 3,
+  //         item: {
+  //           id: '649ec30cb013f04a700e60fb',
+  //           name: 'AK-12 5.45x39 early model 30-round magazine',
+  //           shortName: 'AK-12 old',
+  //         },
+  //       },
+  //       {
+  //         count: 1,
+  //         item: {
+  //           id: '6570900858b315e8b70a8a98',
+  //           name: '5.45x39mm 7N40 ammo pack (120 pcs)',
+  //           shortName: '7N40',
+  //         },
+  //       },
+  //     ],
+  //     traderStanding: [
+  //       {
+  //         trader: {
+  //           id: '54cb50c76803fa8b248b4571',
+  //           name: 'Prapor',
+  //         },
+  //         standing: 0.01,
+  //       },
+  //     ],
+  //   },
+  // },
+  // winter_2025_clearing_the_way: {
+  //   id: 'winter_2025_clearing_the_way',
+  //   name: 'Clearing the Way',
+  //   wikiLink: 'https://escapefromtarkov.fandom.com/wiki/Clearing_the_Way',
+  //   trader: {
+  //     id: '58330581ace78e27b8b10cee',
+  //     name: 'Skier',
+  //   },
+  //   maps: [
+  //     {
+  //       id: '56f40101d2720b2a4d8b45d6',
+  //       name: 'Customs',
+  //     },
+  //   ],
+  //   map: {
+  //     id: '56f40101d2720b2a4d8b45d6',
+  //     name: 'Customs',
+  //   },
+  //   kappaRequired: false,
+  //   factionName: 'Any',
+  //   taskRequirements: [
+  //     {
+  //       task: {
+  //         id: 'winter_2025_missing_in_action',
+  //         name: 'Missing in Action',
+  //       },
+  //     },
+  //   ],
+  //   objectives: [
+  //     {
+  //       id: 'winter_2025_clearing_the_way_obj01',
+  //       description: 'Eliminate any 20 targets on Customs',
+  //       type: 'shoot',
+  //       maps: [
+  //         {
+  //           id: '56f40101d2720b2a4d8b45d6',
+  //           name: 'Customs',
+  //         },
+  //       ],
+  //       count: 20,
+  //     },
+  //   ],
+  //   experience: 12000,
+  //   finishRewards: {
+  //     items: [
+  //       {
+  //         count: 51000,
+  //         item: {
+  //           id: '5449016a4bdc2d6f028b456f',
+  //           name: 'Roubles',
+  //           shortName: 'RUB',
+  //         },
+  //       },
+  //       {
+  //         count: 2,
+  //         item: {
+  //           id: '62a0a0bb621468534a797ad5',
+  //           name: 'Set of files "Master"',
+  //           shortName: 'Master',
+  //         },
+  //       },
+  //       {
+  //         count: 2,
+  //         item: {
+  //           id: '5e2af00086f7746d3f3c33f7',
+  //           name: 'Smoked Chimney drain cleaner',
+  //           shortName: 'DCleaner',
+  //         },
+  //       },
+  //     ],
+  //     traderStanding: [
+  //       {
+  //         trader: {
+  //           id: '58330581ace78e27b8b10cee',
+  //           name: 'Skier',
+  //         },
+  //         standing: 0.01,
+  //       },
+  //     ],
+  //   },
+  // },
+  // winter_2025_come_by_the_fire: {
+  //   id: 'winter_2025_come_by_the_fire',
+  //   name: 'Come by the Fire',
+  //   wikiLink: 'https://escapefromtarkov.fandom.com/wiki/Come_by_the_Fire',
+  //   trader: {
+  //     id: '58330581ace78e27b8b10cee',
+  //     name: 'Skier',
+  //   },
+  //   maps: [
+  //     {
+  //       id: '5704e3c2d2720bac5b8b4567',
+  //       name: 'Woods',
+  //     },
+  //   ],
+  //   map: {
+  //     id: '5704e3c2d2720bac5b8b4567',
+  //     name: 'Woods',
+  //   },
+  //   kappaRequired: false,
+  //   factionName: 'Any',
+  //   taskRequirements: [
+  //     {
+  //       task: {
+  //         id: 'winter_2025_clearing_the_way',
+  //         name: 'Clearing the Way',
+  //       },
+  //     },
+  //   ],
+  //   objectives: [
+  //     {
+  //       id: 'winter_2025_come_by_the_fire_obj01',
+  //       description: "Locate and mark the first spot from Skier's route with an MS2000 Marker",
+  //       type: 'mark',
+  //       maps: [
+  //         {
+  //           id: '5704e3c2d2720bac5b8b4567',
+  //           name: 'Woods',
+  //         },
+  //       ],
+  //       markerItem: {
+  //         id: '5991b51486f77447b112d44f',
+  //         name: 'MS2000 Marker',
+  //         shortName: 'MS2000',
+  //       },
+  //     },
+  //     {
+  //       id: 'winter_2025_come_by_the_fire_obj02',
+  //       description: "Locate and mark the second spot from Skier's route with an MS2000 Marker",
+  //       type: 'mark',
+  //       maps: [
+  //         {
+  //           id: '5704e3c2d2720bac5b8b4567',
+  //           name: 'Woods',
+  //         },
+  //       ],
+  //       markerItem: {
+  //         id: '5991b51486f77447b112d44f',
+  //         name: 'MS2000 Marker',
+  //         shortName: 'MS2000',
+  //       },
+  //     },
+  //     {
+  //       id: 'winter_2025_come_by_the_fire_obj03',
+  //       description: "Locate and mark the third spot from Skier's route with an MS2000 Marker",
+  //       type: 'mark',
+  //       maps: [
+  //         {
+  //           id: '5704e3c2d2720bac5b8b4567',
+  //           name: 'Woods',
+  //         },
+  //       ],
+  //       markerItem: {
+  //         id: '5991b51486f77447b112d44f',
+  //         name: 'MS2000 Marker',
+  //         shortName: 'MS2000',
+  //       },
+  //     },
+  //     {
+  //       id: 'winter_2025_come_by_the_fire_obj04',
+  //       description: "Locate and mark the fourth spot from Skier's route with an MS2000 Marker",
+  //       type: 'mark',
+  //       maps: [
+  //         {
+  //           id: '5704e3c2d2720bac5b8b4567',
+  //           name: 'Woods',
+  //         },
+  //       ],
+  //       markerItem: {
+  //         id: '5991b51486f77447b112d44f',
+  //         name: 'MS2000 Marker',
+  //         shortName: 'MS2000',
+  //       },
+  //     },
+  //     {
+  //       id: 'winter_2025_come_by_the_fire_obj05',
+  //       description: 'Eliminate any 5 targets while wearing a Pompon hat on Woods',
+  //       type: 'shoot',
+  //       maps: [
+  //         {
+  //           id: '5704e3c2d2720bac5b8b4567',
+  //           name: 'Woods',
+  //         },
+  //       ],
+  //       wearing: [
+  //         { id: '5b4329075acfc400153b78ff' },
+  //       ],
+  //       count: 5,
+  //     },
+  //   ],
+  //   experience: 10000,
+  //   finishRewards: {
+  //     items: [
+  //       {
+  //         count: 42000,
+  //         item: {
+  //           id: '5449016a4bdc2d6f028b456f',
+  //           name: 'Roubles',
+  //           shortName: 'RUB',
+  //         },
+  //       },
+  //       {
+  //         count: 1,
+  //         item: {
+  //           id: '5fc3f2d5900b1d5091531e57',
+  //           name: 'TDI KRISS Vector Gen.2 9x19 submachine gun',
+  //           shortName: 'Vector 9x19',
+  //         },
+  //       },
+  //       {
+  //         count: 4,
+  //         item: {
+  //           id: '5a7ad2e851dfba0016153692',
+  //           name: 'Glock 9x19 "Big Stick" 33-round magazine',
+  //           shortName: 'Big Stick',
+  //         },
+  //       },
+  //       {
+  //         count: 4,
+  //         item: {
+  //           id: '65702591c5d7d4cb4d07857c',
+  //           name: '9x19mm AP 6.3 ammo pack (50 pcs)',
+  //           shortName: 'AP 6.3',
+  //         },
+  //       },
+  //     ],
+  //     traderStanding: [
+  //       {
+  //         trader: {
+  //           id: '58330581ace78e27b8b10cee',
+  //           name: 'Skier',
+  //         },
+  //         standing: 0.01,
+  //       },
+  //     ],
+  //   },
+  // },
+  // winter_2025_knuckle_sandwich: {
+  //   id: 'winter_2025_knuckle_sandwich',
+  //   name: 'Knuckle Sandwich',
+  //   wikiLink: 'https://escapefromtarkov.fandom.com/wiki/Knuckle_Sandwich',
+  //   trader: {
+  //     id: '54cb50c76803fa8b248b4571',
+  //     name: 'Prapor',
+  //   },
+  //   maps: [
+  //     {
+  //       id: '5704e3c2d2720bac5b8b4567',
+  //       name: 'Woods',
+  //     },
+  //   ],
+  //   map: {
+  //     id: '5704e3c2d2720bac5b8b4567',
+  //     name: 'Woods',
+  //   },
+  //   kappaRequired: false,
+  //   factionName: 'Any',
+  //   taskRequirements: [
+  //     {
+  //       task: {
+  //         id: 'winter_2025_come_by_the_fire',
+  //         name: 'Come by the Fire',
+  //       },
+  //     },
+  //   ],
+  //   objectives: [
+  //     {
+  //       id: 'winter_2025_knuckle_sandwich_obj01',
+  //       description: "Stash a TP-200 TNT brick at the first spot from Skier's route",
+  //       type: 'plantItem',
+  //       maps: [
+  //         {
+  //           id: '5704e3c2d2720bac5b8b4567',
+  //           name: 'Woods',
+  //         },
+  //       ],
+  //       items: [
+  //         {
+  //           id: '60391b0fb847c71012789415',
+  //           name: 'TP-200 TNT brick',
+  //           shortName: 'TP-200',
+  //         },
+  //       ],
+  //       count: 1,
+  //     },
+  //     {
+  //       id: 'winter_2025_knuckle_sandwich_obj02',
+  //       description: "Stash a TP-200 TNT brick at the second spot from Skier's route",
+  //       type: 'plantItem',
+  //       maps: [
+  //         {
+  //           id: '5704e3c2d2720bac5b8b4567',
+  //           name: 'Woods',
+  //         },
+  //       ],
+  //       items: [
+  //         {
+  //           id: '60391b0fb847c71012789415',
+  //           name: 'TP-200 TNT brick',
+  //           shortName: 'TP-200',
+  //         },
+  //       ],
+  //       count: 1,
+  //     },
+  //     {
+  //       id: 'winter_2025_knuckle_sandwich_obj03',
+  //       description: "Stash a TP-200 TNT brick at the third spot from Skier's route",
+  //       type: 'plantItem',
+  //       maps: [
+  //         {
+  //           id: '5704e3c2d2720bac5b8b4567',
+  //           name: 'Woods',
+  //         },
+  //       ],
+  //       items: [
+  //         {
+  //           id: '60391b0fb847c71012789415',
+  //           name: 'TP-200 TNT brick',
+  //           shortName: 'TP-200',
+  //         },
+  //       ],
+  //       count: 1,
+  //     },
+  //     {
+  //       id: 'winter_2025_knuckle_sandwich_obj04',
+  //       description: "Stash a TP-200 TNT brick at the fourth spot from Skier's route",
+  //       type: 'plantItem',
+  //       maps: [
+  //         {
+  //           id: '5704e3c2d2720bac5b8b4567',
+  //           name: 'Woods',
+  //         },
+  //       ],
+  //       items: [
+  //         {
+  //           id: '60391b0fb847c71012789415',
+  //           name: 'TP-200 TNT brick',
+  //           shortName: 'TP-200',
+  //         },
+  //       ],
+  //       count: 1,
+  //     },
+  //     {
+  //       id: 'winter_2025_knuckle_sandwich_obj05',
+  //       description: 'Eliminate any 15 targets while wearing a Ushanka ear flap hat on Woods',
+  //       type: 'shoot',
+  //       maps: [
+  //         {
+  //           id: '5704e3c2d2720bac5b8b4567',
+  //           name: 'Woods',
+  //         },
+  //       ],
+  //       wearing: [
+  //         { id: '59e7708286f7742cbd762753' },
+  //       ],
+  //       count: 15,
+  //     },
+  //   ],
+  //   experience: 15000,
+  //   finishRewards: {
+  //     items: [
+  //       {
+  //         count: 63000,
+  //         item: {
+  //           id: '5449016a4bdc2d6f028b456f',
+  //           name: 'Roubles',
+  //           shortName: 'RUB',
+  //         },
+  //       },
+  //       {
+  //         count: 2,
+  //         item: {
+  //           id: '59e35de086f7741778269d84',
+  //           name: 'Electric drill',
+  //           shortName: 'Drill',
+  //         },
+  //       },
+  //       {
+  //         count: 2,
+  //         item: {
+  //           id: '590a3c0a86f774385a33c450',
+  //           name: 'Spark plug',
+  //           shortName: 'SPlug',
+  //         },
+  //       },
+  //     ],
+  //     traderStanding: [
+  //       {
+  //         trader: {
+  //           id: '54cb50c76803fa8b248b4571',
+  //           name: 'Prapor',
+  //         },
+  //         standing: 0.01,
+  //       },
+  //     ],
+  //   },
+  // },
+  // winter_2025_a_small_celebration: {
+  //   id: 'winter_2025_a_small_celebration',
+  //   name: 'A Small Celebration',
+  //   wikiLink: 'https://escapefromtarkov.fandom.com/wiki/A_Small_Celebration',
+  //   trader: {
+  //     id: '5ac3b934156ae10c4430e83c',
+  //     name: 'Ragman',
+  //   },
+  //   maps: [
+  //     {
+  //       id: '56f40101d2720b2a4d8b45d6',
+  //       name: 'Customs',
+  //     },
+  //     {
+  //       id: '5714dbc024597771384a510d',
+  //       name: 'Interchange',
+  //     },
+  //     {
+  //       id: '5704e4dad2720bb55b8b4567',
+  //       name: 'Lighthouse',
+  //     },
+  //     {
+  //       id: '5704e5fad2720bc05b8b4567',
+  //       name: 'Reserve',
+  //     },
+  //     {
+  //       id: '5704e554d2720bac5b8b456e',
+  //       name: 'Shoreline',
+  //     },
+  //     {
+  //       id: '5704e3c2d2720bac5b8b4567',
+  //       name: 'Woods',
+  //     },
+  //   ],
+  //   map: null,
+  //   kappaRequired: false,
+  //   factionName: 'Any',
+  //   taskRequirements: [
+  //     {
+  //       task: {
+  //         id: 'winter_2025_knuckle_sandwich',
+  //         name: 'Knuckle Sandwich',
+  //       },
+  //     },
+  //   ],
+  //   objectives: [
+  //     {
+  //       id: 'winter_2025_a_small_celebration_obj01',
+  //       description: 'Launch a firework in the appropriate spot',
+  //       type: 'useItem',
+  //       maps: [
+  //         {
+  //           id: '56f40101d2720b2a4d8b45d6',
+  //           name: 'Customs',
+  //         },
+  //         {
+  //           id: '5714dbc024597771384a510d',
+  //           name: 'Interchange',
+  //         },
+  //         {
+  //           id: '5704e4dad2720bb55b8b4567',
+  //           name: 'Lighthouse',
+  //         },
+  //         {
+  //           id: '5704e5fad2720bc05b8b4567',
+  //           name: 'Reserve',
+  //         },
+  //         {
+  //           id: '5704e554d2720bac5b8b456e',
+  //           name: 'Shoreline',
+  //         },
+  //         {
+  //           id: '5704e3c2d2720bac5b8b4567',
+  //           name: 'Woods',
+  //         },
+  //       ],
+  //       useAny: [
+  //         {
+  //           id: '675ea3d6312c0a5c4e04e317',
+  //           name: 'RSP-30 reactive signal cartridge (Firework)',
+  //           shortName: 'Firework',
+  //         },
+  //       ],
+  //       count: 1,
+  //     },
+  //     {
+  //       id: 'winter_2025_a_small_celebration_obj02',
+  //       description: 'Eat some Olivier salad',
+  //       type: 'useItem',
+  //       useAny: [
+  //         {
+  //           id: '67586b7e49c2fa592e0d8ed9',
+  //           name: 'Olivier salad box',
+  //           shortName: 'Salad',
+  //         },
+  //       ],
+  //       count: 1,
+  //     },
+  //     {
+  //       id: 'winter_2025_a_small_celebration_obj03',
+  //       description: 'Drink some vodka',
+  //       type: 'useItem',
+  //       useAny: [
+  //         {
+  //           id: '5d40407c86f774318526545a',
+  //           name: 'Bottle of Tarkovskaya vodka',
+  //           shortName: 'Vodka',
+  //         },
+  //       ],
+  //       count: 1,
+  //     },
+  //   ],
+  //   experience: 20000,
+  //   finishRewards: {
+  //     items: [
+  //       {
+  //         count: 2,
+  //         item: {
+  //           id: '544a5caa4bdc2d1a388b4568',
+  //           name: 'Crye Precision AVS plate carrier (Ranger Green)',
+  //           shortName: 'AVS',
+  //         },
+  //       },
+  //       {
+  //         count: 1,
+  //         item: {
+  //           id: '67600929bd0a0549d70993f6',
+  //           name: 'Ballistic plate case',
+  //           shortName: 'Plates',
+  //         },
+  //       },
+  //     ],
+  //     traderStanding: [
+  //       {
+  //         trader: {
+  //           id: '5ac3b934156ae10c4430e83c',
+  //           name: 'Ragman',
+  //         },
+  //         standing: 0.01,
+  //       },
+  //     ],
+  //   },
+  // },
 
   // Setting Priorities
   // Proof: https://escapefromtarkov.fandom.com/wiki/Setting_Priorities
@@ -606,7 +797,10 @@
     id: 'setting_priorities',
     name: 'Setting Priorities',
     wikiLink: 'https://escapefromtarkov.fandom.com/wiki/Setting_Priorities',
-    trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' },
+    trader: {
+      id: '5a7c2eca46aef81a7ca2145d',
+      name: 'Mechanic',
+    },
     kappaRequired: false,
     factionName: 'Any',
     taskRequirements: [
@@ -616,7 +810,12 @@
           name: 'A Shooter Born in Heaven',
         },
       },
-      { task: { id: '61958c366726521dd96828ec', name: 'Cargo X - Part 4' } },
+      {
+        task: {
+          id: '61958c366726521dd96828ec',
+          name: 'Cargo X - Part 4',
+        },
+      },
     ],
     objectives: [
       {
@@ -624,15 +823,42 @@
         description: 'Eliminate 15 PMC operatives while using an active headset without wearing any armor',
         type: 'shoot',
         wearing: [
-          { id: '5b432b965acfc47a8774094e', name: 'GSSh-01 active headset' },
-          { id: '5aa2ba71e5b5b000137b758f', name: 'MSA Sordin Supreme PRO-X/L headset' },
-          { id: '6033fa48ffd42c541047f728', name: 'OPSMEN Earmor M32 headset' },
-          { id: '5a16b9fffcdbcb0176308b34', name: 'Ops-Core FAST RAC Headset' },
-          { id: '5645bcc04bdc2d363b8b4572', name: 'Peltor ComTac II headset (OD Green)' },
-          { id: '628e4e576d783146b124c64d', name: 'Peltor ComTac IV Hybrid headset (Coyote Brown)' },
-          { id: '5c165d832e2216398b5a7e36', name: 'Peltor Tactical Sport headset' },
-          { id: '5e4d34ca86f774264f758330', name: "Walker's Razor Digital headset" },
-          { id: '5f60cd6cf2bcbb675b00dac6', name: "Walker's XCEL 500BT Digital headset" },
+          {
+            id: '5b432b965acfc47a8774094e',
+            name: 'GSSh-01 active headset',
+          },
+          {
+            id: '5aa2ba71e5b5b000137b758f',
+            name: 'MSA Sordin Supreme PRO-X/L headset',
+          },
+          {
+            id: '6033fa48ffd42c541047f728',
+            name: 'OPSMEN Earmor M32 headset',
+          },
+          {
+            id: '5a16b9fffcdbcb0176308b34',
+            name: 'Ops-Core FAST RAC Headset',
+          },
+          {
+            id: '5645bcc04bdc2d363b8b4572',
+            name: 'Peltor ComTac II headset (OD Green)',
+          },
+          {
+            id: '628e4e576d783146b124c64d',
+            name: 'Peltor ComTac IV Hybrid headset (Coyote Brown)',
+          },
+          {
+            id: '5c165d832e2216398b5a7e36',
+            name: 'Peltor Tactical Sport headset',
+          },
+          {
+            id: '5e4d34ca86f774264f758330',
+            name: "Walker's Razor Digital headset",
+          },
+          {
+            id: '5f60cd6cf2bcbb675b00dac6',
+            name: "Walker's XCEL 500BT Digital headset",
+          },
         ],
         count: 15,
       },
@@ -640,17 +866,49 @@
         id: 'setting_priorities_obj02',
         description: 'Eliminate 15 PMC operatives while wearing the TSh-4M-L soft tank crew helmet without wearing any active headset',
         type: 'shoot',
-        wearing: [{ id: '5df8a58286f77412631087ed', name: "TSh-4M-L soft tank crew helmet"}],
+        wearing: [
+          {
+            id: '5df8a58286f77412631087ed',
+            name: 'TSh-4M-L soft tank crew helmet',
+          },
+        ],
         notWearing: [
-          { id: '5b432b965acfc47a8774094e', name: 'GSSh-01 active headset' },
-          { id: '5aa2ba71e5b5b000137b758f', name: 'MSA Sordin Supreme PRO-X/L headset' },
-          { id: '6033fa48ffd42c541047f728', name: 'OPSMEN Earmor M32 headset' },
-          { id: '5a16b9fffcdbcb0176308b34', name: 'Ops-Core FAST RAC Headset' },
-          { id: '5645bcc04bdc2d363b8b4572', name: 'Peltor ComTac II headset (OD Green)' },
-          { id: '628e4e576d783146b124c64d', name: 'Peltor ComTac IV Hybrid headset (Coyote Brown)' },
-          { id: '5c165d832e2216398b5a7e36', name: 'Peltor Tactical Sport headset' },
-          { id: '5e4d34ca86f774264f758330', name: "Walker's Razor Digital headset" },
-          { id: '5f60cd6cf2bcbb675b00dac6', name: "Walker's XCEL 500BT Digital headset" },
+          {
+            id: '5b432b965acfc47a8774094e',
+            name: 'GSSh-01 active headset',
+          },
+          {
+            id: '5aa2ba71e5b5b000137b758f',
+            name: 'MSA Sordin Supreme PRO-X/L headset',
+          },
+          {
+            id: '6033fa48ffd42c541047f728',
+            name: 'OPSMEN Earmor M32 headset',
+          },
+          {
+            id: '5a16b9fffcdbcb0176308b34',
+            name: 'Ops-Core FAST RAC Headset',
+          },
+          {
+            id: '5645bcc04bdc2d363b8b4572',
+            name: 'Peltor ComTac II headset (OD Green)',
+          },
+          {
+            id: '628e4e576d783146b124c64d',
+            name: 'Peltor ComTac IV Hybrid headset (Coyote Brown)',
+          },
+          {
+            id: '5c165d832e2216398b5a7e36',
+            name: 'Peltor Tactical Sport headset',
+          },
+          {
+            id: '5e4d34ca86f774264f758330',
+            name: "Walker's Razor Digital headset",
+          },
+          {
+            id: '5f60cd6cf2bcbb675b00dac6',
+            name: "Walker's XCEL 500BT Digital headset",
+          },
         ],
         count: 15,
       },
@@ -669,7 +927,10 @@
       ],
       traderStanding: [
         {
-          trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' },
+          trader: {
+            id: '5a7c2eca46aef81a7ca2145d',
+            name: 'Mechanic',
+          },
           standing: 0.01,
         },
       ],
@@ -682,12 +943,18 @@
     id: 'no_questions_asked',
     name: 'No Questions Asked',
     wikiLink: 'https://escapefromtarkov.fandom.com/wiki/No_Questions_Asked',
-    trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+    trader: {
+      id: '54cb50c76803fa8b248b4571',
+      name: 'Prapor',
+    },
     kappaRequired: false,
     factionName: 'Any',
     taskRequirements: [
       {
-        task: { id: '59ca2eb686f77445a80ed049', name: 'The Punisher - Part 6' },
+        task: {
+          id: '59ca2eb686f77445a80ed049',
+          name: 'The Punisher - Part 6',
+        },
       },
     ],
     objectives: [
@@ -735,12 +1002,25 @@
     id: 'goals_and_means',
     name: 'Goals and Means',
     wikiLink: 'https://escapefromtarkov.fandom.com/wiki/Goals_and_Means',
-    trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' },
+    trader: {
+      id: '5a7c2eca46aef81a7ca2145d',
+      name: 'Mechanic',
+    },
     kappaRequired: false,
     factionName: 'Any',
     taskRequirements: [
-      { task: { id: '5ae3280386f7742a41359364', name: 'Gunsmith - Part 15' } },
-      { task: { id: '625d700cc48e6c62a440fab5', name: 'Getting Acquainted' } },
+      {
+        task: {
+          id: '5ae3280386f7742a41359364',
+          name: 'Gunsmith - Part 15',
+        },
+      },
+      {
+        task: {
+          id: '625d700cc48e6c62a440fab5',
+          name: 'Getting Acquainted',
+        },
+      },
     ],
     objectives: [
       {
@@ -813,7 +1093,10 @@
       // Unlocks purchase of AS VAL MOD.4 (Default) at Mechanic LL4.
       offerUnlock: [
         {
-          trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' },
+          trader: {
+            id: '5a7c2eca46aef81a7ca2145d',
+            name: 'Mechanic',
+          },
           level: 4,
           item: {
             id: '68d502e016a16a91e200bbbc',
@@ -824,7 +1107,10 @@
       ],
       traderStanding: [
         {
-          trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' },
+          trader: {
+            id: '5a7c2eca46aef81a7ca2145d',
+            name: 'Mechanic',
+          },
           standing: 0.02,
         },
       ],

--- a/src/overrides/tasks.json5
+++ b/src/overrides/tasks.json5
@@ -396,9 +396,9 @@
   },
   // The Blood of War - Part 1 - Truck #2 Location Change, Truck #4 Missing
   // Proof: https://escapefromtarkov.fandom.com/wiki/The_Blood_of_War_-_Part_1
-  "5ae448f286f77448d73c0131": {
+  '5ae448f286f77448d73c0131': {
     objectives: {
-      "5ae452de86f77450595c4333": {
+      '5ae452de86f77450595c4333': {
         zones: [
           {
             map: {
@@ -438,26 +438,26 @@
     },
     objectivesAdd: [
       {
-        id: "the_blood_of_war_-_part_1_obj04",
-        description: "Mark the fourth fuel tank with an MS2000 Marker on Interchange",
-        type: "mark",
+        id: 'the_blood_of_war_-_part_1_obj04',
+        description: 'Mark the fourth fuel tank with an MS2000 Marker on Interchange',
+        type: 'mark',
         maps: [
           {
-            id: "5714dbc024597771384a510d",
-            name: "Interchange",
+            id: '5714dbc024597771384a510d',
+            name: 'Interchange',
           },
         ],
         markerItem: {
-          id: "5991b51486f77447b112d44f",
-          name: "MS2000 Marker",
-          shortName: "MS2000",
+          id: '5991b51486f77447b112d44f',
+          name: 'MS2000 Marker',
+          shortName: 'MS2000',
         },
         optional: true,
         zones: [
           {
             map: {
-              id: "5714dbc024597771384a510d",
-              name: "Interchange",
+              id: '5714dbc024597771384a510d',
+              name: 'Interchange',
             },
             outline: [
               {


### PR DESCRIPTION
## Description
Temporary workaround: update the objective description for **Vacate the Premises** to explicitly note that the required kill count differs by `gameMode`.

Task `67d03be712fb5f8fd2096332`, objective `67d03be712fb5f8fd2096334`:
- `regular` (PvP): `count = 24`
- `pve`: `count = 36`

This PR intentionally does **not** override `count` (overrides are ID-keyed and mode-agnostic), and only updates the displayed objective text. Please check related issues.

## Type of Change
- [x] Data correction (fixing incorrect tarkov.dev data)
- [ ] New data addition (data not in tarkov.dev)
- [ ] Schema update
- [ ] Documentation update
- [ ] Build/tooling update

## Proof of Correctness
- https://escapefromtarkov.fandom.com/wiki/Vacate_the_Premises

## Checklist
- [x] I have included proof links in the JSON5 comments
- [x] I have noted the original incorrect value in inline comments
- [x] I have included the entity name as a comment above each ID
- [x] Field names match tarkov.dev schema exactly (camelCase)
- [x] Validation passes locally (`npm run validate`)

## Related Issues
- TarkovTracker [Issue #138](https://github.com/tarkovtracker-org/TarkovTracker/issues/138): Bug Report: Mode-Specific Task Data Is Incorrectly Overwritten by Mode-Agnostic Overlay
- tarkov-data-overlay [Issue #93](https://github.com/tarkovtracker-org/tarkov-data-overlay/issues/93): Bug Report: Mode-Specific Task Data Is Incorrectly Overwritten by Mode-Agnostic Overlay
- tarkov-data-overlay [Issue #73](https://github.com/tarkovtracker-org/tarkov-data-overlay/issues/73): [Overlay - Quests] Vacate the Premises
- Temporary Fixes #73 
