### PR TITLE
Drip-Out - Part 2

### DIFF
--- a/src/overrides/tasks.json5
+++ b/src/overrides/tasks.json5
@@ -493,4 +493,34 @@
       },
     ],
   },
+  // Drip-Out - Part 2 (USEC) - Objective maps incorrect
+  // Proof: https://escapefromtarkov.fandom.com/wiki/Drip-Out_-_Part_2
+  // Rogues are only present on Lighthouse (Water Treatment Plant), not Customs or Woods.
+  '6615141bfda04449120269a7': {
+    objectives: {
+      '6615141bfda04449120269a8': {
+        maps: [
+          {
+            id: '5704e4dad2720bb55b8b4567',
+            name: 'Lighthouse',
+          },
+        ], // Was: [{ id: '56f40101d2720b2a4d8b45d6', name: 'Customs' }, { id: '5704e3c2d2720bac5b8b4567', name: 'Woods' }, { id: '5704e4dad2720bb55b8b4567', name: 'Lighthouse' }]
+      },
+    },
+  },
+  // Drip-Out - Part 2 (Bear) - Objective maps incorrect
+  // Proof: https://escapefromtarkov.fandom.com/wiki/Drip-Out_-_Part_2
+  // Rogues are only present on Lighthouse (Water Treatment Plant), not Customs or Woods.
+  '6613f307fca4f2f386029409': {
+    objectives: {
+      '6615127fd998c5f2aaa4a8a0': {
+        maps: [
+          {
+            id: '5704e4dad2720bb55b8b4567',
+            name: 'Lighthouse',
+          },
+        ], // Was: [{ id: '56f40101d2720b2a4d8b45d6', name: 'Customs' }, { id: '5704e3c2d2720bac5b8b4567', name: 'Woods' }, { id: '5704e4dad2720bb55b8b4567', name: 'Lighthouse' }]
+      },
+    },
+  },
 }


### PR DESCRIPTION
## Description
Limits the "Eliminate Rogues" objective in **Drip-Out - Part 2** to **Lighthouse only**.

tarkov.dev currently lists this objective as available on Customs/Woods/Lighthouse, but Rogues are Lighthouse-only (Water Treatment Plant).

This fix touches **two different task IDs** because Drip-Out - Part 2 exists as separate tasks for each faction:
- **USEC** task `6615141bfda04449120269a7` (objective `6615141bfda04449120269a8`)
- **BEAR** task `6613f307fca4f2f386029409` (objective `6615127fd998c5f2aaa4a8a0`)

Files:
- `src/overrides/tasks.json5`


## Type of Change
- [x] Data correction (fixing incorrect tarkov.dev data)
- [ ] New data addition (data not in tarkov.dev)
- [ ] Schema update
- [ ] Documentation update
- [ ] Build/tooling update

## Proof of Correctness
- https://escapefromtarkov.fandom.com/wiki/Drip-Out_-_Part_2
- https://escapefromtarkov.fandom.com/wiki/Rogues


## Checklist
- [x] I have included proof links in the JSON5 comments
- [x] I have noted the original incorrect value in inline comments
- [x] I have included the entity name as a comment above each ID
- [x] Field names match tarkov.dev schema exactly (camelCase)
- [x] Validation passes locally (`npm run validate`)


## Related Issues
Closes #68 
