### PR TITLE
fix(events): remove smuggler quests

### DIFF
--- a/src/additions/tasksAdd.json5
+++ b/src/additions/tasksAdd.json5
@@ -1359,267 +1359,267 @@
   // Bulldogs Under The Rug
   // Proof: https://escapefromtarkov.fandom.com/wiki/Bulldogs_Under_The_Rug
   // Proof: https://escapefromtarkov.fandom.com/wiki/Events
-  bulldogs_under_the_rug: {
-    id: 'bulldogs_under_the_rug',
-    name: 'Bulldogs Under The Rug',
-    wikiLink: 'https://escapefromtarkov.fandom.com/wiki/Bulldogs_Under_The_Rug',
-    trader: {
-      id: '5935c25fb3acc3127c3d8cd9',
-      name: 'Peacekeeper',
-    },
-    map: null,
-    kappaRequired: false,
-    lightkeeperRequired: false,
-    factionName: 'Any',
-    taskRequirements: [
-      {
-        task: {
-          id: '5a27b75b86f7742e97191958',
-          name: 'Fishing Gear',
-        },
-      },
-    ],
-    objectives: [
-      {
-        id: 'bulldogs_under_the_rug_obj01',
-        description: 'Eliminate a smuggler on any location',
-        type: 'shoot',
-        optional: false,
-        count: 1,
-        shotType: 'kill',
-        targetNames: ['Smuggler'],
-      },
-      {
-        id: 'bulldogs_under_the_rug_obj02',
-        description: "Locate the smuggler's camp on Shoreline",
-        type: 'visit',
-        maps: [
-          {
-            id: '5704e554d2720bac5b8b456e',
-            name: 'Shoreline',
-          },
-        ],
-        optional: false,
-      },
-      {
-        id: 'bulldogs_under_the_rug_obj03',
-        description: "Obtain the evidence of the smugglers' ties to Edward",
-        type: 'findQuestItem',
-        optional: false,
-        count: 1,
-      },
-    ],
-    experience: 10000,
-    finishRewards: {
-      items: [
-        {
-          count: 700,
-          item: {
-            id: '5696686a4bdc2da3298b456a',
-            name: 'Dollars',
-            shortName: 'USD',
-          },
-        },
-        {
-          count: 1,
-          item: {
-            id: '6165ac306ef05c2ce828ef74',
-            name: 'FN SCAR-H 7.62x51 assault rifle (FDE)',
-            shortName: 'Mk 17',
-          },
-        },
-        {
-          count: 6,
-          item: {
-            id: '6183d53f1cb55961fa0fdcda',
-            name: 'FN SCAR-H 7.62x51 20-round magazine (FDE)',
-            shortName: 'Mk17',
-          },
-        },
-        {
-          count: 8,
-          item: {
-            id: '6769b8e3c1a1466c850658a8',
-            name: '7.62x51mm M80A1 ammo pack (20 pcs)',
-            shortName: 'M80A1',
-          },
-        },
-      ],
-    },
-  },
+  // bulldogs_under_the_rug: {
+  //   id: 'bulldogs_under_the_rug',
+  //   name: 'Bulldogs Under The Rug',
+  //   wikiLink: 'https://escapefromtarkov.fandom.com/wiki/Bulldogs_Under_The_Rug',
+  //   trader: {
+  //     id: '5935c25fb3acc3127c3d8cd9',
+  //     name: 'Peacekeeper',
+  //   },
+  //   map: null,
+  //   kappaRequired: false,
+  //   lightkeeperRequired: false,
+  //   factionName: 'Any',
+  //   taskRequirements: [
+  //     {
+  //       task: {
+  //         id: '5a27b75b86f7742e97191958',
+  //         name: 'Fishing Gear',
+  //       },
+  //     },
+  //   ],
+  //   objectives: [
+  //     {
+  //       id: 'bulldogs_under_the_rug_obj01',
+  //       description: 'Eliminate a smuggler on any location',
+  //       type: 'shoot',
+  //       optional: false,
+  //       count: 1,
+  //       shotType: 'kill',
+  //       targetNames: ['Smuggler'],
+  //     },
+  //     {
+  //       id: 'bulldogs_under_the_rug_obj02',
+  //       description: "Locate the smuggler's camp on Shoreline",
+  //       type: 'visit',
+  //       maps: [
+  //         {
+  //           id: '5704e554d2720bac5b8b456e',
+  //           name: 'Shoreline',
+  //         },
+  //       ],
+  //       optional: false,
+  //     },
+  //     {
+  //       id: 'bulldogs_under_the_rug_obj03',
+  //       description: "Obtain the evidence of the smugglers' ties to Edward",
+  //       type: 'findQuestItem',
+  //       optional: false,
+  //       count: 1,
+  //     },
+  //   ],
+  //   experience: 10000,
+  //   finishRewards: {
+  //     items: [
+  //       {
+  //         count: 700,
+  //         item: {
+  //           id: '5696686a4bdc2da3298b456a',
+  //           name: 'Dollars',
+  //           shortName: 'USD',
+  //         },
+  //       },
+  //       {
+  //         count: 1,
+  //         item: {
+  //           id: '6165ac306ef05c2ce828ef74',
+  //           name: 'FN SCAR-H 7.62x51 assault rifle (FDE)',
+  //           shortName: 'Mk 17',
+  //         },
+  //       },
+  //       {
+  //         count: 6,
+  //         item: {
+  //           id: '6183d53f1cb55961fa0fdcda',
+  //           name: 'FN SCAR-H 7.62x51 20-round magazine (FDE)',
+  //           shortName: 'Mk17',
+  //         },
+  //       },
+  //       {
+  //         count: 8,
+  //         item: {
+  //           id: '6769b8e3c1a1466c850658a8',
+  //           name: '7.62x51mm M80A1 ammo pack (20 pcs)',
+  //           shortName: 'M80A1',
+  //         },
+  //       },
+  //     ],
+  //   },
+  // },
 
   // Accept Delivery
   // Proof: https://escapefromtarkov.fandom.com/wiki/Accept_Delivery
   // Proof: https://escapefromtarkov.fandom.com/wiki/Events
-  accept_delivery: {
-    id: 'accept_delivery',
-    name: 'Accept Delivery',
-    wikiLink: 'https://escapefromtarkov.fandom.com/wiki/Accept_Delivery',
-    trader: {
-      id: '5935c25fb3acc3127c3d8cd9',
-      name: 'Peacekeeper',
-    },
-    map: null,
-    kappaRequired: false,
-    lightkeeperRequired: false,
-    factionName: 'Any',
-    taskRequirements: [
-      {
-        task: {
-          id: 'bulldogs_under_the_rug',
-          name: 'Bulldogs Under The Rug',
-        },
-      },
-    ],
-    objectives: [
-      {
-        id: 'accept_delivery_obj01',
-        description: "Obtain and hand over the locked smugglers' case",
-        type: 'giveItem',
-        optional: false,
-        count: 1,
-        items: [
-          {
-            id: '6740987b89d5e1ddc603f4f0',
-            name: 'Locked case',
-            shortName: 'Locked case',
-          },
-        ],
-      },
-      {
-        id: 'accept_delivery_obj02',
-        description: 'Obtain and hand over the key to the locked case',
-        type: 'giveItem',
-        optional: false,
-        count: 1,
-        items: [
-          {
-            id: '67449b6c89d5e1ddc603f504',
-            name: 'Case key',
-            shortName: 'Case key',
-          },
-        ],
-      },
-    ],
-    experience: 11500,
-    finishRewards: {
-      items: [
-        {
-          count: 1100,
-          item: {
-            id: '5696686a4bdc2da3298b456a',
-            name: 'Dollars',
-            shortName: 'USD',
-          },
-        },
-        {
-          count: 3,
-          item: {
-            id: '5c12613b86f7743bbe2c3f76',
-            name: 'Intelligence folder',
-            shortName: 'Intelligence',
-          },
-        },
-      ],
-    },
-  },
+  // accept_delivery: {
+  //   id: 'accept_delivery',
+  //   name: 'Accept Delivery',
+  //   wikiLink: 'https://escapefromtarkov.fandom.com/wiki/Accept_Delivery',
+  //   trader: {
+  //     id: '5935c25fb3acc3127c3d8cd9',
+  //     name: 'Peacekeeper',
+  //   },
+  //   map: null,
+  //   kappaRequired: false,
+  //   lightkeeperRequired: false,
+  //   factionName: 'Any',
+  //   taskRequirements: [
+  //     {
+  //       task: {
+  //         id: 'bulldogs_under_the_rug',
+  //         name: 'Bulldogs Under The Rug',
+  //       },
+  //     },
+  //   ],
+  //   objectives: [
+  //     {
+  //       id: 'accept_delivery_obj01',
+  //       description: "Obtain and hand over the locked smugglers' case",
+  //       type: 'giveItem',
+  //       optional: false,
+  //       count: 1,
+  //       items: [
+  //         {
+  //           id: '6740987b89d5e1ddc603f4f0',
+  //           name: 'Locked case',
+  //           shortName: 'Locked case',
+  //         },
+  //       ],
+  //     },
+  //     {
+  //       id: 'accept_delivery_obj02',
+  //       description: 'Obtain and hand over the key to the locked case',
+  //       type: 'giveItem',
+  //       optional: false,
+  //       count: 1,
+  //       items: [
+  //         {
+  //           id: '67449b6c89d5e1ddc603f504',
+  //           name: 'Case key',
+  //           shortName: 'Case key',
+  //         },
+  //       ],
+  //     },
+  //   ],
+  //   experience: 11500,
+  //   finishRewards: {
+  //     items: [
+  //       {
+  //         count: 1100,
+  //         item: {
+  //           id: '5696686a4bdc2da3298b456a',
+  //           name: 'Dollars',
+  //           shortName: 'USD',
+  //         },
+  //       },
+  //       {
+  //         count: 3,
+  //         item: {
+  //           id: '5c12613b86f7743bbe2c3f76',
+  //           name: 'Intelligence folder',
+  //           shortName: 'Intelligence',
+  //         },
+  //       },
+  //     ],
+  //   },
+  // },
 
   // Thirty Pieces of Silver
   // Proof: user-provided in-game screenshot (March 12, 2026)
   // Proof: https://escapefromtarkov.fandom.com/wiki/Events
   // Proof: https://escapefromtarkov.fandom.com/wiki/Thirty_Pieces_of_Silver
-  thirty_pieces_of_silver: {
-    id: 'thirty_pieces_of_silver',
-    name: 'Thirty Pieces of Silver',
-    wikiLink: 'https://escapefromtarkov.fandom.com/wiki/Thirty_Pieces_of_Silver',
-    trader: {
-      id: '5935c25fb3acc3127c3d8cd9',
-      name: 'Peacekeeper',
-    },
-    map: null,
-    kappaRequired: false,
-    lightkeeperRequired: false,
-    factionName: 'Any',
-    taskRequirements: [
-      {
-        task: {
-          id: 'accept_delivery',
-          name: 'Accept Delivery',
-        },
-      },
-    ],
-    // Wiki initial equipment unlocks an Opened case craft at Workbench level 1.
-    // That is not modeled as a tangible task reward in this overlay schema.
-    objectives: [
-      {
-        id: 'thirty_pieces_of_silver_obj01',
-        description: 'Eliminate smugglers',
-        type: 'shoot',
-        optional: false,
-        count: 25,
-        shotType: 'kill',
-        targetNames: ['Smuggler'],
-      },
-      {
-        id: 'thirty_pieces_of_silver_obj02',
-        description: 'Obtain and hand over contraband boxes',
-        type: 'giveItem',
-        optional: false,
-        count: 3,
-        items: [
-          {
-            id: '67408903268737ef6908d432',
-            name: 'Contraband box',
-            shortName: 'Contraband',
-          },
-        ],
-      },
-      {
-        id: 'thirty_pieces_of_silver_obj03',
-        description: "Obtain and hand over locked smugglers' weapon cases",
-        type: 'giveItem',
-        optional: false,
-        count: 3,
-      },
-    ],
-    experience: 15000,
-    finishRewards: {
-      items: [
-        {
-          count: 1400,
-          item: {
-            id: '5696686a4bdc2da3298b456a',
-            name: 'Dollars',
-            shortName: 'USD',
-          },
-        },
-        {
-          count: 1,
-          item: {
-            id: '65290f395ae2ae97b80fdf2d',
-            name: 'SIG MCX-SPEAR 6.8x51 assault rifle',
-            shortName: 'SPEAR 6.8',
-          },
-        },
-        {
-          count: 6,
-          item: {
-            id: '65293c7a17e14363030ad308',
-            name: 'AR-10 7.62x51 Lancer L7AWM 25-round magazine',
-            shortName: 'L7AWM',
-          },
-        },
-        {
-          count: 10,
-          item: {
-            id: '67600a516f01341c9106ab4c',
-            name: '6.8x51mm SIG Hybrid ammo pack (20 pcs)',
-            shortName: 'Hybrid',
-          },
-        },
-      ],
-    },
-  },
+  // thirty_pieces_of_silver: {
+  //   id: 'thirty_pieces_of_silver',
+  //   name: 'Thirty Pieces of Silver',
+  //   wikiLink: 'https://escapefromtarkov.fandom.com/wiki/Thirty_Pieces_of_Silver',
+  //   trader: {
+  //     id: '5935c25fb3acc3127c3d8cd9',
+  //     name: 'Peacekeeper',
+  //   },
+  //   map: null,
+  //   kappaRequired: false,
+  //   lightkeeperRequired: false,
+  //   factionName: 'Any',
+  //   taskRequirements: [
+  //     {
+  //       task: {
+  //         id: 'accept_delivery',
+  //         name: 'Accept Delivery',
+  //       },
+  //     },
+  //   ],
+  //   // Wiki initial equipment unlocks an Opened case craft at Workbench level 1.
+  //   // That is not modeled as a tangible task reward in this overlay schema.
+  //   objectives: [
+  //     {
+  //       id: 'thirty_pieces_of_silver_obj01',
+  //       description: 'Eliminate smugglers',
+  //       type: 'shoot',
+  //       optional: false,
+  //       count: 25,
+  //       shotType: 'kill',
+  //       targetNames: ['Smuggler'],
+  //     },
+  //     {
+  //       id: 'thirty_pieces_of_silver_obj02',
+  //       description: 'Obtain and hand over contraband boxes',
+  //       type: 'giveItem',
+  //       optional: false,
+  //       count: 3,
+  //       items: [
+  //         {
+  //           id: '67408903268737ef6908d432',
+  //           name: 'Contraband box',
+  //           shortName: 'Contraband',
+  //         },
+  //       ],
+  //     },
+  //     {
+  //       id: 'thirty_pieces_of_silver_obj03',
+  //       description: "Obtain and hand over locked smugglers' weapon cases",
+  //       type: 'giveItem',
+  //       optional: false,
+  //       count: 3,
+  //     },
+  //   ],
+  //   experience: 15000,
+  //   finishRewards: {
+  //     items: [
+  //       {
+  //         count: 1400,
+  //         item: {
+  //           id: '5696686a4bdc2da3298b456a',
+  //           name: 'Dollars',
+  //           shortName: 'USD',
+  //         },
+  //       },
+  //       {
+  //         count: 1,
+  //         item: {
+  //           id: '65290f395ae2ae97b80fdf2d',
+  //           name: 'SIG MCX-SPEAR 6.8x51 assault rifle',
+  //           shortName: 'SPEAR 6.8',
+  //         },
+  //       },
+  //       {
+  //         count: 6,
+  //         item: {
+  //           id: '65293c7a17e14363030ad308',
+  //           name: 'AR-10 7.62x51 Lancer L7AWM 25-round magazine',
+  //           shortName: 'L7AWM',
+  //         },
+  //       },
+  //       {
+  //         count: 10,
+  //         item: {
+  //           id: '67600a516f01341c9106ab4c',
+  //           name: '6.8x51mm SIG Hybrid ammo pack (20 pcs)',
+  //           shortName: 'Hybrid',
+  //         },
+  //       },
+  //     ],
+  //   },
+  // },
 
 //  // Duck Hunt
 //  // Proof: https://escapefromtarkov.fandom.com/wiki/Duck_Hunt


### PR DESCRIPTION
## Description
Remove smuggler event quests


## Type of Change
- [x] Data correction (comment event quest)

## Proof of Correctness
https://escapefromtarkov.fandom.com/wiki/Events#Smugglers_2026_(12_March_2026)

## Related Issues
Closes #196 
