### PR TITLE
fix(schema): allow extra fields in objectivesAdd

### DIFF
--- a/src/schemas/task-override.schema.json
+++ b/src/schemas/task-override.schema.json
@@ -723,7 +723,7 @@
       "objectivesAdd": {
         "description": "Objective additions for missing API objectives",
         "items": {
-          "additionalProperties": false,
+          "additionalProperties": true,
           "properties": {
             "containsAll": {
               "items": {


### PR DESCRIPTION
## Description
Fixes `npm run validate` failures when a task override uses `objectivesAdd` entries that include fields not explicitly listed in the schema (for example `exitStatus` on extract/transit objectives).

Changes:
- Loosens the `objectivesAdd[]` item schema by setting `additionalProperties: true`
- Keeps the existing known fields documented under `properties`, but permits extra keys used by specific objective types

Files:
- `src/schemas/task-override.schema.json`


## Type of Change
<!-- Check all that apply -->
- [ ] Data correction (fixing incorrect tarkov.dev data)
- [ ] New data addition (data not in tarkov.dev)
- [x] Schema update
- [ ] Documentation update
- [x] Build/tooling update


## Rationale
We already support adding missing objectives via `objectivesAdd`, and we already use `exitStatus` on existing objective patches under `objectives`.

However, the schema for `objectivesAdd[]` items was strict (`additionalProperties: false`), so AJV rejected any extra objective fields that weren’t explicitly enumerated. In practice, added objectives can require type-specific fields (like `exitStatus` for extract/transit objectives), and keeping an exhaustive whitelist in sync is brittle.

This change opts for a permissive item schema for `objectivesAdd[]`, so we can add missing objectives without schema churn for every new field.


## Test Plan
- `npm run validate`
- `npm test`


## Checklist
- [x] Schema change matches intended behavior (allow extra objective fields in `objectivesAdd[]`)