### PR TITLE
fix(events): disable expired Casus belli (Pillager) event tasks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,3 +24,13 @@ Recent history favors Conventional Commit prefixes like `feat:`, `chore:`, and `
 - Edit the correct JSON5 file in `src/overrides/` or `src/additions/`.
 - Provide proof (wiki link, screenshot, or patch notes).
 - Run `npm run validate` and `npm run build` before submitting.
+
+## Fetching Wiki Data
+The EFT Fandom wiki serves rendered HTML page paths (`https://escapefromtarkov.fandom.com/wiki/...`) behind a Cloudflare managed challenge. Non-browser clients (curl, agent fetch tools, scripts) get `HTTP 403` with a `cf-mitigated: challenge` header instead of content, regardless of User-Agent. Do not scrape `/wiki/` HTML.
+
+Use the MediaWiki API instead — it is not challenged and returns full content (no User-Agent required):
+- Wikitext: `https://escapefromtarkov.fandom.com/api.php?action=parse&page=<Title>&prop=wikitext&format=json`
+- Rendered HTML fragment: `...&prop=text`
+- Plain-text extract: `action=query&prop=extracts&...`
+
+`scripts/wiki-task-spike.ts` already uses `api.php` (`WIKI_API`); follow that pattern for any new wiki access. The `{{Historical content}}` / `{{Event content}}` templates at the top of a page's wikitext indicate expired/event content (verify before adding or for removing stale event additions).

--- a/src/additions/tasksAdd.json5
+++ b/src/additions/tasksAdd.json5
@@ -1749,263 +1749,265 @@
 //    },
 //  },
 
-    // Pillager event tasks
+    // Pillager event tasks (event ended - disabled, see issue #217).
+    // Wiki marks these as {{Historical content}}/{{Event content}}.
+    // Re-enable (uncomment) if the event returns.
     // Casus Belli
     // Proof: https://escapefromtarkov.fandom.com/wiki/Casus_belli
-    casus_belli: {
-      id: 'casus_belli',
-      name: 'Casus belli',
-      wikiLink: 'https://escapefromtarkov.fandom.com/wiki/Casus_belli',
-      trader: {
-        id: '6617beeaa9cfa777ca915b7c',
-        name: 'Ref',
-      },
-      map: null,
-      kappaRequired: false,
-      factionName: 'Any',
-      objectives: [
-        {
-          id: 'casus_belli_obj01',
-          description: 'Eliminate 5 pillagers',
-          type: 'shoot',
-          maps: [
-            { id: '56f40101d2720b2a4d8b45d6', name: 'Customs' },
-            { id: '5714dbc024597771384a510d', name: 'Interchange' },
-            { id: '5704e3c2d2720bac5b8b4567', name: 'Woods' },
-            { id: '5704e554d2720bac5b8b456e', name: 'Shoreline' },
-            { id: '5704e4dad2720bb55b8b4567', name: 'Lighthouse' },
-          ],
-          count: 5,
-          shotType: 'kill',
-          targetNames: ['Pillager'],
-          optional: false,
-        },
-        {
-          id: 'casus_belli_obj02',
-          description: 'Hand over 3 found in raid painted CQCM masks',
-          type: 'giveItem',
-          items: [
-            {
-              id: '67a4b71ad3228756b6088ee2',
-              name: 'Atomic Defense CQCM ballistic mask (Smile)',
-              shortName: 'Smile',
-            },
-            {
-              id: '67a5c5b6dfdf568c9009af66',
-              name: 'Atomic Defense CQCM ballistic mask (Stop Me)',
-              shortName: 'Stop Me',
-            },
-            {
-              id: '67a5c5df782ce4655104db14',
-              name: 'Atomic Defense CQCM ballistic mask (Scars)',
-              shortName: 'Scars',
-            },
-            {
-              id: '67a5c5f37f52620c5b05b4d6',
-              name: 'Atomic Defense CQCM ballistic mask (Target)',
-              shortName: 'Target',
-            },
-            {
-              id: '67a5c6068fcd9fb73f0752cf',
-              name: 'Atomic Defense CQCM ballistic mask (Skull)',
-              shortName: 'Skull',
-            },
-            {
-              id: '67a5c61c7f52620c5b05b4d8',
-              name: 'Atomic Defense CQCM ballistic mask (Demon)',
-              shortName: 'Demon',
-            },
-            {
-              id: '67a5c657782ce4655104db16',
-              name: 'Atomic Defense CQCM ballistic mask (El Día de Muertos)',
-              shortName: 'Muertos',
-            },
-            {
-              id: '688b3bfa1ed594eccd0c45ee',
-              name: 'Atomic Defense CQCM ballistic mask (Ping)',
-              shortName: 'Ping',
-            },
-            {
-              id: '68a9a04373d52d47830759c7',
-              name: 'Atomic Defense CQCM ballistic mask (Loui Peeton)',
-              shortName: 'Loui Peeton',
-            },
-            {
-              id: '68a9a0b01696fb8c1e0ee9cc',
-              name: 'Atomic Defense CQCM ballistic mask (Toxic)',
-              shortName: 'Toxic',
-            },
-            {
-              id: '68a9a1223e1ee5a70504c126',
-              name: 'Atomic Defense CQCM ballistic mask (Crash Tested)',
-              shortName: 'Crash Tested',
-            },
-            {
-              id: '68a9a15d73d52d47830759c9',
-              name: 'Atomic Defense CQCM ballistic mask (Demonic Face)',
-              shortName: 'Demonic',
-            },
-            {
-              id: '68d54d0525ac8590a8075ac3',
-              name: 'Atomic Defense CQCM ballistic mask (Loui Peeton)',
-              shortName: 'LP',
-            },
-            {
-              id: '6936ff8734029a096c06f95a',
-              name: 'Atomic Defense CQCM ballistic mask (Blasted Ice)',
-              shortName: 'Blasted Ice',
-            },
-          ],
-          foundInRaid: true,
-          count: 3,
-          optional: false,
-        },
-      ],
-      experience: 10000,
-      finishRewards: {
-        items: [
-          {
-            count: 50,
-            item: {
-              id: '5d235b4d86f7742e017bc88a',
-              name: 'GP coin',
-              shortName: 'GP',
-            },
-          },
-          {
-            count: 1,
-            item: {
-              id: '5fbcc1d9016cce60e8341ab3',
-              name: 'SIG MCX .300 Blackout assault rifle',
-              shortName: 'MCX',
-            },
-          },
-          {
-            count: 1,
-            item: {
-              id: '544a378f4bdc2d30388b4567',
-              name: 'AR-15 5.56x45 Magpul PMAG 40 GEN M3 STANAG 40-round magazine',
-              shortName: 'GEN M3',
-            },
-          },
-          {
-            count: 2,
-            item: {
-              id: '657023bebfc87b3a34093207',
-              name: '.300 Blackout BCP FMJ ammo pack (50 pcs)',
-              shortName: 'FMJ',
-            },
-          },
-        ],
-      },
-    },
+    // casus_belli: {
+      // id: 'casus_belli',
+      // name: 'Casus belli',
+      // wikiLink: 'https://escapefromtarkov.fandom.com/wiki/Casus_belli',
+      // trader: {
+        // id: '6617beeaa9cfa777ca915b7c',
+        // name: 'Ref',
+      // },
+      // map: null,
+      // kappaRequired: false,
+      // factionName: 'Any',
+      // objectives: [
+        // {
+          // id: 'casus_belli_obj01',
+          // description: 'Eliminate 5 pillagers',
+          // type: 'shoot',
+          // maps: [
+            // { id: '56f40101d2720b2a4d8b45d6', name: 'Customs' },
+            // { id: '5714dbc024597771384a510d', name: 'Interchange' },
+            // { id: '5704e3c2d2720bac5b8b4567', name: 'Woods' },
+            // { id: '5704e554d2720bac5b8b456e', name: 'Shoreline' },
+            // { id: '5704e4dad2720bb55b8b4567', name: 'Lighthouse' },
+          // ],
+          // count: 5,
+          // shotType: 'kill',
+          // targetNames: ['Pillager'],
+          // optional: false,
+        // },
+        // {
+          // id: 'casus_belli_obj02',
+          // description: 'Hand over 3 found in raid painted CQCM masks',
+          // type: 'giveItem',
+          // items: [
+            // {
+              // id: '67a4b71ad3228756b6088ee2',
+              // name: 'Atomic Defense CQCM ballistic mask (Smile)',
+              // shortName: 'Smile',
+            // },
+            // {
+              // id: '67a5c5b6dfdf568c9009af66',
+              // name: 'Atomic Defense CQCM ballistic mask (Stop Me)',
+              // shortName: 'Stop Me',
+            // },
+            // {
+              // id: '67a5c5df782ce4655104db14',
+              // name: 'Atomic Defense CQCM ballistic mask (Scars)',
+              // shortName: 'Scars',
+            // },
+            // {
+              // id: '67a5c5f37f52620c5b05b4d6',
+              // name: 'Atomic Defense CQCM ballistic mask (Target)',
+              // shortName: 'Target',
+            // },
+            // {
+              // id: '67a5c6068fcd9fb73f0752cf',
+              // name: 'Atomic Defense CQCM ballistic mask (Skull)',
+              // shortName: 'Skull',
+            // },
+            // {
+              // id: '67a5c61c7f52620c5b05b4d8',
+              // name: 'Atomic Defense CQCM ballistic mask (Demon)',
+              // shortName: 'Demon',
+            // },
+            // {
+              // id: '67a5c657782ce4655104db16',
+              // name: 'Atomic Defense CQCM ballistic mask (El Día de Muertos)',
+              // shortName: 'Muertos',
+            // },
+            // {
+              // id: '688b3bfa1ed594eccd0c45ee',
+              // name: 'Atomic Defense CQCM ballistic mask (Ping)',
+              // shortName: 'Ping',
+            // },
+            // {
+              // id: '68a9a04373d52d47830759c7',
+              // name: 'Atomic Defense CQCM ballistic mask (Loui Peeton)',
+              // shortName: 'Loui Peeton',
+            // },
+            // {
+              // id: '68a9a0b01696fb8c1e0ee9cc',
+              // name: 'Atomic Defense CQCM ballistic mask (Toxic)',
+              // shortName: 'Toxic',
+            // },
+            // {
+              // id: '68a9a1223e1ee5a70504c126',
+              // name: 'Atomic Defense CQCM ballistic mask (Crash Tested)',
+              // shortName: 'Crash Tested',
+            // },
+            // {
+              // id: '68a9a15d73d52d47830759c9',
+              // name: 'Atomic Defense CQCM ballistic mask (Demonic Face)',
+              // shortName: 'Demonic',
+            // },
+            // {
+              // id: '68d54d0525ac8590a8075ac3',
+              // name: 'Atomic Defense CQCM ballistic mask (Loui Peeton)',
+              // shortName: 'LP',
+            // },
+            // {
+              // id: '6936ff8734029a096c06f95a',
+              // name: 'Atomic Defense CQCM ballistic mask (Blasted Ice)',
+              // shortName: 'Blasted Ice',
+            // },
+          // ],
+          // foundInRaid: true,
+          // count: 3,
+          // optional: false,
+        // },
+      // ],
+      // experience: 10000,
+      // finishRewards: {
+        // items: [
+          // {
+            // count: 50,
+            // item: {
+              // id: '5d235b4d86f7742e017bc88a',
+              // name: 'GP coin',
+              // shortName: 'GP',
+            // },
+          // },
+          // {
+            // count: 1,
+            // item: {
+              // id: '5fbcc1d9016cce60e8341ab3',
+              // name: 'SIG MCX .300 Blackout assault rifle',
+              // shortName: 'MCX',
+            // },
+          // },
+          // {
+            // count: 1,
+            // item: {
+              // id: '544a378f4bdc2d30388b4567',
+              // name: 'AR-15 5.56x45 Magpul PMAG 40 GEN M3 STANAG 40-round magazine',
+              // shortName: 'GEN M3',
+            // },
+          // },
+          // {
+            // count: 2,
+            // item: {
+              // id: '657023bebfc87b3a34093207',
+              // name: '.300 Blackout BCP FMJ ammo pack (50 pcs)',
+              // shortName: 'FMJ',
+            // },
+          // },
+        // ],
+      // },
+    // },
 
     // Backup Plan
     // Proof: https://escapefromtarkov.fandom.com/wiki/Backup_Plan
-    backup_plan: {
-      id: 'backup_plan',
-      name: 'Backup Plan',
-      wikiLink: 'https://escapefromtarkov.fandom.com/wiki/Backup_Plan',
-      trader: {
-        id: '6617beeaa9cfa777ca915b7c',
-        name: 'Ref',
-      },
-      map: null,
-      kappaRequired: false,
-      factionName: 'Any',
-      taskRequirements: [
-        {
-          task: {
-            id: 'casus_belli',
-            name: 'Casus belli',
-          },
-        },
-      ],
-      objectives: [
-        {
-          id: 'backup_plan_obj01',
-          description: 'Stash the Grizzly medkit in the large barn at the old sawmill on Woods',
-          type: 'plantItem',
-          maps: [{ id: '5704e3c2d2720bac5b8b4567', name: 'Woods' }],
-          items: [
-            {
-              id: '590c657e86f77412b013051d',
-              name: 'Grizzly medical kit',
-              shortName: 'Grizzly',
-            },
-          ],
-          count: 1,
-          optional: false,
-        },
-        {
-          id: 'backup_plan_obj02',
-          description: 'Transit from Woods to Customs',
-          type: 'extract',
-          maps: [
-            { id: '5704e3c2d2720bac5b8b4567', name: 'Woods' },
-            { id: '56f40101d2720b2a4d8b45d6', name: 'Customs' },
-          ],
-          exitStatus: ['ExpBonusmarathon Name'],
-          count: 1,
-          optional: false,
-        },
-        {
-          id: 'backup_plan_obj03',
-          description: 'Eliminate any 6 targets on Customs',
-          type: 'shoot',
-          maps: [{ id: '56f40101d2720b2a4d8b45d6', name: 'Customs' }],
-          count: 6,
-          shotType: 'kill',
-          optional: false,
-        },
-        {
-          id: 'backup_plan_obj04',
-          description: 'Survive and extract from Customs',
-          type: 'extract',
-          maps: [{ id: '56f40101d2720b2a4d8b45d6', name: 'Customs' }],
-          exitStatus: ['Survived'],
-          count: 1,
-          optional: false,
-        },
-      ],
-      experience: 12000,
-      finishRewards: {
-        items: [
-          {
-            count: 50,
-            item: {
-              id: '5d235b4d86f7742e017bc88a',
-              name: 'GP coin',
-              shortName: 'GP',
-            },
-          },
-          {
-            count: 1,
-            item: {
-              id: '606587252535c57a13424cfd',
-              name: 'CMMG Mk47 Mutant 7.62x39 assault rifle',
-              shortName: 'Mk47',
-            },
-          },
-          {
-            count: 3,
-            item: {
-              id: '59d6272486f77466146386ff',
-              name: 'AK 7.62x39 Magpul PMAG 30 GEN M3 30-round magazine',
-              shortName: 'GEN M3',
-            },
-          },
-          {
-            count: 7,
-            item: {
-              id: '64acea09c4eda9354b0226ad',
-              name: '7.62x39mm T-45M1 gzh ammo pack (20 pcs)',
-              shortName: 'T-45M1',
-            },
-          },
-        ],
-      },
-    },
+    // backup_plan: {
+      // id: 'backup_plan',
+      // name: 'Backup Plan',
+      // wikiLink: 'https://escapefromtarkov.fandom.com/wiki/Backup_Plan',
+      // trader: {
+        // id: '6617beeaa9cfa777ca915b7c',
+        // name: 'Ref',
+      // },
+      // map: null,
+      // kappaRequired: false,
+      // factionName: 'Any',
+      // taskRequirements: [
+        // {
+          // task: {
+            // id: 'casus_belli',
+            // name: 'Casus belli',
+          // },
+        // },
+      // ],
+      // objectives: [
+        // {
+          // id: 'backup_plan_obj01',
+          // description: 'Stash the Grizzly medkit in the large barn at the old sawmill on Woods',
+          // type: 'plantItem',
+          // maps: [{ id: '5704e3c2d2720bac5b8b4567', name: 'Woods' }],
+          // items: [
+            // {
+              // id: '590c657e86f77412b013051d',
+              // name: 'Grizzly medical kit',
+              // shortName: 'Grizzly',
+            // },
+          // ],
+          // count: 1,
+          // optional: false,
+        // },
+        // {
+          // id: 'backup_plan_obj02',
+          // description: 'Transit from Woods to Customs',
+          // type: 'extract',
+          // maps: [
+            // { id: '5704e3c2d2720bac5b8b4567', name: 'Woods' },
+            // { id: '56f40101d2720b2a4d8b45d6', name: 'Customs' },
+          // ],
+          // exitStatus: ['ExpBonusmarathon Name'],
+          // count: 1,
+          // optional: false,
+        // },
+        // {
+          // id: 'backup_plan_obj03',
+          // description: 'Eliminate any 6 targets on Customs',
+          // type: 'shoot',
+          // maps: [{ id: '56f40101d2720b2a4d8b45d6', name: 'Customs' }],
+          // count: 6,
+          // shotType: 'kill',
+          // optional: false,
+        // },
+        // {
+          // id: 'backup_plan_obj04',
+          // description: 'Survive and extract from Customs',
+          // type: 'extract',
+          // maps: [{ id: '56f40101d2720b2a4d8b45d6', name: 'Customs' }],
+          // exitStatus: ['Survived'],
+          // count: 1,
+          // optional: false,
+        // },
+      // ],
+      // experience: 12000,
+      // finishRewards: {
+        // items: [
+          // {
+            // count: 50,
+            // item: {
+              // id: '5d235b4d86f7742e017bc88a',
+              // name: 'GP coin',
+              // shortName: 'GP',
+            // },
+          // },
+          // {
+            // count: 1,
+            // item: {
+              // id: '606587252535c57a13424cfd',
+              // name: 'CMMG Mk47 Mutant 7.62x39 assault rifle',
+              // shortName: 'Mk47',
+            // },
+          // },
+          // {
+            // count: 3,
+            // item: {
+              // id: '59d6272486f77466146386ff',
+              // name: 'AK 7.62x39 Magpul PMAG 30 GEN M3 30-round magazine',
+              // shortName: 'GEN M3',
+            // },
+          // },
+          // {
+            // count: 7,
+            // item: {
+              // id: '64acea09c4eda9354b0226ad',
+              // name: '7.62x39mm T-45M1 gzh ammo pack (20 pcs)',
+              // shortName: 'T-45M1',
+            // },
+          // },
+        // ],
+      // },
+    // },
 
     // add Taking What's Mine soon
 }


### PR DESCRIPTION
## **User description**
## Summary

The **Casus belli** Pillager event (introduced 9 April 2026) has ended, but the overlay still **added** the event quests `casus_belli` and `backup_plan`, so downstream consumers (TarkovTracker, etc.) surface phantom quests that no longer exist in-game. This fix disables the expired event tasks.

Resolves #217 and consolidates the duplicate reports #198, #212, #213, #214, #215, #216.

## Changes

- **`src/additions/tasksAdd.json5`** — comment out the `casus_belli` and `backup_plan` blocks, matching the existing Winter 2025 event-task precedent (and prior "comment out Duck Hunt task" history). They are kept commented (not deleted) so the verified data can be re-enabled quickly if the event returns; full history is also preserved in commit `d32d955`. The header comment now records why they are disabled and links #217.
- **`AGENTS.md`** — add a "Fetching Wiki Data" section documenting that Fandom `/wiki/` HTML pages now return `HTTP 403` (Cloudflare `cf-mitigated: challenge`) and that the MediaWiki `api.php` endpoint must be used instead (the pattern `scripts/wiki-task-spike.ts` already follows).

`dist/overlay.json` is intentionally **not** included — CI rebuilds and commits it on merge to `main` with the correct version tag (`chore: build overlay [skip ci]`), the same way the original add commit `d32d955` left dist to CI.

## Verification

- Wiki status confirmed via the MediaWiki API (HTML is Cloudflare-challenged): the `Casus_belli` and `Backup_Plan` pages are flagged `{{Historical content}}` / `{{Event content}}` and use past tense ("was a Quest"), confirming the event has ended.
- `npm run validate` — all source files valid.
- `npm run build` — succeeds; rebuilt `dist/overlay.json` contains **0** occurrences of `casus_belli` / `backup_plan` (verified locally, then reverted so CI owns dist).
- `npm run typecheck` — passes.
- `npm test` — 147/147 pass.
- Confirmed no other source references depend on these task IDs (`backup_plan`'s `taskRequirements` on `casus_belli` is disabled along with the block).

## Notes

- `short_on_hands` and `run_aground` from the original #198 request were never actually added, so there is nothing to remove for those, and they should not be added now that the event is over.


___

## **CodeAnt-AI Description**
**Hide expired Pillager event tasks and document how to check wiki content**

### What Changed
- Removed the ended Casus Belli and Backup Plan event quests from the overlay so players no longer see phantom tasks that are not available in game
- Kept the expired quest data commented out with a note explaining why it is disabled, so it can be restored if the event returns
- Added guidance for fetching Tarkov wiki data through the MediaWiki API instead of the wiki HTML pages, which now return Cloudflare 403 errors

### Impact
`✅ Fewer phantom event quests`
`✅ Clearer task lists after events end`
`✅ Fewer failed wiki fetches`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
