### PR TITLE
Forester's Duty

### DIFF
--- a/src/overrides/tasks.json5
+++ b/src/overrides/tasks.json5
@@ -358,9 +358,13 @@
     objectives: {
       '66ab9da7eb102b9bcd08591d': {
         description: 'Eliminate 5 Scavs on Lighthouse (In one raid)', // Was: Eliminate Scavs at the village on Lighthouse (In one raid)
+        zones: [], // Was: [{ id: "Marafon_kill_village_lighthouse", position: { x: -72.8853149, y: 5.777012, z: -286.249237 }, outline: [...] }]
+        zoneNames: [], // Was: ['Village']
       },
       '66ab9da7eb102b9bcd085922': {
         description: 'Eliminate 5 Scavs on Shoreline (In one raid)', // Was: Eliminate Scavs at the village on Shoreline (In one raid)
+        zones: [], // Was: [{ id: "marafon_kill_village_shoreline", position: { x: 377.300049, y: -54.42, z: 136.299988 }, outline: [...] }]
+        zoneNames: [], // Was: ['Village']
       },
     },
   },


### PR DESCRIPTION
## Description
Fixes inaccurate objective zone geometry for **Forester's Duty** (`66ab9da7eb102b9bcd08591c`) that was bleeding through to TarkovTracker map overlays.

Changes:
- Clear `zones` for objectives `66ab9da7eb102b9bcd08591d` (Lighthouse) and `66ab9da7eb102b9bcd085922` (Shoreline)
- Clear `zoneNames` for both objectives (removes the stale "Village" label)
- Keep the existing corrected objective descriptions already tracked in this overlay

Files:
- `src/overrides/tasks.json5`


## Type of Change
<!-- Check all that apply -->
- [x] Data correction (fixing incorrect tarkov.dev data)
- [ ] New data addition (data not in tarkov.dev)
- [ ] Schema update
- [ ] Documentation update
- [ ] Build/tooling update


## Proof of Correctness
- https://escapefromtarkov.fandom.com/wiki/Forester%27s_Duty
- https://github.com/tarkovtracker-org/tarkov-data-overlay/issues/113


## Test Plan
- `npm run validate`
- `npm test`


## Checklist
- [x] I have included proof links in the JSON5 comments
- [x] I have noted the original incorrect value in inline comments
- [x] I have included the entity name as a comment above each ID
- [x] Field names match tarkov.dev schema exactly (camelCase)
- [x] Validation passes locally (`npm run validate`)


## Related Issues
Closes #113
