### PR TITLE
fix(tasks): correct quest XP for Gendarmerie and Debtor

### DIFF
--- a/src/overrides/tasks.json5
+++ b/src/overrides/tasks.json5
@@ -770,4 +770,10 @@
   '64e7b99017ab941a6f7bf9d7': {
     experience: 7100, // Was: 21500
   },
+  // Debtor - Experience incorrect
+  // Proof: https://escapefromtarkov.fandom.com/wiki/Debtor
+  // Wiki rewards show +13,200 EXP.
+  '639dbaf17c898a131e1cffff': {
+    experience: 13200, // Was: 26600
+  },
 }


### PR DESCRIPTION
## Description

Correct task completion XP (`Task.experience`) for four quests where the API value differs from the Escape from Tarkov Fandom wiki.

Includes one commit per quest for easier review.

Maintainer merge order: N/A (single PR)
Depends on: none

## Type of Change

- [x] Data correction (fixing incorrect tarkov.dev data)
- [ ] New data addition (data not in tarkov.dev)
- [ ] Schema update
- [ ] Documentation update
- [ ] Build/tooling update

## Proof of Correctness

- Gendarmerie - District Patrol (`64e7b9bffd30422ed03dad38`): `experience` 25000 -> 8300
  - Proof: https://escapefromtarkov.fandom.com/wiki/Gendarmerie_-_District_Patrol
- Gendarmerie - Tickets, Please (`64e7b9a4aac4cd0a726562cb`): `experience` 22600 -> 7500
  - Proof: https://escapefromtarkov.fandom.com/wiki/Gendarmerie_-_Tickets%2C_Please
- Gendarmerie - Mall Cop (`64e7b99017ab941a6f7bf9d7`): `experience` 21500 -> 7100
  - Proof: https://escapefromtarkov.fandom.com/wiki/Gendarmerie_-_Mall_Cop
- Debtor (`639dbaf17c898a131e1cffff`): `experience` 26600 -> 13200
  - Proof: https://escapefromtarkov.fandom.com/wiki/Debtor

## Checklist

- [x] I have included proof links in the JSON5 comments
- [x] I have noted the original incorrect value in inline comments
- [x] I have included the entity name as a comment above each ID
- [x] Field names match tarkov.dev schema exactly (camelCase)
- [x] Validation passes locally (`npm run validate`)

## Related Issues

Closes #
