### PR TITLE
fix: correct To Great Heights! - Part 5 objective text

### DIFF
--- a/src/overrides/modes/pve/tasks.json5
+++ b/src/overrides/modes/pve/tasks.json5
@@ -1,1 +1,12 @@
-{}
+{
+  // To Great Heights! - Part 5 [PVE ZONE] - objective text duplicates Part 6's
+  // Proof: https://escapefromtarkov.fandom.com/wiki/To_Great_Heights!_-_Part_5
+  // tarkov.dev returns Part 6's "Win two matches in a row" objective for Part 5.
+  '68342265a8d674b5740b31f0': {
+    objectives: {
+      '68342265a8d674b5740b31f3': {
+        description: 'Win a match claiming at least 2nd place in the team in TeamFight, BlastGang, or CheckPoint mode in Arena', // Was: "Win two matches in a row in TeamFight, BlastGang, or CheckPoint mode in Arena"
+      },
+    },
+  },
+}

--- a/src/overrides/modes/regular/tasks.json5
+++ b/src/overrides/modes/regular/tasks.json5
@@ -10,4 +10,15 @@
       },
     },
   },
+
+  // To Great Heights! - Part 5 [PVP ZONE] - objective text duplicates Part 6's
+  // Proof: https://escapefromtarkov.fandom.com/wiki/To_Great_Heights!_-_Part_5
+  // tarkov.dev returns Part 6's "Win two matches in a row" objective for Part 5.
+  '66058cc9ae4719735349b9ea': {
+    objectives: {
+      '662ba87106e44407b79e9ab2': {
+        description: 'Win a match claiming at least 2nd place in the team in TeamFight, BlastGang, or CheckPoint mode in Arena', // Was: "Win two matches in a row in TeamFight, BlastGang, or CheckPoint mode in Arena"
+      },
+    },
+  },
 }


### PR DESCRIPTION
## **User description**
## Summary

`To Great Heights! - Part 5` shows the wrong objective in both game modes. tarkov.dev returns Part 6's "win matches in a row" text for Part 5's objective; per the wiki, Part 5's objective is **"Win a match claiming at least 2nd place in the team in TeamFight, BlastGang, or CheckPoint mode in Arena"**.

This adds objective `description` overrides for Part 5 in both modes (different task/objective IDs per mode, so they live in the per-mode files):

| Mode | Task ID | Objective ID |
|------|---------|--------------|
| regular | `66058cc9ae4719735349b9ea` | `662ba87106e44407b79e9ab2` |
| pve | `68342265a8d674b5740b31f0` | `68342265a8d674b5740b31f3` |

## Verification

Confirmed at the raw source level (not just the adapted view):
- Raw `tasks_en` translation for Part 5's objective = `"Win two matches in a row..."` (Part 6's text), in both modes.
- Part 5's objective is a single `visit` type with no `count`/`zones`/`maps` — no other field carries the real text.
- Wiki Part 5 has no Historical/Event flags, a single objective, and chains `Part 4 -> Part 5 -> Part 6`.

Proof: https://escapefromtarkov.fandom.com/wiki/To_Great_Heights!_-_Part_5

## Commands run
- `npm run validate` ✅
- `npm run build` ✅ (dist left for the post-merge `chore: build overlay` commit)

## Related
Refs #201. Note: the issue's other claim ("Part 6 missing") is already resolved upstream — tarkov.dev now has a full Part 1-6 chain in both modes.


___

## **CodeAnt-AI Description**
Fix the objective text for To Great Heights! - Part 5

### What Changed
- Shows the correct Arena objective for To Great Heights! - Part 5 instead of the Part 6 text
- Applies the fix in both regular and PvE modes

### Impact
`✅ Clearer quest objectives`
`✅ Fewer wrong task instructions`
`✅ Consistent quest text across game modes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
