### PR TITLE
refactor: replace tarkov.dev GraphQL client with json.tarkov.dev adapter

### DIFF
--- a/src/lib/tarkov-api.ts
+++ b/src/lib/tarkov-api.ts
@@ -343,7 +343,7 @@ function adaptTask(raw: JsonRecord, ctx: Context): TaskData {
     name: translate(ctx.tasksEn, raw.name) ?? id,
     minPlayerLevel: typeof raw.minPlayerLevel === 'number' ? raw.minPlayerLevel : undefined,
     wikiLink: typeof raw.wikiLink === 'string' ? raw.wikiLink : undefined,
-    map: raw.map == null ? null : resolveMapRef(raw.map, ctx),
+    map: raw.map === null ? null : resolveMapRef(raw.map, ctx),
     kappaRequired: typeof raw.kappaRequired === 'boolean' ? raw.kappaRequired : undefined,
     lightkeeperRequired:
       typeof raw.lightkeeperRequired === 'boolean' ? raw.lightkeeperRequired : undefined,

--- a/src/lib/tarkov-api.ts
+++ b/src/lib/tarkov-api.ts
@@ -1,338 +1,433 @@
 /**
- * Tarkov.dev API client
+ * Tarkov.dev data client (json.tarkov.dev)
  *
- * Provides a clean interface for querying the tarkov.dev GraphQL API.
- * Separates API concerns from validation and presentation logic.
+ * Fetches task data from the json.tarkov.dev static JSON endpoints and adapts
+ * it into the `TaskData[]` shape consumed by the override validator.
+ *
+ * Why JSON instead of GraphQL:
+ * The legacy `api.tarkov.dev/graphql` endpoint has been replaced by static
+ * per-mode JSON files. The JSON payloads use id-keyed objects, string-id
+ * references between entities, and translation placeholders that resolve via a
+ * sibling `_en` endpoint. This module fetches the relevant endpoints, resolves
+ * references and english translations, and produces the same `TaskData` objects
+ * the validator already understands, so `fetchTasks()` keeps its signature.
+ *
+ * The previous GraphQL `usingWeapon` broken-item fallback is obsolete: the JSON
+ * endpoint returns plain id strings, so there is no upstream item-resolution
+ * error to recover from.
+ *
+ * Note: resolving objective/reward item names requires the `items` payload,
+ * which is large. Results are memoized per endpoint path for the life of the
+ * process so a single run that fetches `regular` then `pve` only downloads each
+ * file once.
  */
 
-import type { TaskData } from "./types.js";
+import type {
+  TaskData,
+  TaskItemRef,
+  TaskObjective,
+  TaskRewards,
+  TaskRequirement,
+} from './types.js';
 
-const TARKOV_API = "https://api.tarkov.dev/graphql";
+const TARKOV_JSON_BASE = 'https://json.tarkov.dev';
+const DEFAULT_MAX_RETRIES = 3;
+const MAX_BACKOFF_MS = 5000;
+
+type GameMode = 'regular' | 'pve';
+
+type JsonRecord = Record<string, unknown>;
+
+type Envelope = {
+  data: unknown;
+  translations?: string[];
+};
+
+/** Flat translation map: key -> english string. */
+type TranslationMap = Record<string, string>;
+
+const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
 
 function getValueType(value: unknown): string {
-  if (value === null) return "null";
-  if (Array.isArray(value)) return "array";
+  if (value === null) return 'null';
+  if (Array.isArray(value)) return 'array';
   return typeof value;
 }
 
-/**
- * GraphQL query fragments for fetching all tasks with their details.
- * Keep the main and fallback queries identical except for usingWeapon.
- */
-const TASK_OBJECTIVE_SHOOT_WITH_USING_WEAPON = `
-          count
-          usingWeapon { id name shortName }
-          usingWeaponMods { id name shortName }
-          wearing { id name shortName }
-          notWearing { id name shortName }
-          requiredKeys { id name shortName }
-`;
-
-const TASK_OBJECTIVE_SHOOT_WITHOUT_USING_WEAPON = `
-          count
-          usingWeaponMods { id name shortName }
-          wearing { id name shortName }
-          notWearing { id name shortName }
-          requiredKeys { id name shortName }
-`;
-
-function buildTasksQuery(taskObjectiveShootFields: string): string {
-  return `
-  query($gameMode: GameMode) {
-    tasks(lang: en, gameMode: $gameMode) {
-      id
-      name
-      minPlayerLevel
-      wikiLink
-      kappaRequired
-      lightkeeperRequired
-      map {
-        id
-        name
-      }
-      experience
-      taskRequirements {
-        task {
-          id
-          name
-        }
-        status
-      }
-      traderRequirements {
-        trader {
-          id
-          name
-        }
-        value
-        compareMethod
-      }
-      factionName
-      requiredPrestige {
-        id
-        name
-        prestigeLevel
-      }
-      objectives {
-        id
-        type
-        description
-        maps {
-          id
-          name
-        }
-        ... on TaskObjectiveBasic {
-          requiredKeys { id name shortName }
-        }
-        ... on TaskObjectiveMark {
-          markerItem { id name shortName }
-          requiredKeys { id name shortName }
-        }
-        ... on TaskObjectiveExtract {
-          requiredKeys { id name shortName }
-        }
-        ... on TaskObjectiveShoot {${taskObjectiveShootFields}
-        }
-        ... on TaskObjectiveItem {
-          count
-          items { id name shortName }
-          foundInRaid
-          requiredKeys { id name shortName }
-        }
-        ... on TaskObjectiveQuestItem {
-          count
-          questItem { id name shortName }
-          requiredKeys { id name shortName }
-        }
-        ... on TaskObjectiveUseItem {
-          count
-          useAny { id name shortName }
-          requiredKeys { id name shortName }
-        }
-        ... on TaskObjectiveBuildItem {
-          item { id name shortName }
-          containsAll { id name shortName }
-        }
-      }
-      startRewards {
-        items { item { id name shortName } count }
-        traderStanding { trader { id name } standing }
-        offerUnlock { id trader { id name } level item { id name shortName } }
-        skillLevelReward {
-          name
-          level
-          skill {
-            id
-            name
-            imageLink
-          }
-        }
-        traderUnlock {
-          id
-          name
-        }
-        achievement {
-          id
-          name
-          description
-        }
-        customization {
-          id
-          name
-          customizationType
-          customizationTypeName
-          imageLink
-        }
-      }
-      finishRewards {
-        items { item { id name shortName } count }
-        traderStanding { trader { id name } standing }
-        offerUnlock { id trader { id name } level item { id name shortName } }
-        skillLevelReward {
-          name
-          level
-          skill {
-            id
-            name
-            imageLink
-          }
-        }
-        traderUnlock {
-          id
-          name
-        }
-        achievement {
-          id
-          name
-          description
-        }
-        customization {
-          id
-          name
-          customizationType
-          customizationTypeName
-          imageLink
-        }
-      }
-    }
-  }
-`;
+function isRecord(value: unknown): value is JsonRecord {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
-const TASKS_QUERY = buildTasksQuery(TASK_OBJECTIVE_SHOOT_WITH_USING_WEAPON);
-const TASKS_QUERY_WITHOUT_USING_WEAPON = buildTasksQuery(
-  TASK_OBJECTIVE_SHOOT_WITHOUT_USING_WEAPON
-);
-
-class GraphQLRequestError extends Error {
-  constructor(readonly graphQLErrors: unknown[]) {
-    super(`GraphQL errors: ${JSON.stringify(graphQLErrors)}`);
-    this.name = "GraphQLRequestError";
-  }
-}
-
-const MISSING_ITEM_MESSAGE_PATTERN = /no\s+item|not\s+found|undefined/i;
-
-function getGraphQLErrorsFromMessage(message: string): unknown[] | undefined {
-  const prefix = "GraphQL errors: ";
-  const json = message.startsWith(prefix) ? message.slice(prefix.length) : message;
-
-  try {
-    const parsed = JSON.parse(json) as unknown;
-    if (Array.isArray(parsed)) return parsed;
-
-    if (parsed && typeof parsed === "object" && "errors" in parsed) {
-      const errors = (parsed as { errors?: unknown }).errors;
-      if (Array.isArray(errors)) return errors;
-    }
-  } catch {
-    return undefined;
-  }
-
+function stringId(value: unknown): string | undefined {
+  if (typeof value === 'string') return value;
+  if (isRecord(value) && typeof value.id === 'string') return value.id;
   return undefined;
 }
 
-function hasUsingWeaponPath(path: unknown): boolean {
-  return Array.isArray(path) && path.includes("usingWeapon");
-}
-
-function hasMissingItemMessage(message: unknown): boolean {
-  return MISSING_ITEM_MESSAGE_PATTERN.test(String(message ?? ""));
-}
-
-function getGraphQLErrorsFromError(
-  error: unknown,
-  message: string
-): unknown[] | undefined {
-  if (error instanceof GraphQLRequestError) return error.graphQLErrors;
-
-  if (error && typeof error === "object" && "graphQLErrors" in error) {
-    const graphQLErrors = (error as { graphQLErrors?: unknown }).graphQLErrors;
-    if (Array.isArray(graphQLErrors)) return graphQLErrors;
-  }
-
-  return getGraphQLErrorsFromMessage(message);
-}
-
-function isMissingUsingWeaponItemError(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error);
-  const graphQLErrors = getGraphQLErrorsFromError(error, message);
-
-  if (graphQLErrors) {
-    return graphQLErrors.length > 0 && graphQLErrors.every((entry) => {
-      if (!entry || typeof entry !== "object") return false;
-      const graphQLError = entry as { message?: unknown; path?: unknown };
-      return (
-        hasUsingWeaponPath(graphQLError.path) &&
-        hasMissingItemMessage(graphQLError.message)
-      );
-    });
-  }
-
-  return message.includes("usingWeapon") && MISSING_ITEM_MESSAGE_PATTERN.test(message);
+/**
+ * Remove undefined values so adapted objects compare cleanly against overrides.
+ */
+function compact<T extends JsonRecord>(value: T): T {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entry]) => entry !== undefined)
+  ) as T;
 }
 
 /**
- * Execute a GraphQL query against the tarkov.dev API
+ * Build an id -> record lookup from either an id-keyed object or an array of
+ * records.
  */
-async function executeQuery<T>(query: string, variables?: Record<string, unknown>): Promise<T> {
-  const response = await fetch(TARKOV_API, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ query, variables }),
-  });
+function toLookup(value: unknown): Map<string, JsonRecord> {
+  const entries: Array<readonly [string, JsonRecord]> = [];
+  const records = Array.isArray(value)
+    ? value
+    : isRecord(value)
+      ? Object.values(value)
+      : [];
+  for (const entry of records) {
+    if (!isRecord(entry)) continue;
+    const id = typeof entry.id === 'string' ? entry.id : undefined;
+    if (id) entries.push([id, entry] as const);
+  }
+  return new Map(entries);
+}
 
-  if (!response.ok) {
-    throw new Error(
-      `API request failed: ${response.status} ${response.statusText}`
+/**
+ * Resolve a translation key against the english map. Falls back to the raw key
+ * when no translation exists, which matches how the api previously surfaced
+ * untranslated strings.
+ */
+function translate(map: TranslationMap, key: unknown): string | undefined {
+  if (typeof key !== 'string') return undefined;
+  if (UNSAFE_KEYS.has(key)) return undefined;
+  const value = map[key];
+  return typeof value === 'string' ? value : key;
+}
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+const inFlight = new Map<string, Promise<Envelope>>();
+
+/** Thrown for malformed payloads; not worth retrying since a retry won't fix shape. */
+class EnvelopeValidationError extends Error {}
+
+function validateEnvelope(payload: unknown, path: string): Envelope {
+  if (!isRecord(payload) || !('data' in payload) || payload.data == null) {
+    throw new EnvelopeValidationError(
+      `Invalid json.tarkov.dev response for ${path}: missing data`
     );
   }
-
-  const result = await response.json();
-
-  if (!result || typeof result !== "object" || Array.isArray(result)) {
-    throw new Error(
-      `Invalid GraphQL response: expected an object, got ${getValueType(result)}`
+  if (payload.translations !== undefined && !Array.isArray(payload.translations)) {
+    throw new EnvelopeValidationError(
+      `Invalid json.tarkov.dev response for ${path}: translations is not an array`
     );
   }
+  return payload as Envelope;
+}
 
-  if ("errors" in result) {
-    const errors = (result as { errors?: unknown }).errors;
-    if (Array.isArray(errors)) {
-      throw new GraphQLRequestError(errors);
+async function fetchEnvelopeOnce(path: string): Promise<Envelope> {
+  let lastError: Error | null = null;
+  for (let attempt = 1; attempt <= DEFAULT_MAX_RETRIES; attempt += 1) {
+    try {
+      const response = await fetch(`${TARKOV_JSON_BASE}/${path}`, {
+        headers: { Accept: 'application/json' },
+      });
+      if (!response.ok) {
+        throw new Error(
+          `tarkov.dev request failed: ${response.status} ${response.statusText} (${path})`
+        );
+      }
+      const payload = await response.json();
+      return validateEnvelope(payload, path);
+    } catch (error) {
+      // Malformed payloads will not change on retry; fail fast.
+      if (error instanceof EnvelopeValidationError) throw error;
+      lastError = error instanceof Error ? error : new Error(String(error));
+      if (attempt === DEFAULT_MAX_RETRIES) break;
+      await sleep(Math.min(1000 * 2 ** (attempt - 1), MAX_BACKOFF_MS));
     }
-    throw new Error(`GraphQL errors: ${JSON.stringify(errors)}`);
   }
+  throw lastError ?? new Error(`Failed to fetch ${path}`);
+}
 
-  if (!("data" in result)) {
-    throw new Error("Invalid GraphQL response: missing data field");
-  }
+/** Fetch an endpoint envelope, memoized per path for the life of the process. */
+function fetchEnvelope(path: string): Promise<Envelope> {
+  const existing = inFlight.get(path);
+  if (existing) return existing;
+  const promise = fetchEnvelopeOnce(path).catch((error) => {
+    inFlight.delete(path);
+    throw error;
+  });
+  inFlight.set(path, promise);
+  return promise;
+}
 
-  return result.data;
+/** Fetch an `_en` endpoint and return its flat translation map. */
+async function fetchTranslations(mode: GameMode, endpoint: string): Promise<TranslationMap> {
+  const envelope = await fetchEnvelope(`${mode}/${endpoint}_en`);
+  return isRecord(envelope.data) ? (envelope.data as TranslationMap) : {};
+}
+
+/** Shared lookups + translation maps used by the adapters. */
+type Context = {
+  itemsById: Map<string, JsonRecord>;
+  questItemsById: Map<string, JsonRecord>;
+  tasksById: Map<string, JsonRecord>;
+  mapsById: Map<string, JsonRecord>;
+  tradersById: Map<string, JsonRecord>;
+  prestigeById: Map<string, JsonRecord>;
+  itemsEn: TranslationMap;
+  tasksEn: TranslationMap;
+  mapsEn: TranslationMap;
+  tradersEn: TranslationMap;
+};
+
+/**
+ * Resolve an item reference (string id or inline `{id,...}`) into the
+ * `{id,name,shortName}` shape the validator compares against.
+ */
+function resolveItemRef(value: unknown, ctx: Context): TaskItemRef | undefined {
+  const id = stringId(value);
+  const inline = isRecord(value) ? value : undefined;
+  const raw = (id ? ctx.itemsById.get(id) ?? ctx.questItemsById.get(id) : undefined) ?? inline;
+  if (!id && !raw) return undefined;
+  const name =
+    translate(ctx.itemsEn, raw?.name) ??
+    (typeof inline?.name === 'string' ? inline.name : undefined);
+  const shortName =
+    translate(ctx.itemsEn, raw?.shortName) ??
+    (typeof inline?.shortName === 'string' ? inline.shortName : undefined);
+  return compact({ id: id ?? '', name, shortName }) as TaskItemRef;
+}
+
+function resolveItemRefs(value: unknown, ctx: Context): TaskItemRef[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  return value
+    .map((entry) => resolveItemRef(entry, ctx))
+    .filter((entry): entry is TaskItemRef => Boolean(entry));
+}
+
+function resolveItemRefMatrix(value: unknown, ctx: Context): TaskItemRef[][] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  return value
+    .map((group) => {
+      const list = Array.isArray(group) ? group : [group];
+      return list
+        .map((entry) => resolveItemRef(entry, ctx))
+        .filter((entry): entry is TaskItemRef => Boolean(entry));
+    })
+    .filter((group) => group.length > 0);
+}
+
+function resolveMapRef(
+  value: unknown,
+  ctx: Context
+): { id: string; name: string } | undefined {
+  const id = stringId(value);
+  if (!id) return undefined;
+  const raw = ctx.mapsById.get(id);
+  const name = translate(ctx.mapsEn, raw?.name);
+  return compact({ id, name }) as { id: string; name: string };
+}
+
+function resolveMapRefs(value: unknown, ctx: Context): Array<{ id: string; name: string }> | undefined {
+  if (!Array.isArray(value)) return undefined;
+  return value
+    .map((entry) => resolveMapRef(entry, ctx))
+    .filter((entry): entry is { id: string; name: string } => Boolean(entry));
+}
+
+function resolveTraderRef(value: unknown, ctx: Context): { id: string; name: string } | undefined {
+  const id = stringId(value);
+  if (!id) return undefined;
+  const raw = ctx.tradersById.get(id);
+  const name = translate(ctx.tradersEn, raw?.name);
+  return compact({ id, name }) as { id: string; name: string };
+}
+
+function resolveTaskRef(value: unknown, ctx: Context): { id: string; name: string } | undefined {
+  const id = stringId(value);
+  if (!id) return undefined;
+  const raw = ctx.tasksById.get(id);
+  const name = translate(ctx.tasksEn, raw?.name);
+  return compact({ id, name }) as { id: string; name: string };
 }
 
 /**
- * Fetch all tasks from tarkov.dev API
+ * Resolve a task `requiredPrestige` reference (a prestige-id string) into the
+ * `{id,name,prestigeLevel}` object the validator expects. The prestige level
+ * lives in the separate `prestige` array of the tasks payload.
  */
-export async function fetchTasks(gameMode?: 'regular' | 'pve'): Promise<TaskData[]> {
-  const variables = gameMode ? { gameMode } : undefined;
-  let data: unknown;
+function resolveRequiredPrestige(
+  value: unknown,
+  ctx: Context
+): { id?: string; name: string; prestigeLevel: number } | undefined {
+  const id = stringId(value);
+  if (!id) return undefined;
+  const raw = ctx.prestigeById.get(id);
+  if (!raw) return undefined;
+  const prestigeLevel = typeof raw.prestigeLevel === 'number' ? raw.prestigeLevel : 0;
+  const name = translate(ctx.tasksEn, raw.name) ?? id;
+  return { id, name, prestigeLevel };
+}
 
-  try {
-    data = await executeQuery<unknown>(TASKS_QUERY, variables);
-  } catch (error) {
-    if (!isMissingUsingWeaponItemError(error)) throw error;
-    data = await executeQuery<unknown>(
-      TASKS_QUERY_WITHOUT_USING_WEAPON,
-      variables
-    );
-  }
+function resolveZone(value: unknown, ctx: Context): unknown {
+  if (!isRecord(value)) return value;
+  return compact({ ...value, map: resolveMapRef(value.map, ctx) });
+}
 
-  if (!data || typeof data !== "object" || Array.isArray(data)) {
+function adaptObjective(raw: JsonRecord, ctx: Context): TaskObjective {
+  return compact({
+    ...raw,
+    id: stringId(raw) ?? '',
+    description: translate(ctx.tasksEn, raw.description),
+    maps: resolveMapRefs(raw.maps, ctx),
+    items: resolveItemRefs(raw.items, ctx),
+    item: raw.item !== undefined ? resolveItemRef(raw.item, ctx) : undefined,
+    markerItem: raw.markerItem !== undefined ? resolveItemRef(raw.markerItem, ctx) : undefined,
+    questItem: raw.questItem !== undefined ? resolveItemRef(raw.questItem, ctx) : undefined,
+    useAny: resolveItemRefs(raw.useAny, ctx),
+    containsAll: resolveItemRefs(raw.containsAll, ctx),
+    usingWeapon: resolveItemRefs(raw.usingWeapon, ctx),
+    usingWeaponMods: resolveItemRefMatrix(raw.usingWeaponMods, ctx),
+    requiredKeys: resolveItemRefMatrix(raw.requiredKeys, ctx),
+    wearing: resolveItemRefMatrix(raw.wearing, ctx),
+    notWearing: resolveItemRefs(raw.notWearing, ctx),
+    zones: Array.isArray(raw.zones) ? raw.zones.map((zone) => resolveZone(zone, ctx)) : undefined,
+    possibleLocations: Array.isArray(raw.possibleLocations)
+      ? raw.possibleLocations.map((location) => resolveZone(location, ctx))
+      : undefined,
+  }) as unknown as TaskObjective;
+}
+
+function adaptReward(raw: unknown, ctx: Context): TaskRewards | undefined {
+  if (!isRecord(raw)) return undefined;
+  return compact({
+    ...raw,
+    items: Array.isArray(raw.items)
+      ? raw.items.filter(isRecord).map((entry) =>
+          compact({ ...entry, item: resolveItemRef(entry.item, ctx) })
+        )
+      : undefined,
+    traderStanding: Array.isArray(raw.traderStanding)
+      ? raw.traderStanding.filter(isRecord).map((entry) =>
+          compact({ ...entry, trader: resolveTraderRef(entry.trader, ctx) })
+        )
+      : undefined,
+    offerUnlock: Array.isArray(raw.offerUnlock)
+      ? raw.offerUnlock.filter(isRecord).map((entry) =>
+          compact({
+            ...entry,
+            trader: resolveTraderRef(entry.trader, ctx),
+            item: resolveItemRef(entry.item, ctx),
+          })
+        )
+      : undefined,
+  }) as unknown as TaskRewards;
+}
+
+function adaptTaskRequirement(raw: unknown, ctx: Context): TaskRequirement {
+  if (!isRecord(raw)) return raw as TaskRequirement;
+  return compact({ ...raw, task: resolveTaskRef(raw.task, ctx) }) as unknown as TaskRequirement;
+}
+
+function adaptTraderRequirement(raw: unknown, ctx: Context): unknown {
+  if (!isRecord(raw)) return raw;
+  return compact({ ...raw, trader: resolveTraderRef(raw.trader, ctx) });
+}
+
+function adaptTask(raw: JsonRecord, ctx: Context): TaskData {
+  const id = stringId(raw) ?? '';
+  return compact({
+    id,
+    name: translate(ctx.tasksEn, raw.name) ?? id,
+    minPlayerLevel: typeof raw.minPlayerLevel === 'number' ? raw.minPlayerLevel : undefined,
+    wikiLink: typeof raw.wikiLink === 'string' ? raw.wikiLink : undefined,
+    map: raw.map == null ? null : resolveMapRef(raw.map, ctx),
+    kappaRequired: typeof raw.kappaRequired === 'boolean' ? raw.kappaRequired : undefined,
+    lightkeeperRequired:
+      typeof raw.lightkeeperRequired === 'boolean' ? raw.lightkeeperRequired : undefined,
+    factionName: typeof raw.factionName === 'string' ? raw.factionName : undefined,
+    requiredPrestige: resolveRequiredPrestige(raw.requiredPrestige, ctx),
+    experience: typeof raw.experience === 'number' ? raw.experience : undefined,
+    taskRequirements: Array.isArray(raw.taskRequirements)
+      ? raw.taskRequirements.map((req) => adaptTaskRequirement(req, ctx))
+      : undefined,
+    traderRequirements: Array.isArray(raw.traderRequirements)
+      ? raw.traderRequirements.map((req) => adaptTraderRequirement(req, ctx))
+      : undefined,
+    objectives: Array.isArray(raw.objectives)
+      ? raw.objectives.filter(isRecord).map((objective) => adaptObjective(objective, ctx))
+      : undefined,
+    startRewards: adaptReward(raw.startRewards, ctx),
+    finishRewards: adaptReward(raw.finishRewards, ctx),
+  }) as unknown as TaskData;
+}
+
+async function buildContext(mode: GameMode, tasksData: JsonRecord): Promise<Context> {
+  const [itemsEnvelope, mapsEnvelope, tradersEnvelope, itemsEn, tasksEn, mapsEn, tradersEn] =
+    await Promise.all([
+      fetchEnvelope(`${mode}/items`),
+      fetchEnvelope(`${mode}/maps`),
+      fetchEnvelope(`${mode}/traders`),
+      fetchTranslations(mode, 'items'),
+      fetchTranslations(mode, 'tasks'),
+      fetchTranslations(mode, 'maps'),
+      fetchTranslations(mode, 'traders'),
+    ]);
+
+  const itemsData = isRecord(itemsEnvelope.data) ? itemsEnvelope.data : {};
+  const mapsData = isRecord(mapsEnvelope.data) ? mapsEnvelope.data : {};
+
+  return {
+    itemsById: toLookup(itemsData.items),
+    questItemsById: toLookup(tasksData.questItems),
+    tasksById: toLookup(tasksData.tasks),
+    mapsById: toLookup(mapsData.maps),
+    tradersById: toLookup(tradersEnvelope.data),
+    prestigeById: toLookup(tasksData.prestige),
+    itemsEn,
+    tasksEn,
+    mapsEn,
+    tradersEn,
+  };
+}
+
+/**
+ * Fetch all tasks for a game mode from json.tarkov.dev and adapt them into
+ * the `TaskData[]` shape used by the override validator.
+ */
+export async function fetchTasks(gameMode?: GameMode): Promise<TaskData[]> {
+  const mode: GameMode = gameMode ?? 'regular';
+
+  const tasksEnvelope = await fetchEnvelope(`${mode}/tasks`);
+  const tasksData = isRecord(tasksEnvelope.data) ? tasksEnvelope.data : undefined;
+  if (!tasksData || !isRecord(tasksData.tasks)) {
     throw new Error(
-      `Invalid GraphQL response: expected data to be an object, got ${getValueType(data)}`
+      `Invalid json.tarkov.dev response for ${mode}/tasks: expected data.tasks object, got ${getValueType(
+        tasksData?.tasks
+      )}`
     );
   }
 
-  if (!("tasks" in data)) {
-    throw new Error("Invalid GraphQL response: missing data.tasks");
-  }
+  const ctx = await buildContext(mode, tasksData);
 
-  const tasks = (data as { tasks: unknown }).tasks;
-  if (!Array.isArray(tasks)) {
-    throw new Error(
-      `Invalid GraphQL response: expected data.tasks to be an array, got ${getValueType(tasks)}`
-    );
-  }
-
-  return tasks as TaskData[];
+  return Object.values(tasksData.tasks)
+    .filter(isRecord)
+    .map((task) => adaptTask(task, ctx));
 }
 
 /**
  * Find a task by ID from a list of tasks
  */
-export function findTaskById(
-  tasks: TaskData[],
-  taskId: string
-): TaskData | undefined {
+export function findTaskById(tasks: TaskData[], taskId: string): TaskData | undefined {
   return tasks.find((t) => t.id === taskId);
+}
+
+/**
+ * Clear the per-process endpoint memo cache. Intended for tests that stub
+ * `fetch` and need each case to fetch fresh data.
+ */
+export function __clearTarkovApiCache(): void {
+  inFlight.clear();
 }

--- a/tests/tarkov-api.test.ts
+++ b/tests/tarkov-api.test.ts
@@ -1,40 +1,297 @@
 /**
- * Tests for tarkov-api module
+ * Tests for the json.tarkov.dev adapter (tarkov-api module)
  */
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { fetchTasks, findTaskById, type TaskData } from '../src/lib/index.js';
+import { __clearTarkovApiCache, fetchTasks, findTaskById, type TaskData } from '../src/lib/index.js';
 
-describe('tarkov-api', () => {
+type Routes = Record<string, unknown>;
+
+/**
+ * Stub global fetch with a path-routing mock. Keys are endpoint paths relative
+ * to the json.tarkov.dev base (e.g. `regular/tasks`, `regular/tasks_en`).
+ */
+function mockEndpoints(routes: Routes) {
+  const fetchMock = vi.fn(async (url: string) => {
+    const path = String(url).replace('https://json.tarkov.dev/', '');
+    if (!(path in routes)) {
+      return {
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+        json: async () => ({}),
+      };
+    }
+    return {
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => routes[path],
+    };
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+/** Minimal set of empty endpoints so a fetch never hits the 404 path. */
+function baseRoutes(mode: string, overrides: Routes = {}): Routes {
+  return {
+    [`${mode}/tasks`]: { data: { tasks: {} } },
+    [`${mode}/tasks_en`]: { data: {} },
+    [`${mode}/items`]: { data: { items: {} } },
+    [`${mode}/items_en`]: { data: {} },
+    [`${mode}/maps`]: { data: { maps: {} } },
+    [`${mode}/maps_en`]: { data: {} },
+    [`${mode}/traders`]: { data: {} },
+    [`${mode}/traders_en`]: { data: {} },
+    ...overrides,
+  };
+}
+
+describe('tarkov-api (json.tarkov.dev adapter)', () => {
   afterEach(() => {
+    __clearTarkovApiCache();
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
 
-  it('fetchTasks returns tasks when API request succeeds', async () => {
-    const tasks: TaskData[] = [{ id: 'task-1', name: 'Task 1' }];
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      statusText: 'OK',
-      json: async () => ({ data: { tasks } }),
-    });
-    vi.stubGlobal('fetch', fetchMock);
-
-    const result = await fetchTasks();
-
-    expect(result).toEqual(tasks);
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(fetchMock).toHaveBeenCalledWith(
-      'https://api.tarkov.dev/graphql',
-      expect.objectContaining({
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+  it('resolves task name and objective description from the _en map', async () => {
+    mockEndpoints(
+      baseRoutes('regular', {
+        'regular/tasks': {
+          data: {
+            tasks: {
+              t1: {
+                id: 't1',
+                name: 't1 name',
+                wikiLink: 'https://wiki/T1',
+                objectives: [{ id: 'o1', type: 'visit', description: 'o1' }],
+              },
+            },
+          },
+        },
+        'regular/tasks_en': {
+          data: { 't1 name': 'The First Task', o1: 'Visit the place' },
+        },
       })
     );
+
+    const tasks = await fetchTasks();
+
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].name).toBe('The First Task');
+    expect(tasks[0].objectives?.[0].description).toBe('Visit the place');
   });
 
-  it('fetchTasks throws when HTTP response is not ok', async () => {
+  it('expands item id refs to {id,name,shortName} and preserves nested matrices', async () => {
+    mockEndpoints(
+      baseRoutes('regular', {
+        'regular/tasks': {
+          data: {
+            tasks: {
+              t1: {
+                id: 't1',
+                name: 't1 name',
+                objectives: [
+                  {
+                    id: 'o1',
+                    type: 'shoot',
+                    description: 'o1',
+                    usingWeapon: ['w1'],
+                    usingWeaponMods: [['m1'], ['m2']],
+                  },
+                ],
+              },
+            },
+          },
+        },
+        'regular/tasks_en': { data: { 't1 name': 'T1', o1: 'Kill' } },
+        'regular/items': {
+          data: {
+            items: {
+              w1: { id: 'w1', name: 'w1 name', shortName: 'w1 short' },
+              m1: { id: 'm1', name: 'm1 name', shortName: 'm1 short' },
+              m2: { id: 'm2', name: 'm2 name', shortName: 'm2 short' },
+            },
+          },
+        },
+        'regular/items_en': {
+          data: {
+            'w1 name': 'Weapon One',
+            'w1 short': 'W1',
+            'm1 name': 'Mod One',
+            'm1 short': 'M1',
+            'm2 name': 'Mod Two',
+            'm2 short': 'M2',
+          },
+        },
+      })
+    );
+
+    const tasks = await fetchTasks();
+    const objective = tasks[0].objectives?.[0];
+
+    expect(objective?.usingWeapon).toEqual([{ id: 'w1', name: 'Weapon One', shortName: 'W1' }]);
+    expect(objective?.usingWeaponMods).toEqual([
+      [{ id: 'm1', name: 'Mod One', shortName: 'M1' }],
+      [{ id: 'm2', name: 'Mod Two', shortName: 'M2' }],
+    ]);
+  });
+
+  it('resolves map refs and keeps map: null intact', async () => {
+    mockEndpoints(
+      baseRoutes('regular', {
+        'regular/tasks': {
+          data: {
+            tasks: {
+              mapped: { id: 'mapped', name: 'mapped name', map: 'map1' },
+              nomap: { id: 'nomap', name: 'nomap name', map: null },
+            },
+          },
+        },
+        'regular/tasks_en': { data: { 'mapped name': 'Mapped', 'nomap name': 'NoMap' } },
+        'regular/maps': { data: { maps: { map1: { id: 'map1', name: 'map1 name' } } } },
+        'regular/maps_en': { data: { 'map1 name': 'Customs' } },
+      })
+    );
+
+    const tasks = await fetchTasks();
+    const byId = Object.fromEntries(tasks.map((t) => [t.id, t]));
+
+    expect(byId.mapped.map).toEqual({ id: 'map1', name: 'Customs' });
+    expect(byId.nomap.map).toBeNull();
+  });
+
+  it('resolves trader refs in requirements and reward standings', async () => {
+    mockEndpoints(
+      baseRoutes('regular', {
+        'regular/tasks': {
+          data: {
+            tasks: {
+              t1: {
+                id: 't1',
+                name: 't1 name',
+                traderRequirements: [{ trader: 'tr1', value: 2, compareMethod: '>=' }],
+                finishRewards: {
+                  traderStanding: [{ trader: 'tr1', standing: 0.05 }],
+                  items: [{ item: 'i1', count: 3 }],
+                },
+              },
+            },
+          },
+        },
+        'regular/tasks_en': { data: { 't1 name': 'T1' } },
+        'regular/traders': { data: { tr1: { id: 'tr1', name: 'tr1 name' } } },
+        'regular/traders_en': { data: { 'tr1 name': 'Prapor' } },
+        'regular/items': { data: { items: { i1: { id: 'i1', name: 'i1 name', shortName: 'i1s' } } } },
+        'regular/items_en': { data: { 'i1 name': 'Bandage', 'i1s': 'Band' } },
+      })
+    );
+
+    const tasks = await fetchTasks();
+    const task = tasks[0];
+
+    expect(task.traderRequirements?.[0].trader).toEqual({ id: 'tr1', name: 'Prapor' });
+    expect(task.finishRewards?.traderStanding?.[0].trader).toEqual({ id: 'tr1', name: 'Prapor' });
+    expect(task.finishRewards?.items?.[0].item).toEqual({
+      id: 'i1',
+      name: 'Bandage',
+      shortName: 'Band',
+    });
+  });
+
+  it('resolves requiredPrestige from the prestige array', async () => {
+    mockEndpoints(
+      baseRoutes('regular', {
+        'regular/tasks': {
+          data: {
+            tasks: {
+              t1: { id: 't1', name: 't1 name', requiredPrestige: 'p1' },
+            },
+            prestige: [{ id: 'p1', name: 'p1 name', prestigeLevel: 2 }],
+          },
+        },
+        'regular/tasks_en': { data: { 't1 name': 'New Beginning', 'p1 name': 'Prestige 2' } },
+      })
+    );
+
+    const tasks = await fetchTasks();
+
+    expect(tasks[0].requiredPrestige).toEqual({
+      id: 'p1',
+      name: 'Prestige 2',
+      prestigeLevel: 2,
+    });
+  });
+
+  it('resolves taskRequirements task refs', async () => {
+    mockEndpoints(
+      baseRoutes('regular', {
+        'regular/tasks': {
+          data: {
+            tasks: {
+              prereq: { id: 'prereq', name: 'prereq name' },
+              t1: {
+                id: 't1',
+                name: 't1 name',
+                taskRequirements: [{ task: 'prereq', status: ['complete'] }],
+              },
+            },
+          },
+        },
+        'regular/tasks_en': { data: { 'prereq name': 'Debut', 't1 name': 'Shootout' } },
+      })
+    );
+
+    const tasks = await fetchTasks();
+    const t1 = tasks.find((t) => t.id === 't1');
+
+    expect(t1?.taskRequirements?.[0]).toEqual({
+      task: { id: 'prereq', name: 'Debut' },
+      status: ['complete'],
+    });
+  });
+
+  it('falls back to the raw key when a name has no translation', async () => {
+    mockEndpoints(
+      baseRoutes('regular', {
+        'regular/tasks': {
+          data: { tasks: { t1: { id: 't1', name: 't1 name' } } },
+        },
+        'regular/tasks_en': { data: {} },
+      })
+    );
+
+    const tasks = await fetchTasks();
+
+    expect(tasks[0].name).toBe('t1 name');
+  });
+
+  it('requests pve endpoints when pve mode is requested', async () => {
+    const fetchMock = mockEndpoints(baseRoutes('pve'));
+
+    await fetchTasks('pve');
+
+    const requested = fetchMock.mock.calls.map((call) => String(call[0]));
+    expect(requested).toContain('https://json.tarkov.dev/pve/tasks');
+    expect(requested).toContain('https://json.tarkov.dev/pve/items_en');
+    expect(requested.every((url) => !url.includes('/regular/'))).toBe(true);
+  });
+
+  it('memoizes endpoint fetches across calls within a process', async () => {
+    const fetchMock = mockEndpoints(baseRoutes('regular'));
+
+    await fetchTasks();
+    await fetchTasks();
+
+    const tasksCalls = fetchMock.mock.calls.filter(
+      (call) => String(call[0]) === 'https://json.tarkov.dev/regular/tasks'
+    );
+    expect(tasksCalls).toHaveLength(1);
+  });
+
+  it('throws when an endpoint returns a non-ok response', async () => {
+    vi.useFakeTimers();
     vi.stubGlobal(
       'fetch',
       vi.fn().mockResolvedValue({
@@ -45,205 +302,28 @@ describe('tarkov-api', () => {
       })
     );
 
-    await expect(fetchTasks()).rejects.toThrow(
-      'API request failed: 503 Service Unavailable'
+    const promise = fetchTasks();
+    const assertion = expect(promise).rejects.toThrow(
+      'tarkov.dev request failed: 503 Service Unavailable'
     );
+    await vi.runAllTimersAsync();
+    await assertion;
+    vi.useRealTimers();
   });
 
-  it('fetchTasks throws when GraphQL errors are returned', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue({
-        ok: true,
-        status: 200,
-        statusText: 'OK',
-        json: async () => ({
-          errors: [{ message: 'Something failed' }],
-        }),
-      })
-    );
-
-    await expect(fetchTasks()).rejects.toThrow('GraphQL errors');
-  });
-
-  it('fetchTasks retries without usingWeapon when upstream has a broken item reference', async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        statusText: 'OK',
-        json: async () => ({
-          errors: [
-            {
-              message: 'No item found with id undefined',
-              path: ['tasks', 218, 'objectives', 0, 'usingWeapon', 0],
-            },
-          ],
-        }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        statusText: 'OK',
-        json: async () => ({ data: { tasks: [{ id: 'task-1', name: 'Task 1' }] } }),
-      });
-    vi.stubGlobal('fetch', fetchMock);
-
-    await expect(fetchTasks()).resolves.toEqual([{ id: 'task-1', name: 'Task 1' }]);
-
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    const firstRequest = fetchMock.mock.calls[0][1] as { body?: string };
-    const firstPayload = JSON.parse(String(firstRequest.body)) as { query: string };
-    expect(firstPayload.query).toContain('usingWeapon { id name shortName }');
-
-    const retryRequest = fetchMock.mock.calls[1][1] as { body?: string };
-    const retryPayload = JSON.parse(String(retryRequest.body)) as { query: string };
-    expect(retryPayload.query).not.toContain('usingWeapon { id name shortName }');
-    expect(retryPayload.query).toContain('usingWeaponMods { id name shortName }');
-  });
-
-  it('fetchTasks retries without usingWeapon when the upstream missing-item wording changes', async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        statusText: 'OK',
-        json: async () => ({
-          errors: [
-            {
-              message: 'Item not found for id 660bbc47c38b837877075e47',
-              path: ['tasks', 218, 'objectives', 0, 'usingWeapon', 0],
-            },
-          ],
-        }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        statusText: 'OK',
-        json: async () => ({ data: { tasks: [{ id: 'task-1', name: 'Task 1' }] } }),
-      });
-    vi.stubGlobal('fetch', fetchMock);
-
-    await expect(fetchTasks()).resolves.toEqual([{ id: 'task-1', name: 'Task 1' }]);
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-
-    const firstRequest = fetchMock.mock.calls[0][1] as { body?: string };
-    const firstPayload = JSON.parse(String(firstRequest.body)) as { query: string };
-    expect(firstPayload.query).toContain('usingWeapon { id name shortName }');
-
-    const retryRequest = fetchMock.mock.calls[1][1] as { body?: string };
-    const retryPayload = JSON.parse(String(retryRequest.body)) as { query: string };
-    expect(retryPayload.query).not.toContain('usingWeapon { id name shortName }');
-    expect(retryPayload.query).toContain('usingWeaponMods { id name shortName }');
-  });
-
-  it('fetchTasks does not retry when a usingWeapon error is mixed with other GraphQL errors', async () => {
-    const fetchMock = vi.fn().mockResolvedValueOnce({
-      ok: true,
-      status: 200,
-      statusText: 'OK',
-      json: async () => ({
-        errors: [
-          {
-            message: 'Item not found for id 660bbc47c38b837877075e47',
-            path: ['tasks', 218, 'objectives', 0, 'usingWeapon', 0],
-          },
-          {
-            message: 'Unrelated backend failure',
-            path: ['tasks', 10, 'objectives', 0, 'description'],
-          },
-        ],
-      }),
-    });
-    vi.stubGlobal('fetch', fetchMock);
-
-    await expect(fetchTasks()).rejects.toThrow('GraphQL errors');
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-  });
-
-  it('fetchTasks sends pve gameMode variables when requested', async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      statusText: 'OK',
-      json: async () => ({ data: { tasks: [] } }),
-    });
-    vi.stubGlobal('fetch', fetchMock);
-
-    await fetchTasks('pve');
-
-    const request = fetchMock.mock.calls[0][1] as { body?: string };
-    const payload = JSON.parse(String(request.body)) as {
-      variables?: { gameMode?: string };
-    };
-
-    expect(payload.variables).toEqual({ gameMode: 'pve' });
-  });
-
-  it('fetchTasks throws when GraphQL response is not an object', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue({
-        ok: true,
-        status: 200,
-        statusText: 'OK',
-        json: async () => null,
-      })
-    );
+  it('throws when the tasks envelope is missing data', async () => {
+    mockEndpoints({ 'regular/tasks': {} });
 
     await expect(fetchTasks()).rejects.toThrow(
-      'Invalid GraphQL response: expected an object, got null'
+      'Invalid json.tarkov.dev response for regular/tasks: missing data'
     );
   });
 
-  it('fetchTasks throws when GraphQL response is missing data', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue({
-        ok: true,
-        status: 200,
-        statusText: 'OK',
-        json: async () => ({}),
-      })
-    );
+  it('throws when data.tasks is not an object', async () => {
+    mockEndpoints({ 'regular/tasks': { data: { tasks: [] } } });
 
     await expect(fetchTasks()).rejects.toThrow(
-      'Invalid GraphQL response: missing data field'
-    );
-  });
-
-  it('fetchTasks throws when GraphQL response is missing tasks', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue({
-        ok: true,
-        status: 200,
-        statusText: 'OK',
-        json: async () => ({ data: {} }),
-      })
-    );
-
-    await expect(fetchTasks()).rejects.toThrow(
-      'Invalid GraphQL response: missing data.tasks'
-    );
-  });
-
-  it('fetchTasks throws when GraphQL tasks payload is not an array', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue({
-        ok: true,
-        status: 200,
-        statusText: 'OK',
-        json: async () => ({ data: { tasks: {} } }),
-      })
-    );
-
-    await expect(fetchTasks()).rejects.toThrow(
-      'Invalid GraphQL response: expected data.tasks to be an array, got object'
+      'Invalid json.tarkov.dev response for regular/tasks: expected data.tasks object'
     );
   });
 

--- a/tests/tarkov-api.test.ts
+++ b/tests/tarkov-api.test.ts
@@ -162,6 +162,21 @@ describe('tarkov-api (json.tarkov.dev adapter)', () => {
     expect(byId.nomap.map).toBeNull();
   });
 
+  it('omits map when the field is absent (not forced to null)', async () => {
+    mockEndpoints(
+      baseRoutes('regular', {
+        'regular/tasks': {
+          data: { tasks: { t1: { id: 't1', name: 't1 name' } } },
+        },
+        'regular/tasks_en': { data: { 't1 name': 'T1' } },
+      })
+    );
+
+    const tasks = await fetchTasks();
+
+    expect('map' in tasks[0]).toBe(false);
+  });
+
   it('resolves trader refs in requirements and reward standings', async () => {
     mockEndpoints(
       baseRoutes('regular', {


### PR DESCRIPTION
## **User description**
## Summary

Replaces the legacy `api.tarkov.dev/graphql` client with an adapter for the new static `json.tarkov.dev` per-mode JSON endpoints. `fetchTasks(gameMode)` keeps the same signature and `TaskData[]` return type, so `scripts/check-overrides.ts` and `src/lib/task-validator.ts` are unchanged.

## Why

tarkov.dev moved task data from the GraphQL API to static JSON files (`json.tarkov.dev/<mode>/<endpoint>`). The JSON payloads use id-keyed objects, string-id references between entities, and translation placeholders resolved via sibling `_en` endpoints. This adapter fetches the relevant endpoints, resolves references and english translations, and produces the same `TaskData` objects the validator already understands.

## Changes

`src/lib/tarkov-api.ts` (rewrite):
- Fetches `<mode>/tasks`, `items`, `maps`, `traders` plus their `_en` translation maps in parallel.
- Resolves string-id refs (`trader`, `taskRequirements[].task`, objective items, reward items) into `{id,name[,shortName]}` and translates task names / objective descriptions.
- Resolves `requiredPrestige` (a prestige-id string on the task) against the tasks payload's `prestige` array into `{id,name,prestigeLevel}`, preserving `getPrestigeLevel` behavior in check-overrides.
- Handles the mixed objective shapes: `usingWeapon`/`notWearing` as flat arrays, `usingWeaponMods`/`requiredKeys`/`wearing` as nested matrices, and inline `{id,name}` refs (e.g. `wearing`) as well as bare id strings.
- Memoizes endpoint fetches per path so a run that fetches `regular` then `pve` downloads each file once.
- Drops the GraphQL `usingWeapon` broken-item fallback (obsolete: JSON returns plain id strings, no upstream resolution error).

`tests/tarkov-api.test.ts` (rewrite): path-routing endpoint fixtures covering translation resolution, ref expansion, nested matrices, gameMode path building, memoization, and error cases.

## Verification

- **Parity proven**: `npm run check-overrides` produces **byte-identical summary blocks** and identical verdict tallies (41 STILL NEEDED, 13 FIXED IN API, 0 NEEDS REVIEW, 0 REMOVED) vs the prior GraphQL output. The only diffs are richer display data the JSON endpoint provides (objective `zones`, `exitStatus`) and a couple of extra passthrough fields (`attributes`, `craftUnlock`) — none change any verdict.
- **Live smoke**: regular ~499 tasks, `Collector` resolves correctly (kappaRequired=true), `requiredPrestige.prestigeLevel` resolves, pve resolves, every task has a non-empty name.
- `npm run typecheck` passes, `npm test` 148/148 pass, `npm run validate` passes, `npm run build` succeeds.
- `dist/overlay.json` intentionally not included — CI rebuilds and commits it on merge.

## Follow-ups (out of scope)

- `monitor/server.js` has its own duplicate GraphQL client (plain JS, no `src/lib` import) and still hits GraphQL — recommend a separate PR to port it to the JSON endpoints.
- `scripts/wiki-task-spike.ts` (experiment) and `examples/apply-overlay.ts` (doc example) still reference GraphQL; optional later cleanup.


___

## **CodeAnt-AI Description**
**Switch task data loading to json.tarkov.dev and keep task validation working**

### What Changed
- Task data now loads from the new `json.tarkov.dev` endpoints instead of the old GraphQL API.
- Task names, objective text, maps, traders, items, and prestige levels are resolved into the same shape the validator expects.
- PVE requests now read from the PVE JSON endpoints, and repeated lookups in one run reuse cached responses.
- Invalid or missing endpoint responses now fail with clearer messages.

### Impact
`✅ Task checks keep working after the tarkov.dev API change`
`✅ Correct task data in regular and PVE modes`
`✅ Fewer repeated downloads during override checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
