### PR TITLE
refactor: promote wiki spike to wiki-compare tool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,4 +33,4 @@ Use the MediaWiki API instead — it is not challenged and returns full content 
 - Rendered HTML fragment: `...&prop=text`
 - Plain-text extract: `action=query&prop=extracts&...`
 
-`scripts/wiki-task-spike.ts` already uses `api.php` (`WIKI_API`); follow that pattern for any new wiki access. The `{{Historical content}}` / `{{Event content}}` templates at the top of a page's wikitext indicate expired/event content (verify before adding or for removing stale event additions).
+`scripts/wiki-compare.ts` (run via `npm run wiki:compare`) already uses `api.php` (`WIKI_API`); follow that pattern for any new wiki access. The `{{Historical content}}` / `{{Event content}}` templates at the top of a page's wikitext indicate expired/event content (verify before adding or for removing stale event additions).

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "validate": "tsx scripts/validate.ts",
     "build": "tsx scripts/build.ts",
     "check-overrides": "tsx scripts/check-overrides.ts",
+    "wiki:compare": "tsx scripts/wiki-compare.ts",
     "monitor": "node monitor/server.js",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/scripts/wiki-compare.ts
+++ b/scripts/wiki-compare.ts
@@ -1,12 +1,18 @@
 #!/usr/bin/env tsx
 /**
- * Spike: compare a single task between tarkov.dev and the wiki.
+ * Compare tasks between tarkov.dev and the EFT wiki.
  *
- * Goal: validate wiki extraction feasibility for tasks.
+ * Research/comparison tool: surfaces discrepancies (level, objectives,
+ * rewards, prerequisites, maps) for a single task or in bulk, filtered
+ * against existing overlay corrections and suppressions.
+ *
+ * Pure comparison/normalization helpers are exported for tests; the CLI
+ * entry point only runs when this file is executed directly.
  */
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import JSON5 from 'json5';
 
 import {
@@ -704,7 +710,7 @@ function parseArgs(argv: string[]): CliOptions & { help?: boolean } {
 
 function printUsage(): void {
   console.log('Usage:');
-  console.log('  tsx scripts/wiki-task-spike.ts [options] [taskName]');
+  console.log('  tsx scripts/wiki-compare.ts [options] [taskName]');
   console.log();
   console.log('Options:');
   console.log('  --all, -a          Compare all tasks (bulk mode)');
@@ -725,16 +731,16 @@ function printUsage(): void {
   console.log('  --help, -h         Show this help');
   console.log();
   console.log('Examples:');
-  console.log('  tsx scripts/wiki-task-spike.ts Grenadier');
-  console.log('  tsx scripts/wiki-task-spike.ts --all --cache');
+  console.log('  tsx scripts/wiki-compare.ts Grenadier');
+  console.log('  tsx scripts/wiki-compare.ts --all --cache');
   console.log(
-    '  tsx scripts/wiki-task-spike.ts --all --cache --group-by=priority'
+    '  tsx scripts/wiki-compare.ts --all --cache --group-by=priority'
   );
-  console.log('  tsx scripts/wiki-task-spike.ts --all --refresh --output');
+  console.log('  tsx scripts/wiki-compare.ts --all --refresh --output');
   console.log(
-    '  tsx scripts/wiki-task-spike.ts --all --output data/results/pve-comparison.json'
+    '  tsx scripts/wiki-compare.ts --all --output data/results/pve-comparison.json'
   );
-  console.log('  tsx scripts/wiki-task-spike.ts --all --gameMode=pve --cache');
+  console.log('  tsx scripts/wiki-compare.ts --all --gameMode=pve --cache');
   console.log();
 }
 
@@ -3498,7 +3504,7 @@ async function main(): Promise<void> {
     return;
   }
 
-  printHeader('WIKI TASK SPIKE');
+  printHeader('WIKI TASK COMPARE');
 
   const gameMode = options.gameMode ?? 'both';
   const modeLabel =
@@ -3537,7 +3543,33 @@ async function main(): Promise<void> {
   }
 }
 
-main().catch((error) => {
-  printError('Wiki spike failed:', error as Error);
-  process.exit(1);
-});
+function isDirectExecution(): boolean {
+  const entryFile = process.argv[1];
+  if (!entryFile) return false;
+  return import.meta.url === pathToFileURL(entryFile).href;
+}
+
+if (isDirectExecution()) {
+  main().catch((error) => {
+    printError('Wiki compare failed:', error as Error);
+    process.exit(1);
+  });
+}
+
+export {
+  compareTasks,
+  getPriority,
+  parseWikiTask,
+  normalizeObjectiveText,
+  normalizeItemName,
+  normalizeMapName,
+  itemsMatch,
+  buildMapAliasMap,
+};
+export type {
+  Discrepancy,
+  Priority,
+  WikiTaskData,
+  WikiObjective,
+  ExtendedTaskData,
+};

--- a/tests/wiki-compare.test.ts
+++ b/tests/wiki-compare.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+import {
+  compareTasks,
+  getPriority,
+  normalizeItemName,
+  normalizeMapName,
+  itemsMatch,
+  type ExtendedTaskData,
+  type WikiTaskData,
+} from '../scripts/wiki-compare.js';
+
+const EMPTY_ALIASES = new Map<string, string>();
+
+function makeWiki(overrides: Partial<WikiTaskData> = {}): WikiTaskData {
+  return {
+    pageTitle: 'Test Task',
+    requirements: [],
+    objectives: [],
+    rewards: { reputations: [], items: [], raw: [] },
+    previousTasks: [],
+    nextTasks: [],
+    maps: [],
+    relatedItems: [],
+    relatedRequiredItems: [],
+    relatedHandoverItems: [],
+    ...overrides,
+  };
+}
+
+describe('getPriority', () => {
+  it('classifies progression-blocking fields as high', () => {
+    expect(getPriority('minPlayerLevel')).toBe('high');
+    expect(getPriority('taskRequirements')).toBe('high');
+    expect(getPriority('objectives.description')).toBe('high');
+  });
+
+  it('classifies trader-specific reputation as medium', () => {
+    expect(getPriority('reputation.Prapor')).toBe('medium');
+    expect(getPriority('map')).toBe('medium');
+  });
+
+  it('falls back to low for non-blocking fields', () => {
+    expect(getPriority('experience')).toBe('low');
+    expect(getPriority('money')).toBe('low');
+    expect(getPriority('unknown')).toBe('low');
+  });
+});
+
+describe('normalizers', () => {
+  it('normalizeItemName is case/space insensitive', () => {
+    expect(normalizeItemName('  Salewa First Aid Kit ')).toBe(
+      normalizeItemName('salewa first aid kit')
+    );
+  });
+
+  it('normalizeMapName collapses casing', () => {
+    expect(normalizeMapName('Customs')).toBe(normalizeMapName('customs'));
+  });
+
+  it('itemsMatch intersects api/wiki item references', () => {
+    const apiItems = [{ name: 'Bottle of vodka "Tarkovskaya"' }];
+    expect(itemsMatch(apiItems, ['Bottle of vodka "Tarkovskaya"'])).toBe(true);
+    expect(itemsMatch(apiItems, ['Bottle of beer'])).toBe(false);
+  });
+});
+
+describe('compareTasks', () => {
+  const baseApi: ExtendedTaskData = {
+    id: 'task-1',
+    name: 'Test Task',
+    minPlayerLevel: 10,
+    objectives: [
+      { id: 'o1', type: 'shoot', description: 'Eliminate 5 Scavs on Customs', count: 5 },
+    ],
+  };
+
+  it('returns no discrepancies when api and wiki agree', () => {
+    const wiki = makeWiki({
+      minPlayerLevel: 10,
+      objectives: [{ text: 'Eliminate 5 Scavs on Customs', count: 5 }],
+    });
+    const result = compareTasks(baseApi, wiki, EMPTY_ALIASES, false);
+    expect(result.find((d) => d.field === 'minPlayerLevel')).toBeUndefined();
+  });
+
+  it('flags a minPlayerLevel mismatch as high priority', () => {
+    const wiki = makeWiki({
+      minPlayerLevel: 15,
+      objectives: [{ text: 'Eliminate 5 Scavs on Customs', count: 5 }],
+    });
+    const result = compareTasks(baseApi, wiki, EMPTY_ALIASES, false);
+    const level = result.find((d) => d.field === 'minPlayerLevel');
+    expect(level).toBeDefined();
+    expect(level?.apiValue).toBe(10);
+    expect(level?.wikiValue).toBe(15);
+    expect(level?.priority).toBe('high');
+  });
+
+  it('detects an objective count mismatch', () => {
+    const wiki = makeWiki({
+      minPlayerLevel: 10,
+      objectives: [{ text: 'Eliminate 5 Scavs on Customs', count: 8 }],
+    });
+    const result = compareTasks(baseApi, wiki, EMPTY_ALIASES, false);
+    expect(result.some((d) => d.field === 'objectives.count')).toBe(true);
+  });
+
+  it('does not print when verbose is false', () => {
+    const logs: unknown[] = [];
+    const original = console.log;
+    console.log = (...args: unknown[]) => logs.push(args);
+    try {
+      compareTasks(baseApi, makeWiki({ minPlayerLevel: 10 }), EMPTY_ALIASES, false);
+    } finally {
+      console.log = original;
+    }
+    expect(logs).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary
The `wiki-task-spike.ts` script outgrew its "spike" label and is now a maintained research/comparison tool. This promotes it to a first-class tool without relocating its internals.

- Rename `scripts/wiki-task-spike.ts` → `scripts/wiki-compare.ts` (history preserved via `git mv`); de-spiked the header, banner, and error label.
- Guard `main()` behind an `import.meta.url` entry check — the same pattern `check-overrides.ts` and `validate.ts` already use — so the module is importable without firing the CLI or hitting the network.
- Export the comparison engine (`compareTasks`, `getPriority`, `parseWikiTask`, the normalizers, `itemsMatch`, `buildMapAliasMap`) and its types so the logic can be tested.
- Add `npm run wiki:compare`; update the AGENTS.md reference and in-script usage strings.

## Why in-place instead of moving to src/lib
Nothing outside this script reuses the helpers, and `compareTasks(verbose=false)` was already side-effect-free. Exporting in place gets identical testability with a ~40-line diff instead of a ~1900-line relocation. Extraction into `src/lib` can wait until a second consumer needs these helpers.

## Tested
- `npx tsc --noEmit` — clean
- `npx vitest run` — 160/160 pass (new `tests/wiki-compare.test.ts` adds 10: priority classification, normalizers, and `compareTasks` discrepancy output incl. silent-when-not-verbose)
- `npm run wiki:compare -- --help` runs (guard intact)
- `npm run validate` and `npm run build` — green

## Notes
- No generated output changes; `dist/overlay.json` is intentionally left untouched.


___

## **CodeAnt-AI Description**
**Rename the wiki comparison tool and make it safe to import**

### What Changed
- The wiki task comparison script is now presented as a maintained comparison tool, with updated name, banner, usage text, and help examples
- A new `npm run wiki:compare` command runs the tool directly
- The script no longer starts the CLI or network work when it is imported, so it can be reused in tests without side effects
- The comparison logic is now exposed for testing, and new tests cover priority ranking, text matching, mismatch detection, and quiet output when not in verbose mode

### Impact
`✅ Clearer wiki comparison workflow`
`✅ Easier test coverage for task mismatch checks`
`✅ Safer imports without unexpected CLI runs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
