### PR TITLE
ci: modernize Actions and target Node 24 LTS

### DIFF
--- a/.github/workflows/check-overrides.yml.example
+++ b/.github/workflows/check-overrides.yml.example
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/check-overrides.yml.example
+++ b/.github/workflows/check-overrides.yml.example
@@ -20,10 +20,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/check-overrides.yml.example
+++ b/.github/workflows/check-overrides.yml.example
@@ -20,10 +20,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24'
           cache: 'npm'
@@ -38,7 +38,7 @@ jobs:
           cat check-output.txt
 
       - name: Create issue if overrides need updating
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         if: contains(steps.check.outputs.stdout, 'can remove')
         with:
           script: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24'
           cache: 'npm'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/license-year-update.yml
+++ b/.github/workflows/license-year-update.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Update the year in LICENSE
         run: |

--- a/.github/workflows/license-year-update.yml
+++ b/.github/workflows/license-year-update.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Update the year in LICENSE
         run: |

--- a/monitor/server.js
+++ b/monitor/server.js
@@ -738,7 +738,7 @@ function validateEnvelope(payload, path) {
 
 async function fetchEnvelopeOnce(path) {
   if (typeof fetch !== "function") {
-    throw new Error("Global fetch is not available. Node 20.10.0+ is required");
+    throw new Error("Global fetch is not available. Node 22.0.0+ is required");
   }
   let lastError = null;
   for (let attempt = 1; attempt <= MAX_RETRIES; attempt += 1) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "vitest": "^4.1.0"
       },
       "engines": {
-        "node": ">=20.10.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@emnapi/core": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "author": "Lab",
   "license": "MIT",
   "engines": {
-    "node": ">=20.10.0"
+    "node": ">=22.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.19.37",


### PR DESCRIPTION
## Summary
CI modernization driven by the Node 20 deprecation warning on Actions runners.

### 1. Bump action runtimes off deprecated Node 20, pinned to SHAs
GitHub is force-migrating actions bundling the Node 20 runtime to Node 24. Bumped to current majors and pinned to immutable commit SHAs (matching the repo's existing convention for `appleboy/ssh-action` and `softprops/action-gh-release`):
- `actions/checkout@v4` -> `@9c091bb...` # v7.0.0
- `actions/setup-node@v4` -> `@48b55a0...` # v6.4.0
- `actions/github-script@v7` -> `@f28e40c...` # v7.1.0 (template)

### 2. Target Node 24 LTS, drop EOL Node 20
Node 20 reached end-of-life on 2026-04-30.
- CI `node-version: '20'` -> `'24'` (current Active LTS "Krypton", supported to 2028-04)
- `package.json` engines `>=20.10.0` -> `>=22.0.0` (drops EOL 20, still allows Maintenance LTS 22 for contributors)
- Regenerated `package-lock.json` and updated the stale Node-version string in `monitor/server.js` to match

Applied across `ci.yml`, `license-year-update.yml`, and the `check-overrides.yml.example` template.

Note: CI runs on Node 24 (Active LTS) while `engines` allows `>=22` — intentional. Testing on the newest LTS while supporting contributors on 22+ is standard; 24 satisfies the `>=22` constraint.

## Verification
Local Node v24: `npm run validate`, `npm run build`, `npm test` (160 passed) all pass.