### PR TITLE
chore: drop Neuanfang override data now provided upstream

### DIFF
--- a/src/overrides/tasks.json5
+++ b/src/overrides/tasks.json5
@@ -208,12 +208,10 @@
     ],
   },
 
-  // New Beginning (Prestige 1) - Level requirement and objective description incorrect
+  // New Beginning (Prestige 1) - Objective description incorrect
   // Proof: https://escapefromtarkov.fandom.com/wiki/New_Beginning_(Prestige_1)
-  // tarkov.dev shows minPlayerLevel 55; wiki confirms 25.
   // tarkov.dev objective uses Lab -> Streets transit; wiki states surviving and extracting from The Lab instead.
   '6761f28a022f60bb320f3e95': {
-    minPlayerLevel: 25, // Was: 55
     objectives: {
       '6848100b00afffa81f09e36b': {
         description: 'Survive and extract from The Lab', // Was: "Use the transit from The Lab to Streets of Tarkov"
@@ -221,35 +219,15 @@
     },
   },
 
-  // New Beginning (Prestige 2) - Level requirement incorrect
-  // Proof: https://escapefromtarkov.fandom.com/wiki/New_Beginning_(Prestige_2)
-  // tarkov.dev shows minPlayerLevel 55; wiki confirms 30.
-  '6761ff17cdc36bd66102e9d0': {
-    minPlayerLevel: 30, // Was: 55
-  },
-
-  // New Beginning (Prestige 3) - Reputation reward and objectives incorrect
+  // New Beginning (Prestige 3) - Reputation reward and objective exit status incorrect
   // Proof: https://escapefromtarkov.fandom.com/wiki/New_Beginning_(Prestige_3)
-  // tarkov.dev missing the Lab -> Streets transit objective; wiki includes it.
   // tarkov.dev shows +0.01 Ragman rep, wiki shows +0.1.
   '6848100b00afffa81f09e365': {
-    minPlayerLevel: 35, // Was: 55
     objectives: {
       '6848116061809d65b8503617': {
         exitStatus: ['Survived'], // Was: ["ExpBonusmarathon Name"]
       },
     },
-    objectivesAdd: [
-      {
-        id: 'new_beginning_3_obj_transit_lab_streets',
-        description: 'Use the transit from The Lab to Streets of Tarkov',
-        type: 'extract',
-        maps: [{ id: '5b0fc42d86f7744a585f9105', name: 'The Lab' }, { id: '5714dc692459777137212e12', name: 'Streets of Tarkov' }],
-        exitStatus: ['ExpBonusmarathon Name'],
-        count: 1,
-      },
-    ],
-    // Was: transit objective missing in API
     finishRewards: {
       traderStanding: [
         {
@@ -260,28 +238,10 @@
     },
   },
 
-  // New Beginning (Prestige 4) - Reputation reward and objectives incorrect
+  // New Beginning (Prestige 4) - Reputation reward incorrect
   // Proof: https://escapefromtarkov.fandom.com/wiki/New_Beginning_(Prestige_4)
-  // tarkov.dev missing the Interchange extract objective; wiki includes it.
   // tarkov.dev shows +0.01 Ragman rep, wiki shows +0.1.
   '68481881f43abfdda2058369': {
-    minPlayerLevel: 40, // Was: 55
-    objectives: {
-      '68481881f43abfdda205836f': {
-        maps: [{ id: '5b0fc42d86f7744a585f9105', name: 'The Lab' }, { id: '5714dc692459777137212e12', name: 'Streets of Tarkov' }], // Was: [{ id: '5714dc692459777137212e12', name: 'Streets of Tarkov' }, { id: '5714dc692459777137212e12', name: 'Streets of Tarkov' }]
-      },
-    },
-    objectivesAdd: [
-      {
-        id: 'new_beginning_4_obj_extract_interchange',
-        description: 'Survive and extract from Interchange',
-        type: 'extract',
-        maps: [{ id: '5714dbc024597771384a510d', name: 'Interchange' }],
-        exitStatus: ['Survived'],
-        count: 1,
-      },
-    ],
-    // Was: extract objective missing in API
     finishRewards: {
       traderStanding: [
         {


### PR DESCRIPTION
## **User description**
## Summary
Drift check against the live tarkov.dev API flagged several New Beginning (Neuanfang) override fields that upstream now provides. Verified each against both the API and the Fandom wiki (via MediaWiki API), then removed only the redundant fields while keeping corrections still needed.

- **Prestige 1** (`6761f28a022f60bb320f3e95`) — dropped redundant `minPlayerLevel: 25`; kept wiki-confirmed objective description override.
- **Prestige 2** (`6761ff17cdc36bd66102e9d0`) — removed entire block (only set `minPlayerLevel`, now in API).
- **Prestige 3** (`6848100b00afffa81f09e365`) — dropped redundant `minPlayerLevel` and now-native transit `objectivesAdd`; kept wiki-confirmed Ragman +0.1 reward and `exitStatus: ['Survived']` fix.
- **Prestige 4** (`68481881f43abfdda2058369`) — dropped redundant `minPlayerLevel`, objective `maps` fix, and now-native Interchange extract `objectivesAdd`; kept wiki-confirmed Ragman +0.1 reward.

## Proof
- New Beginning (Prestige 1): https://escapefromtarkov.fandom.com/wiki/New_Beginning_(Prestige_1)
- New Beginning (Prestige 3): https://escapefromtarkov.fandom.com/wiki/New_Beginning_(Prestige_3)
- New Beginning (Prestige 4): https://escapefromtarkov.fandom.com/wiki/New_Beginning_(Prestige_4)

Wiki confirms +0.1 Ragman rep for P3/P4 (API still shows +0.01), so those `finishRewards` overrides remain. No `{{Historical content}}` / `{{Event content}}` flags on any page.

## Verification
- `npm run validate` — all files valid
- `npm run build` — overlay regenerated (dist left for CI per repo convention)
- `npm test` — 160 passed
- `npm run check-overrides` — no remaining "Fixed in API" / "MOVE TO OBJECTIVES" stragglers


___

## **CodeAnt-AI Description**
**Correct New Beginning prestige task details**

### What Changed
- Removed stale override data for New Beginning prestige tasks where the live game data now matches upstream
- Fixed Prestige 1 so it shows the right objective text for escaping The Lab
- Kept the remaining Prestige 3 and 4 corrections so they show the right Ragman reward and task completion behavior

### Impact
`✅ Correct quest requirements`
`✅ Accurate reward display`
`✅ Fewer mismatched task details`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
