### PR TITLE
fix: keep override checks resilient

### DIFF
--- a/dist/overlay.json
+++ b/dist/overlay.json
@@ -3244,7 +3244,7 @@
   },
   "$meta": {
     "version": "1.27",
-    "generated": "2026-04-28T10:48:44.215Z",
-    "sha256": "73922c9f752a7cb2840fbad6497b0139a8944cb55f62896fcdfd55650b69dcaa"
+    "generated": "2026-04-28T11:06:25.723Z",
+    "sha256": "f2eacdfd910febda48b24a7833af1521bb2dab5ced23fb449e3eaf68e3771fe9"
   }
 }

--- a/dist/overlay.json
+++ b/dist/overlay.json
@@ -3240,11 +3240,21 @@
           }
         }
       }
+    },
+    "pve": {
+      "tasks": {
+        "6834233fecd5cf3a440d855b": {
+          "trader": {
+            "id": "579dc571d53a0658a154fbec",
+            "name": "Fence"
+          }
+        }
+      }
     }
   },
   "$meta": {
     "version": "1.27",
-    "generated": "2026-04-28T11:06:25.723Z",
-    "sha256": "f2eacdfd910febda48b24a7833af1521bb2dab5ced23fb449e3eaf68e3771fe9"
+    "generated": "2026-04-10T19:21:06.355Z",
+    "sha256": "49c5f2486d44ea10b35149e259d08b9e1366fea9faa2d0ed41ba0306d94a25b0"
   }
 }

--- a/dist/overlay.json
+++ b/dist/overlay.json
@@ -3240,21 +3240,11 @@
           }
         }
       }
-    },
-    "pve": {
-      "tasks": {
-        "6834233fecd5cf3a440d855b": {
-          "trader": {
-            "id": "579dc571d53a0658a154fbec",
-            "name": "Fence"
-          }
-        }
-      }
     }
   },
   "$meta": {
     "version": "1.27",
-    "generated": "2026-04-10T19:21:06.355Z",
-    "sha256": "49c5f2486d44ea10b35149e259d08b9e1366fea9faa2d0ed41ba0306d94a25b0"
+    "generated": "2026-04-28T10:48:44.215Z",
+    "sha256": "73922c9f752a7cb2840fbad6497b0139a8944cb55f62896fcdfd55650b69dcaa"
   }
 }

--- a/src/lib/tarkov-api.ts
+++ b/src/lib/tarkov-api.ts
@@ -164,10 +164,150 @@ const TASKS_QUERY = `
   }
 `;
 
-const TASKS_QUERY_WITHOUT_USING_WEAPON = TASKS_QUERY.replace(
-  /\n\s+usingWeapon \{ id name shortName \}/,
-  ""
-);
+const TASKS_QUERY_WITHOUT_USING_WEAPON = `
+  query($gameMode: GameMode) {
+    tasks(lang: en, gameMode: $gameMode) {
+      id
+      name
+      minPlayerLevel
+      wikiLink
+      kappaRequired
+      lightkeeperRequired
+      map {
+        id
+        name
+      }
+      experience
+      taskRequirements {
+        task {
+          id
+          name
+        }
+        status
+      }
+      traderRequirements {
+        trader {
+          id
+          name
+        }
+        value
+        compareMethod
+      }
+      factionName
+      requiredPrestige {
+        id
+        name
+        prestigeLevel
+      }
+      objectives {
+        id
+        type
+        description
+        maps {
+          id
+          name
+        }
+        ... on TaskObjectiveBasic {
+          requiredKeys { id name shortName }
+        }
+        ... on TaskObjectiveMark {
+          markerItem { id name shortName }
+          requiredKeys { id name shortName }
+        }
+        ... on TaskObjectiveExtract {
+          requiredKeys { id name shortName }
+        }
+        ... on TaskObjectiveShoot {
+          count
+          usingWeaponMods { id name shortName }
+          wearing { id name shortName }
+          notWearing { id name shortName }
+          requiredKeys { id name shortName }
+        }
+        ... on TaskObjectiveItem {
+          count
+          items { id name shortName }
+          foundInRaid
+          requiredKeys { id name shortName }
+        }
+        ... on TaskObjectiveQuestItem {
+          count
+          questItem { id name shortName }
+          requiredKeys { id name shortName }
+        }
+        ... on TaskObjectiveUseItem {
+          count
+          useAny { id name shortName }
+          requiredKeys { id name shortName }
+        }
+        ... on TaskObjectiveBuildItem {
+          item { id name shortName }
+          containsAll { id name shortName }
+        }
+      }
+      startRewards {
+        items { item { id name shortName } count }
+        traderStanding { trader { id name } standing }
+        offerUnlock { id trader { id name } level item { id name shortName } }
+        skillLevelReward {
+          name
+          level
+          skill {
+            id
+            name
+            imageLink
+          }
+        }
+        traderUnlock {
+          id
+          name
+        }
+        achievement {
+          id
+          name
+          description
+        }
+        customization {
+          id
+          name
+          customizationType
+          customizationTypeName
+          imageLink
+        }
+      }
+      finishRewards {
+        items { item { id name shortName } count }
+        traderStanding { trader { id name } standing }
+        offerUnlock { id trader { id name } level item { id name shortName } }
+        skillLevelReward {
+          name
+          level
+          skill {
+            id
+            name
+            imageLink
+          }
+        }
+        traderUnlock {
+          id
+          name
+        }
+        achievement {
+          id
+          name
+          description
+        }
+        customization {
+          id
+          name
+          customizationType
+          customizationTypeName
+          imageLink
+        }
+      }
+    }
+  }
+`;
 
 function isMissingUsingWeaponItemError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);

--- a/src/lib/tarkov-api.ts
+++ b/src/lib/tarkov-api.ts
@@ -217,7 +217,7 @@ function isMissingUsingWeaponItemError(error: unknown): boolean {
   const graphQLErrors = getGraphQLErrorsFromMessage(message);
 
   if (graphQLErrors) {
-    return graphQLErrors.some((entry) => {
+    return graphQLErrors.length > 0 && graphQLErrors.every((entry) => {
       if (!entry || typeof entry !== "object") return false;
       const graphQLError = entry as { message?: unknown; path?: unknown };
       return (

--- a/src/lib/tarkov-api.ts
+++ b/src/lib/tarkov-api.ts
@@ -183,6 +183,13 @@ const TASKS_QUERY_WITHOUT_USING_WEAPON = buildTasksQuery(
   TASK_OBJECTIVE_SHOOT_WITHOUT_USING_WEAPON
 );
 
+class GraphQLRequestError extends Error {
+  constructor(readonly graphQLErrors: unknown[]) {
+    super(`GraphQL errors: ${JSON.stringify(graphQLErrors)}`);
+    this.name = "GraphQLRequestError";
+  }
+}
+
 const MISSING_ITEM_MESSAGE_PATTERN = /no\s+item|not\s+found|undefined/i;
 
 function getGraphQLErrorsFromMessage(message: string): unknown[] | undefined {
@@ -212,9 +219,23 @@ function hasMissingItemMessage(message: unknown): boolean {
   return MISSING_ITEM_MESSAGE_PATTERN.test(String(message ?? ""));
 }
 
+function getGraphQLErrorsFromError(
+  error: unknown,
+  message: string
+): unknown[] | undefined {
+  if (error instanceof GraphQLRequestError) return error.graphQLErrors;
+
+  if (error && typeof error === "object" && "graphQLErrors" in error) {
+    const graphQLErrors = (error as { graphQLErrors?: unknown }).graphQLErrors;
+    if (Array.isArray(graphQLErrors)) return graphQLErrors;
+  }
+
+  return getGraphQLErrorsFromMessage(message);
+}
+
 function isMissingUsingWeaponItemError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
-  const graphQLErrors = getGraphQLErrorsFromMessage(message);
+  const graphQLErrors = getGraphQLErrorsFromError(error, message);
 
   if (graphQLErrors) {
     return graphQLErrors.length > 0 && graphQLErrors.every((entry) => {
@@ -254,8 +275,12 @@ async function executeQuery<T>(query: string, variables?: Record<string, unknown
     );
   }
 
-  if (result.errors) {
-    throw new Error(`GraphQL errors: ${JSON.stringify(result.errors)}`);
+  if ("errors" in result) {
+    const errors = (result as { errors?: unknown }).errors;
+    if (Array.isArray(errors)) {
+      throw new GraphQLRequestError(errors);
+    }
+    throw new Error(`GraphQL errors: ${JSON.stringify(errors)}`);
   }
 
   if (!("data" in result)) {

--- a/src/lib/tarkov-api.ts
+++ b/src/lib/tarkov-api.ts
@@ -183,12 +183,51 @@ const TASKS_QUERY_WITHOUT_USING_WEAPON = buildTasksQuery(
   TASK_OBJECTIVE_SHOOT_WITHOUT_USING_WEAPON
 );
 
+const MISSING_ITEM_MESSAGE_PATTERN = /no\s+item|not\s+found|undefined/i;
+
+function getGraphQLErrorsFromMessage(message: string): unknown[] | undefined {
+  const prefix = "GraphQL errors: ";
+  const json = message.startsWith(prefix) ? message.slice(prefix.length) : message;
+
+  try {
+    const parsed = JSON.parse(json) as unknown;
+    if (Array.isArray(parsed)) return parsed;
+
+    if (parsed && typeof parsed === "object" && "errors" in parsed) {
+      const errors = (parsed as { errors?: unknown }).errors;
+      if (Array.isArray(errors)) return errors;
+    }
+  } catch {
+    return undefined;
+  }
+
+  return undefined;
+}
+
+function hasUsingWeaponPath(path: unknown): boolean {
+  return Array.isArray(path) && path.includes("usingWeapon");
+}
+
+function hasMissingItemMessage(message: unknown): boolean {
+  return MISSING_ITEM_MESSAGE_PATTERN.test(String(message ?? ""));
+}
+
 function isMissingUsingWeaponItemError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
-  return (
-    message.includes("No item found with id undefined") &&
-    message.includes("usingWeapon")
-  );
+  const graphQLErrors = getGraphQLErrorsFromMessage(message);
+
+  if (graphQLErrors) {
+    return graphQLErrors.some((entry) => {
+      if (!entry || typeof entry !== "object") return false;
+      const graphQLError = entry as { message?: unknown; path?: unknown };
+      return (
+        hasUsingWeaponPath(graphQLError.path) &&
+        hasMissingItemMessage(graphQLError.message)
+      );
+    });
+  }
+
+  return message.includes("usingWeapon") && MISSING_ITEM_MESSAGE_PATTERN.test(message);
 }
 
 /**

--- a/src/lib/tarkov-api.ts
+++ b/src/lib/tarkov-api.ts
@@ -164,6 +164,19 @@ const TASKS_QUERY = `
   }
 `;
 
+const TASKS_QUERY_WITHOUT_USING_WEAPON = TASKS_QUERY.replace(
+  /\n\s+usingWeapon \{ id name shortName \}/,
+  ""
+);
+
+function isMissingUsingWeaponItemError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    message.includes("No item found with id undefined") &&
+    message.includes("usingWeapon")
+  );
+}
+
 /**
  * Execute a GraphQL query against the tarkov.dev API
  */
@@ -204,7 +217,17 @@ async function executeQuery<T>(query: string, variables?: Record<string, unknown
  */
 export async function fetchTasks(gameMode?: 'regular' | 'pve'): Promise<TaskData[]> {
   const variables = gameMode ? { gameMode } : undefined;
-  const data = await executeQuery<unknown>(TASKS_QUERY, variables);
+  let data: unknown;
+
+  try {
+    data = await executeQuery<unknown>(TASKS_QUERY, variables);
+  } catch (error) {
+    if (!isMissingUsingWeaponItemError(error)) throw error;
+    data = await executeQuery<unknown>(
+      TASKS_QUERY_WITHOUT_USING_WEAPON,
+      variables
+    );
+  }
 
   if (!data || typeof data !== "object" || Array.isArray(data)) {
     throw new Error(

--- a/src/lib/tarkov-api.ts
+++ b/src/lib/tarkov-api.ts
@@ -16,155 +16,28 @@ function getValueType(value: unknown): string {
 }
 
 /**
- * GraphQL query for fetching all tasks with their details
+ * GraphQL query fragments for fetching all tasks with their details.
+ * Keep the main and fallback queries identical except for usingWeapon.
  */
-const TASKS_QUERY = `
-  query($gameMode: GameMode) {
-    tasks(lang: en, gameMode: $gameMode) {
-      id
-      name
-      minPlayerLevel
-      wikiLink
-      kappaRequired
-      lightkeeperRequired
-      map {
-        id
-        name
-      }
-      experience
-      taskRequirements {
-        task {
-          id
-          name
-        }
-        status
-      }
-      traderRequirements {
-        trader {
-          id
-          name
-        }
-        value
-        compareMethod
-      }
-      factionName
-      requiredPrestige {
-        id
-        name
-        prestigeLevel
-      }
-      objectives {
-        id
-        type
-        description
-        maps {
-          id
-          name
-        }
-        ... on TaskObjectiveBasic {
-          requiredKeys { id name shortName }
-        }
-        ... on TaskObjectiveMark {
-          markerItem { id name shortName }
-          requiredKeys { id name shortName }
-        }
-        ... on TaskObjectiveExtract {
-          requiredKeys { id name shortName }
-        }
-        ... on TaskObjectiveShoot {
+const TASK_OBJECTIVE_SHOOT_WITH_USING_WEAPON = `
           count
           usingWeapon { id name shortName }
           usingWeaponMods { id name shortName }
           wearing { id name shortName }
           notWearing { id name shortName }
           requiredKeys { id name shortName }
-        }
-        ... on TaskObjectiveItem {
-          count
-          items { id name shortName }
-          foundInRaid
-          requiredKeys { id name shortName }
-        }
-        ... on TaskObjectiveQuestItem {
-          count
-          questItem { id name shortName }
-          requiredKeys { id name shortName }
-        }
-        ... on TaskObjectiveUseItem {
-          count
-          useAny { id name shortName }
-          requiredKeys { id name shortName }
-        }
-        ... on TaskObjectiveBuildItem {
-          item { id name shortName }
-          containsAll { id name shortName }
-        }
-      }
-      startRewards {
-        items { item { id name shortName } count }
-        traderStanding { trader { id name } standing }
-        offerUnlock { id trader { id name } level item { id name shortName } }
-        skillLevelReward {
-          name
-          level
-          skill {
-            id
-            name
-            imageLink
-          }
-        }
-        traderUnlock {
-          id
-          name
-        }
-        achievement {
-          id
-          name
-          description
-        }
-        customization {
-          id
-          name
-          customizationType
-          customizationTypeName
-          imageLink
-        }
-      }
-      finishRewards {
-        items { item { id name shortName } count }
-        traderStanding { trader { id name } standing }
-        offerUnlock { id trader { id name } level item { id name shortName } }
-        skillLevelReward {
-          name
-          level
-          skill {
-            id
-            name
-            imageLink
-          }
-        }
-        traderUnlock {
-          id
-          name
-        }
-        achievement {
-          id
-          name
-          description
-        }
-        customization {
-          id
-          name
-          customizationType
-          customizationTypeName
-          imageLink
-        }
-      }
-    }
-  }
 `;
 
-const TASKS_QUERY_WITHOUT_USING_WEAPON = `
+const TASK_OBJECTIVE_SHOOT_WITHOUT_USING_WEAPON = `
+          count
+          usingWeaponMods { id name shortName }
+          wearing { id name shortName }
+          notWearing { id name shortName }
+          requiredKeys { id name shortName }
+`;
+
+function buildTasksQuery(taskObjectiveShootFields: string): string {
+  return `
   query($gameMode: GameMode) {
     tasks(lang: en, gameMode: $gameMode) {
       id
@@ -217,12 +90,7 @@ const TASKS_QUERY_WITHOUT_USING_WEAPON = `
         ... on TaskObjectiveExtract {
           requiredKeys { id name shortName }
         }
-        ... on TaskObjectiveShoot {
-          count
-          usingWeaponMods { id name shortName }
-          wearing { id name shortName }
-          notWearing { id name shortName }
-          requiredKeys { id name shortName }
+        ... on TaskObjectiveShoot {${taskObjectiveShootFields}
         }
         ... on TaskObjectiveItem {
           count
@@ -308,6 +176,12 @@ const TASKS_QUERY_WITHOUT_USING_WEAPON = `
     }
   }
 `;
+}
+
+const TASKS_QUERY = buildTasksQuery(TASK_OBJECTIVE_SHOOT_WITH_USING_WEAPON);
+const TASKS_QUERY_WITHOUT_USING_WEAPON = buildTasksQuery(
+  TASK_OBJECTIVE_SHOOT_WITHOUT_USING_WEAPON
+);
 
 function isMissingUsingWeaponItemError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);

--- a/src/overrides/modes/pve/tasks.json5
+++ b/src/overrides/modes/pve/tasks.json5
@@ -1,11 +1,1 @@
-{
-  // Against the Conscience - Bad trader
-  // Change the objective
-  // Proof: https://escapefromtarkov.fandom.com/wiki/Against_the_Conscience_-_Part_1
-  '6834233fecd5cf3a440d855b': {
-    trader: {
-      id: '579dc571d53a0658a154fbec', // Was: 6617beeaa9cfa777ca915b7c
-      name: 'Fence', // Was: Ref
-    },
-  },
-}
+{}

--- a/tests/tarkov-api.test.ts
+++ b/tests/tarkov-api.test.ts
@@ -66,6 +66,39 @@ describe('tarkov-api', () => {
     await expect(fetchTasks()).rejects.toThrow('GraphQL errors');
   });
 
+  it('fetchTasks retries without usingWeapon when upstream has a broken item reference', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: async () => ({
+          errors: [
+            {
+              message: 'No item found with id undefined',
+              path: ['tasks', 218, 'objectives', 0, 'usingWeapon', 0],
+            },
+          ],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: async () => ({ data: { tasks: [{ id: 'task-1', name: 'Task 1' }] } }),
+      });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(fetchTasks()).resolves.toEqual([{ id: 'task-1', name: 'Task 1' }]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const retryRequest = fetchMock.mock.calls[1][1] as { body?: string };
+    const retryPayload = JSON.parse(String(retryRequest.body)) as { query: string };
+    expect(retryPayload.query).not.toContain('usingWeapon { id name shortName }');
+    expect(retryPayload.query).toContain('usingWeaponMods { id name shortName }');
+  });
+
   it('fetchTasks sends pve gameMode variables when requested', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,

--- a/tests/tarkov-api.test.ts
+++ b/tests/tarkov-api.test.ts
@@ -103,6 +103,34 @@ describe('tarkov-api', () => {
     expect(retryPayload.query).toContain('usingWeaponMods { id name shortName }');
   });
 
+  it('fetchTasks retries without usingWeapon when the upstream missing-item wording changes', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: async () => ({
+          errors: [
+            {
+              message: 'Item not found for id 660bbc47c38b837877075e47',
+              path: ['tasks', 218, 'objectives', 0, 'usingWeapon', 0],
+            },
+          ],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: async () => ({ data: { tasks: [{ id: 'task-1', name: 'Task 1' }] } }),
+      });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(fetchTasks()).resolves.toEqual([{ id: 'task-1', name: 'Task 1' }]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   it('fetchTasks sends pve gameMode variables when requested', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,

--- a/tests/tarkov-api.test.ts
+++ b/tests/tarkov-api.test.ts
@@ -129,6 +129,39 @@ describe('tarkov-api', () => {
 
     await expect(fetchTasks()).resolves.toEqual([{ id: 'task-1', name: 'Task 1' }]);
     expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    const firstRequest = fetchMock.mock.calls[0][1] as { body?: string };
+    const firstPayload = JSON.parse(String(firstRequest.body)) as { query: string };
+    expect(firstPayload.query).toContain('usingWeapon { id name shortName }');
+
+    const retryRequest = fetchMock.mock.calls[1][1] as { body?: string };
+    const retryPayload = JSON.parse(String(retryRequest.body)) as { query: string };
+    expect(retryPayload.query).not.toContain('usingWeapon { id name shortName }');
+    expect(retryPayload.query).toContain('usingWeaponMods { id name shortName }');
+  });
+
+  it('fetchTasks does not retry when a usingWeapon error is mixed with other GraphQL errors', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => ({
+        errors: [
+          {
+            message: 'Item not found for id 660bbc47c38b837877075e47',
+            path: ['tasks', 218, 'objectives', 0, 'usingWeapon', 0],
+          },
+          {
+            message: 'Unrelated backend failure',
+            path: ['tasks', 10, 'objectives', 0, 'description'],
+          },
+        ],
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(fetchTasks()).rejects.toThrow('GraphQL errors');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it('fetchTasks sends pve gameMode variables when requested', async () => {

--- a/tests/tarkov-api.test.ts
+++ b/tests/tarkov-api.test.ts
@@ -93,6 +93,10 @@ describe('tarkov-api', () => {
     await expect(fetchTasks()).resolves.toEqual([{ id: 'task-1', name: 'Task 1' }]);
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
+    const firstRequest = fetchMock.mock.calls[0][1] as { body?: string };
+    const firstPayload = JSON.parse(String(firstRequest.body)) as { query: string };
+    expect(firstPayload.query).toContain('usingWeapon { id name shortName }');
+
     const retryRequest = fetchMock.mock.calls[1][1] as { body?: string };
     const retryPayload = JSON.parse(String(retryRequest.body)) as { query: string };
     expect(retryPayload.query).not.toContain('usingWeapon { id name shortName }');

--- a/tests/validate-script.test.ts
+++ b/tests/validate-script.test.ts
@@ -58,7 +58,7 @@ describe('scripts/validate helpers', () => {
     writeFileSync(filePath, '{ invalid: }', 'utf-8');
 
     try {
-      const result = validateFile(filePath, 'temp/tasks.json5', validators);
+      const result = validateFile(filePath, 'overrides/tasks.json5', validators);
 
       expect(result.valid).toBe(false);
       expect(result.errors?.[0]).toContain("Failed to parse JSON5 file");
@@ -75,7 +75,7 @@ describe('scripts/validate helpers', () => {
     writeFileSync(filePath, '[1]', 'utf-8');
 
     try {
-      const result = validateFile(filePath, 'temp/tasks.json5', validators);
+      const result = validateFile(filePath, 'overrides/tasks.json5', validators);
 
       expect(result.valid).toBe(false);
       expect(result.errors?.some((error) => error.includes('must be object'))).toBe(true);
@@ -91,7 +91,7 @@ describe('scripts/validate helpers', () => {
     writeFileSync(filePath, '[]', 'utf-8');
 
     try {
-      const result = validateFile(filePath, 'temp/tasks.json5', validators);
+      const result = validateFile(filePath, 'overrides/tasks.json5', validators);
 
       expect(result.valid).toBe(false);
       expect(result.errors?.some((error) => error.includes('must be object'))).toBe(true);


### PR DESCRIPTION
## Summary
- Retry task fetching without `usingWeapon` when tarkov.dev returns the current broken item-reference error.
- Remove the now-obsolete PVE `Against the Conscience - Part 1` trader override after upstream fixed it.
- Fix validation-helper tests so schema-error fixtures use a configured schema path.
- Rebuild `dist/overlay.json` with overlay version `1.27`.

## Validation
- `npm run typecheck`
- `TMPDIR=/tmp npm run validate`
- `npm test`
- `OVERLAY_VERSION=1.27 TMPDIR=/tmp npm run build`
- `TMPDIR=/tmp npm run check-overrides`
