### PR TITLE
feat: add quest reference cross-check tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ coverage/
 
 # Generated data (wiki cache, API cache, comparison results)
 data/
+
+eft/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,24 @@ The built `dist/overlay.json` contains entity sections keyed by tarkov.dev IDs (
 - `npm test` runs the Vitest suite; `npm run test:watch` keeps it running.
 - Example single test: `npx vitest run tests/file-loader.test.ts`.
 
+### Reference cross-check tooling (local-only)
+
+The `eft:*` scripts cross-check the overlay against a local quest reference file,
+the authority for numeric quest fields (experience, minPlayerLevel, objective
+counts). The reference file lives in `eft/` and all derived output in `data/` —
+both gitignored. Never commit reference files or anything derived from them; PRs
+carry only the resulting JSON5 corrections plus proof links.
+
+- `npm run eft:normalize` distills a raw reference file into a clean
+  tarkov.dev-shaped `data/eft/quests.<mode>.json`.
+- `npm run eft:compare` lists where the reference disagrees with the live API.
+- `npm run eft:audit` is the three-way `reference -> API -> overrides` check.
+  Per field it reports GAP (API wrong, no override — add one), STALE (API fixed
+  upstream, override redundant — remove it), CONFLICT (override disagrees with
+  the reference — fix it), or OK (override correct and still needed). The
+  reference is mode-specific; the audit auto-detects its mode and refuses a
+  mismatched `--mode` to avoid false positives.
+
 ## Coding Style & Naming Conventions
 
 TypeScript uses 2-space indentation, semicolons, and ESM imports (see `"type": "module"`). Data files are JSON5 and may include comments. Use tarkov.dev entity IDs as keys and field names that match the tarkov.dev API exactly (camelCase). Every correction must include: entity name comment, proof link, and inline “Was:” value. For nested patches (like task objectives), use ID-keyed objects rather than arrays. Empty override files are valid and skipped during build. When adding a new entity type, add its schema to `SCHEMA_CONFIGS` in `src/lib/types.ts`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@types/node": "^20.19.37",
+        "@types/node": "^20.19.43",
         "ajv": "^8.18.0",
         "json5": "^2.2.3",
         "tsx": "^4.21.0",
@@ -858,9 +858,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
-      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
     "validate": "tsx scripts/validate.ts",
     "build": "tsx scripts/build.ts",
     "check-overrides": "tsx scripts/check-overrides.ts",
+    "eft:compare": "tsx scripts/eft-compare.ts",
+    "eft:audit": "tsx scripts/eft-audit.ts",
+    "eft:wiki": "tsx scripts/eft-wiki-crosscheck.ts",
+    "eft:normalize": "tsx scripts/eft-normalize.ts",
     "wiki:compare": "tsx scripts/wiki-compare.ts",
     "monitor": "node monitor/server.js",
     "typecheck": "tsc --noEmit",
@@ -27,7 +31,7 @@
     "node": ">=22.0.0"
   },
   "devDependencies": {
-    "@types/node": "^20.19.37",
+    "@types/node": "^20.19.43",
     "ajv": "^8.18.0",
     "json5": "^2.2.3",
     "tsx": "^4.21.0",

--- a/scripts/check-overrides.ts
+++ b/scripts/check-overrides.ts
@@ -40,8 +40,13 @@ import {
   type ValidationResult,
   type ValidationDetail,
 } from '../src/lib/index.js';
+import {
+  loadEftTasks,
+  crossCheckOverrides,
+  type CrossCheckEntry,
+} from './eft-compare.js';
 
-const { srcDir } = getProjectPaths();
+const { srcDir, rootDir } = getProjectPaths();
 
 /**
  * Load task overrides from source file
@@ -498,6 +503,67 @@ function printEditionReferenceResults(missing: EditionTaskReference[]): void {
 }
 
 /**
+ * Cross-check objective overrides against the local quest reference file
+ * (authoritative source). The API-only validator can only say "override differs
+ * from API", which it treats as "still needed" - it cannot tell when the
+ * override itself is wrong. The reference file adjudicates that. No-ops cleanly
+ * when no reference file is present in `eft/`.
+ */
+function printReferenceCrossCheck(
+  groups: Array<{ label: string; overrides: Record<string, TaskOverride> }>
+): void {
+  const eftTasks = loadEftTasks(join(rootDir, 'eft'));
+  if (!eftTasks) return; // no reference file available; skip silently
+
+  printHeader('REFERENCE CROSS-CHECK');
+
+  const conflicts: CrossCheckEntry[] = [];
+  const unverifiable: CrossCheckEntry[] = [];
+  let confirmed = 0;
+
+  for (const { overrides } of groups) {
+    for (const entry of crossCheckOverrides(overrides, eftTasks)) {
+      if (entry.verdict === 'CONFLICTS_REFERENCE') conflicts.push(entry);
+      else if (entry.verdict === 'NO_REFERENCE_DATA') unverifiable.push(entry);
+      else confirmed += 1;
+    }
+  }
+
+  console.log(
+    formatCountLabel(
+      `${icons.error} Overrides that CONFLICT with the reference (likely wrong)`,
+      conflicts.length,
+      'red'
+    )
+  );
+  for (const c of conflicts) {
+    console.log(`  - ${c.taskId} / ${c.objectiveId} (${c.field})`);
+    console.log(`      override: ${colors.red}${c.override}${colors.reset}`);
+    console.log(`      reference: ${colors.green}${c.reference}${colors.reset}`);
+  }
+  if (conflicts.length === 0) console.log(`  ${dim('None')}`);
+  console.log();
+
+  console.log(
+    formatCountLabel(
+      `${icons.success} Overrides confirmed by the reference`,
+      confirmed,
+      'green'
+    )
+  );
+  console.log();
+
+  console.log(
+    formatCountLabel(
+      `${icons.info} Objective overrides the reference can't adjudicate`,
+      unverifiable.length,
+      'cyan'
+    )
+  );
+  console.log();
+}
+
+/**
  * Main validation function
  */
 async function main(): Promise<void> {
@@ -525,6 +591,11 @@ async function main(): Promise<void> {
 
     printResults(results);
 
+    // Collect every override group for the reference cross-check below.
+    const crossCheckGroups: Array<{ label: string; overrides: Record<string, TaskOverride> }> = [
+      { label: 'base', overrides },
+    ];
+
     printProgress('Checking additions against API...\n');
     const additionResults = checkTaskAdditions(additions, apiTasks);
     printAdditionResults(additionResults);
@@ -536,6 +607,10 @@ async function main(): Promise<void> {
       const modeOverrideCount = Object.keys(modeOverrides).length;
       const modeAdditionCount = Object.keys(modeAdditions).length;
       if (modeOverrideCount === 0 && modeAdditionCount === 0) continue;
+
+      if (modeOverrideCount > 0) {
+        crossCheckGroups.push({ label: mode, overrides: modeOverrides });
+      }
 
       printProgress(`Fetching ${mode} tasks from tarkov.dev API...`);
       const modeApiTasks = await fetchTasks(mode);
@@ -560,6 +635,8 @@ async function main(): Promise<void> {
     printProgress('Checking edition exclusions against API...\n');
     const missingEditionRefs = checkEditionTaskReferences(editions, apiTasks);
     printEditionReferenceResults(missingEditionRefs);
+
+    printReferenceCrossCheck(crossCheckGroups);
 
     process.exit(0);
   } catch (error) {

--- a/scripts/eft-audit.ts
+++ b/scripts/eft-audit.ts
@@ -1,0 +1,325 @@
+#!/usr/bin/env tsx
+/**
+ * Three-way task data audit:  REFERENCE  ->  tarkov.dev API  ->  OUR OVERRIDES
+ *
+ * The local quest reference file is the authority for the numeric quest fields
+ * (experience, minPlayerLevel, objective counts). This audit lines up all three
+ * sources for every comparable field and tells you, per (task, field), exactly
+ * what to do:
+ *
+ *   GAP       API disagrees with the reference and we have NO override for it.
+ *             -> tarkov.dev is wrong and uncorrected; add an override.
+ *
+ *   STALE     We have an override, but the API now equals the reference.
+ *             -> tarkov.dev fixed it upstream; the override is redundant and
+ *                can be removed.
+ *
+ *   CONFLICT  We have an override, but the override value disagrees with the
+ *             reference. -> our override is wrong; fix it.
+ *
+ *   OK        We have an override, the API is (still) wrong, and the override
+ *             matches the reference. -> working as intended, keep it.
+ *
+ * Fields with no reference value (the reference can't adjudicate) are skipped,
+ * so this never produces false GAPs. The reference is per game-mode; pass --mode
+ * to pick which tarkov.dev mode and which mode-specific override file to audit
+ * against (defaults to pve). Shared overrides
+ * (src/overrides/tasks.json5) are merged with the mode file the same way the
+ * built overlay applies them (mode wins per field).
+ *
+ * LOCAL-ONLY: requires a reference file in eft/ (gitignored). No-ops cleanly if absent.
+ *
+ * Usage:
+ *   tsx scripts/eft-audit.ts [eftDir] [--mode pve|regular] [--json out.json]
+ *   npm run eft:audit
+ *
+ * Exit code is 0 always (report tool); use --json for machine-readable output.
+ */
+
+import { writeFileSync } from 'fs';
+import { isAbsolute, join } from 'path';
+import { pathToFileURL } from 'url';
+
+import {
+  fetchTasks,
+  findTaskById,
+  loadJson5File,
+  getProjectPaths,
+  printHeader,
+  printProgress,
+  printSuccess,
+  printError,
+  bold,
+  dim,
+  colors,
+  icons,
+  type GameMode,
+  type TaskData,
+  type TaskOverride,
+} from '../src/lib/index.js';
+import { loadEftTasks, detectReferenceMode, type EftTask } from './eft-compare.js';
+
+type Verdict = 'GAP' | 'STALE' | 'CONFLICT' | 'OK';
+type Field = 'experience' | 'minPlayerLevel' | `objective[${string}].count`;
+
+interface Row {
+  taskId: string;
+  taskName: string;
+  field: Field;
+  reference: number;
+  api: number | undefined;
+  override: number | undefined;
+  verdict: Verdict;
+}
+
+const { srcDir } = getProjectPaths();
+
+/** Load a JSON5 override map, tolerating an absent/empty file. */
+function loadOverrideFile(relPath: string): Record<string, TaskOverride> {
+  try {
+    return loadJson5File<Record<string, TaskOverride>>(join(srcDir, relPath));
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Effective task overrides for a mode: shared overrides merged with the
+ * mode-specific file, mode winning per top-level field (objectives merged by
+ * objective id). Mirrors how the consumer applies base + mode overlays.
+ */
+function effectiveOverrides(mode: GameMode): Record<string, TaskOverride> {
+  const base = loadOverrideFile(join('overrides', 'tasks.json5'));
+  const modeOv = loadOverrideFile(join('overrides', 'modes', mode, 'tasks.json5'));
+
+  const out: Record<string, TaskOverride> = {};
+  for (const [id, ov] of Object.entries(base)) out[id] = { ...ov };
+  for (const [id, ov] of Object.entries(modeOv)) {
+    const merged: TaskOverride = { ...(out[id] ?? {}), ...ov };
+    if (out[id]?.objectives || ov.objectives) {
+      merged.objectives = { ...(out[id]?.objectives ?? {}), ...(ov.objectives ?? {}) };
+    }
+    out[id] = merged;
+  }
+  return out;
+}
+
+/** Classify one (task, field) across the three sources. */
+function classify(
+  reference: number,
+  api: number | undefined,
+  override: number | undefined,
+): Verdict | null {
+  const apiCorrect = api !== undefined && api === reference;
+  const hasOverride = override !== undefined;
+
+  if (!hasOverride) {
+    // No override: only interesting when the API is wrong.
+    return apiCorrect || api === undefined ? null : 'GAP';
+  }
+  // Override present.
+  if (override !== reference) return 'CONFLICT'; // our override is wrong
+  if (apiCorrect) return 'STALE'; // API caught up; override redundant
+  return 'OK'; // API still wrong, override fixes it
+}
+
+function buildRows(
+  eftTasks: Map<string, EftTask>,
+  apiTasks: TaskData[],
+  overrides: Record<string, TaskOverride>,
+): Row[] {
+  const rows: Row[] = [];
+
+  for (const eft of eftTasks.values()) {
+    const api = findTaskById(apiTasks, eft.id);
+    if (!api) continue; // task not in this API mode; nothing to audit
+    const ov = overrides[eft.id];
+    const name = api.name;
+
+    const scalar = (
+      field: 'experience' | 'minPlayerLevel',
+      reference: number | undefined,
+    ): void => {
+      if (reference === undefined) return; // reference can't adjudicate
+      const verdict = classify(reference, api[field], ov?.[field]);
+      if (verdict) {
+        rows.push({
+          taskId: eft.id,
+          taskName: name,
+          field,
+          reference,
+          api: api[field],
+          override: ov?.[field],
+          verdict,
+        });
+      }
+    };
+    scalar('experience', eft.experience);
+    scalar('minPlayerLevel', eft.minPlayerLevel);
+
+    // Objective counts (keyed by objective/condition id).
+    const apiObjectives = new Map((api.objectives ?? []).map((o) => [o.id, o]));
+    for (const [objId, refCount] of eft.counts) {
+      const apiObj = apiObjectives.get(objId);
+      const apiCount = typeof apiObj?.count === 'number' ? apiObj.count : undefined;
+      const objOverride = ov?.objectives?.[objId];
+      const overrideCount =
+        typeof objOverride?.count === 'number' ? objOverride.count : undefined;
+      const verdict = classify(refCount, apiCount, overrideCount);
+      if (verdict) {
+        rows.push({
+          taskId: eft.id,
+          taskName: name,
+          field: `objective[${objId}].count`,
+          reference: refCount,
+          api: apiCount,
+          override: overrideCount,
+          verdict,
+        });
+      }
+    }
+  }
+
+  return rows;
+}
+
+interface Options {
+  eftDir: string;
+  mode: GameMode;
+  jsonOut?: string;
+}
+
+function parseArgs(argv: string[]): Options {
+  let eftDir = 'eft';
+  let mode: GameMode = 'pve';
+  let jsonOut: string | undefined;
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--mode') {
+      const v = argv[(i += 1)];
+      if (v !== 'pve' && v !== 'regular') {
+        throw new Error(`--mode must be 'pve' or 'regular', got '${v}'`);
+      }
+      mode = v;
+    } else if (arg === '--json') {
+      jsonOut = argv[(i += 1)];
+    } else if (!arg.startsWith('--')) {
+      eftDir = arg;
+    }
+  }
+  return { eftDir: isAbsolute(eftDir) ? eftDir : join(process.cwd(), eftDir), mode, jsonOut };
+}
+
+const VERDICT_META: Record<Verdict, { icon: string; color: string; blurb: string }> = {
+  GAP: { icon: icons.error, color: colors.red, blurb: 'API wrong, NO override - add one' },
+  CONFLICT: { icon: icons.error, color: colors.red, blurb: 'override disagrees with reference - fix it' },
+  STALE: { icon: icons.warning, color: colors.yellow, blurb: 'API fixed upstream - override redundant, remove it' },
+  OK: { icon: icons.success, color: colors.green, blurb: 'override correct and still needed' },
+};
+
+function fieldLabel(field: Field): string {
+  return field.startsWith('objective[')
+    ? field.replace(/^objective\[(.*)\]\.count$/, 'objective.count ($1)')
+    : field;
+}
+
+function printReport(rows: Row[], mode: GameMode): void {
+  printHeader(`THREE-WAY AUDIT  (reference -> tarkov.dev ${mode} -> overrides)`);
+
+  const order: Verdict[] = ['GAP', 'CONFLICT', 'STALE', 'OK'];
+  for (const verdict of order) {
+    const items = rows.filter((r) => r.verdict === verdict);
+    if (items.length === 0) continue;
+    const meta = VERDICT_META[verdict];
+    console.log(
+      bold(`\n${meta.icon} ${meta.color}${verdict}${colors.reset} (${items.length}) ${dim('- ' + meta.blurb)}`),
+    );
+    for (const r of items) {
+      console.log(
+        `  ${r.taskName} ${dim(`(${r.taskId})`)} ${dim(fieldLabel(r.field))}\n` +
+          `     reference: ${colors.green}${r.reference}${colors.reset}  ` +
+          `api: ${colors.red}${r.api}${colors.reset}  ` +
+          `override: ${r.override === undefined ? dim('none') : colors.cyan + r.override + colors.reset}`,
+      );
+    }
+  }
+
+  const count = (v: Verdict) => rows.filter((r) => r.verdict === v).length;
+  printHeader('SUMMARY');
+  console.log(`  ${icons.error} GAP      (add override):    ${bold(String(count('GAP')))}`);
+  console.log(`  ${icons.error} CONFLICT (fix override):    ${bold(String(count('CONFLICT')))}`);
+  console.log(`  ${icons.warning} STALE    (remove override): ${bold(String(count('STALE')))}`);
+  console.log(`  ${icons.success} OK       (keep override):   ${bold(String(count('OK')))}`);
+  console.log();
+}
+
+async function main(): Promise<void> {
+  try {
+    const opts = parseArgs(process.argv.slice(2));
+
+    printProgress(`Loading quest reference file from ${opts.eftDir}...`);
+    const eftTasks = loadEftTasks(opts.eftDir);
+    if (!eftTasks) {
+      printError(
+        `No quest reference file found in ${opts.eftDir}`,
+        new Error('place a quest reference file in eft/ to run the audit'),
+      );
+      process.exit(1);
+    }
+    printSuccess(`Loaded ${eftTasks.size} quests from the reference file`);
+
+    // The reference file is mode-specific. Auditing it against a different
+    // tarkov.dev mode produces false GAP/CONFLICT rows (e.g. a PVE reference's
+    // lower XP looks like a "gap" against regular-mode values). Refuse the
+    // mismatch rather than emit misleading results.
+    const refMode = detectReferenceMode(opts.eftDir);
+    if (refMode && refMode !== opts.mode) {
+      printError(
+        'Reference/mode mismatch',
+        new Error(
+          `The reference file in ${opts.eftDir} is a ${refMode} file, but --mode is ${opts.mode}. ` +
+            `Auditing across modes yields false positives. Re-run with --mode ${refMode}, ` +
+            `or supply a ${opts.mode} reference file.`,
+        ),
+      );
+      process.exit(1);
+    }
+    if (!refMode) {
+      console.log(
+        dim(`  (could not detect reference mode; trusting --mode ${opts.mode})`),
+      );
+    }
+
+    printProgress(`Fetching ${opts.mode} tasks from tarkov.dev...`);
+    const apiTasks = await fetchTasks(opts.mode);
+    printSuccess(`Fetched ${apiTasks.length} ${opts.mode} tasks`);
+
+    const overrides = effectiveOverrides(opts.mode);
+    printSuccess(`Loaded effective overrides for ${Object.keys(overrides).length} tasks\n`);
+
+    const rows = buildRows(eftTasks, apiTasks, overrides);
+    printReport(rows, opts.mode);
+
+    if (opts.jsonOut) {
+      writeFileSync(opts.jsonOut, JSON.stringify(rows, null, 2));
+      printSuccess(`Wrote ${rows.length} audit rows to ${opts.jsonOut}`);
+    }
+
+    process.exit(0);
+  } catch (error) {
+    printError('Error during three-way audit:', error as Error);
+    process.exit(1);
+  }
+}
+
+function isDirectExecution(): boolean {
+  const entryFile = process.argv[1];
+  if (!entryFile) return false;
+  return import.meta.url === pathToFileURL(entryFile).href;
+}
+
+if (isDirectExecution()) {
+  main();
+}
+
+export { buildRows, classify, effectiveOverrides, type Row, type Verdict };

--- a/scripts/eft-compare.ts
+++ b/scripts/eft-compare.ts
@@ -1,0 +1,539 @@
+#!/usr/bin/env tsx
+/**
+ * Compare a local EFT quest reference file against tarkov.dev API data.
+ *
+ * The reference file is the authoritative source for the *structured / numeric*
+ * quest fields:
+ *   - experience reward
+ *   - minPlayerLevel (Level start condition)
+ *   - objective counts (condition `value`, keyed by condition id == tarkov.dev
+ *     objective id)
+ *
+ * Objective *description wording* is normally synthesized by tarkov.dev / the
+ * wiki. An enriched reference variant (filename contains `rollinglatest.modified`)
+ * additionally embeds a per-quest `localization.en` block that carries the
+ * canonical objective text (keyed by condition id). When present,
+ * `--descriptions` compares that canonical text against tarkov.dev. This is
+ * noisier than the numeric checks (tarkov.dev intentionally rephrases some
+ * objectives) so it is opt-in and best used to audit existing description
+ * overrides rather than as a fix list.
+ *
+ * The reference file is per game-mode, so compare against the matching
+ * tarkov.dev mode.
+ *
+ * Usage:
+ *   tsx scripts/eft-compare.ts [eftDir] [--mode pve|regular] [--descriptions] [--json out.json]
+ *
+ * eftDir defaults to ./eft. The reference file is auto-detected by the
+ * `quest_list` filename fragment (the enriched variant is preferred).
+ */
+
+import { readFileSync, readdirSync, writeFileSync } from 'fs';
+import { join, isAbsolute } from 'path';
+import { pathToFileURL } from 'url';
+import {
+  fetchTasks,
+  findTaskById,
+  printHeader,
+  printProgress,
+  printSuccess,
+  printError,
+  bold,
+  dim,
+  colors,
+  icons,
+  type TaskData,
+  type GameMode,
+} from '../src/lib/index.js';
+
+// ---------------------------------------------------------------------------
+// Reference-file parsing
+// ---------------------------------------------------------------------------
+
+/** Condition types whose `value` is the objective count tarkov.dev exposes. */
+const COUNTABLE_CONDITIONS = new Set([
+  'CounterCreator',
+  'FindItem',
+  'HandoverItem',
+  'LeaveItemAtLocation',
+  'PlaceBeacon',
+  'SellItemToTrader',
+]);
+
+interface EftCondition {
+  id: string;
+  conditionType?: string;
+  value?: unknown;
+  target?: unknown;
+  status?: number[];
+}
+
+interface EftQuest {
+  _id: string;
+  name?: string;
+  conditions?: {
+    AvailableForStart?: EftCondition[];
+    AvailableForFinish?: EftCondition[];
+  };
+  rewards?: { Success?: Array<{ type?: string; value?: unknown }> };
+  /**
+   * Per-language localized strings. Keyed by language code (`en`, `ru`, ...).
+   * Each value maps either `<questId> <suffix>` (name/description/messages) or a
+   * bare `<conditionId>` (objective text) to its localized string. Only present
+   * in the enriched ("rollinglatest.modified") reference variant.
+   */
+  localization?: Record<string, Record<string, string>>;
+}
+
+/** Hex object id, optionally wrapped as `[<id>]` or `[<id> name]` by the
+ * enriched reference variant. */
+const ID_PATTERN = /[0-9a-f]{24}/;
+const HEX_ID_KEY = /^[0-9a-f]{24}$/;
+
+/** Unwrap a possibly-bracketed id (`[60e7... name] Long Line` -> `60e7...`). */
+function unwrapId(value: string): string {
+  const match = ID_PATTERN.exec(value);
+  return match ? match[0] : value;
+}
+
+/** Normalized authoritative values for a single quest from the reference file. */
+interface EftTask {
+  id: string;
+  experience?: number;
+  minPlayerLevel?: number;
+  /** objective id -> required count */
+  counts: Map<string, number>;
+  /** objective (condition) id -> canonical English objective text, when the
+   * reference file carries a `localization.en` block. Empty otherwise. */
+  descriptions: Map<string, string>;
+}
+
+function asNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+/** Locate the quest reference file inside the eft directory. Prefers the
+ * enriched ("rollinglatest.modified") variant since it additionally carries
+ * `localization.en` objective text. */
+function findReferenceFile(eftDir: string): string {
+  const candidates = readdirSync(eftDir).filter(
+    (f) => /quest[_-]list/i.test(f) && f.endsWith('.json'),
+  );
+  if (candidates.length === 0) {
+    throw new Error(`No quest reference file found in ${eftDir}`);
+  }
+  const enriched = candidates.find((f) => f.includes('rollinglatest.modified'));
+  return join(eftDir, enriched ?? candidates[0]);
+}
+
+/** Read the quest array out of the reference-file envelope. */
+function readQuestArray(file: string): EftQuest[] {
+  const raw = JSON.parse(readFileSync(file, 'utf-8')) as unknown;
+  // The reference format is { request, response: { decoded_response: { data: [...] } } }.
+  const decoded = (raw as any)?.response?.decoded_response;
+  const data = decoded?.data ?? (raw as any)?.data ?? raw;
+  if (!Array.isArray(data)) {
+    throw new Error(`Unexpected quest reference shape in ${file}: expected an array of quests`);
+  }
+  return data as EftQuest[];
+}
+
+function parseEftTasks(quests: EftQuest[]): Map<string, EftTask> {
+  const out = new Map<string, EftTask>();
+  for (const q of quests) {
+    if (!q?._id) continue;
+    const id = unwrapId(q._id);
+    const start = q.conditions?.AvailableForStart ?? [];
+    const finish = q.conditions?.AvailableForFinish ?? [];
+
+    const experience = q.rewards?.Success?.filter((r) => r.type === 'Experience')
+      .map((r) => asNumber(r.value))
+      .find((v) => v !== undefined);
+
+    const minPlayerLevel = start
+      .filter((c) => c.conditionType === 'Level')
+      .map((c) => asNumber(c.value))
+      .find((v) => v !== undefined);
+
+    const counts = new Map<string, number>();
+    for (const c of finish) {
+      if (c.conditionType && COUNTABLE_CONDITIONS.has(c.conditionType)) {
+        const v = asNumber(c.value);
+        if (v !== undefined) counts.set(unwrapId(c.id), v);
+      }
+    }
+
+    const descriptions = new Map<string, string>();
+    const en = q.localization?.en;
+    if (en) {
+      for (const [key, value] of Object.entries(en)) {
+        // Bare 24-hex keys are objective (condition) text; `<id> <suffix>`
+        // keys are quest name/description/messages which we don't compare here.
+        if (HEX_ID_KEY.test(key) && typeof value === 'string') {
+          descriptions.set(key, value);
+        }
+      }
+    }
+
+    out.set(id, { id, experience, minPlayerLevel, counts, descriptions });
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Comparison
+// ---------------------------------------------------------------------------
+
+interface Discrepancy {
+  taskId: string;
+  taskName: string;
+  field: string;
+  /** what tarkov.dev currently has */
+  api: string;
+  /** what the reference file says (source of truth) */
+  eft: string;
+}
+
+function compare(
+  eftTasks: Map<string, EftTask>,
+  apiTasks: TaskData[],
+  options: { descriptions?: boolean } = {},
+): {
+  discrepancies: Discrepancy[];
+  matched: number;
+  apiMissing: number;
+} {
+  const discrepancies: Discrepancy[] = [];
+  let matched = 0;
+  let apiMissing = 0;
+
+  for (const eft of eftTasks.values()) {
+    const api = findTaskById(apiTasks, eft.id);
+    if (!api) {
+      apiMissing += 1;
+      continue;
+    }
+    matched += 1;
+    const name = api.name;
+
+    if (eft.experience !== undefined && api.experience !== undefined && eft.experience !== api.experience) {
+      discrepancies.push({
+        taskId: eft.id,
+        taskName: name,
+        field: 'experience',
+        api: String(api.experience),
+        eft: String(eft.experience),
+      });
+    }
+
+    if (
+      eft.minPlayerLevel !== undefined &&
+      api.minPlayerLevel !== undefined &&
+      eft.minPlayerLevel !== api.minPlayerLevel
+    ) {
+      discrepancies.push({
+        taskId: eft.id,
+        taskName: name,
+        field: 'minPlayerLevel',
+        api: String(api.minPlayerLevel),
+        eft: String(eft.minPlayerLevel),
+      });
+    }
+
+    const apiObjectives = new Map((api.objectives ?? []).map((o) => [o.id, o]));
+    for (const [objId, eftCount] of eft.counts) {
+      const obj = apiObjectives.get(objId);
+      if (!obj || typeof obj.count !== 'number') continue;
+      if (obj.count !== eftCount) {
+        discrepancies.push({
+          taskId: eft.id,
+          taskName: name,
+          field: `objective[${objId}].count`,
+          api: String(obj.count),
+          eft: String(eftCount),
+        });
+      }
+    }
+
+    if (options.descriptions) {
+      for (const [objId, eftText] of eft.descriptions) {
+        const obj = apiObjectives.get(objId);
+        if (!obj || typeof obj.description !== 'string') continue;
+        if (normalizeDescription(obj.description) !== normalizeDescription(eftText)) {
+          discrepancies.push({
+            taskId: eft.id,
+            taskName: name,
+            field: `objective[${objId}].description`,
+            api: obj.description,
+            eft: eftText,
+          });
+        }
+      }
+    }
+  }
+
+  return { discrepancies, matched, apiMissing };
+}
+
+/**
+ * Normalize objective text before comparison so we only flag genuine wording
+ * differences, not whitespace / punctuation / case noise.
+ */
+function normalizeDescription(value: string): string {
+  return value
+    .replace(/\s+/g, ' ')
+    .replace(/[. ]+$/g, '')
+    .trim()
+    .toLowerCase();
+}
+
+// ---------------------------------------------------------------------------
+// Override cross-check (against the reference file)
+// ---------------------------------------------------------------------------
+
+/**
+ * The tarkov.dev-only validator can only tell whether an override differs from
+ * the API; it reads "override != API" as "keep the override". That hides the
+ * case where the override itself is wrong. With the reference file as a third,
+ * authoritative source we can classify each objective-level override:
+ *
+ *   MATCHES_REFERENCE   - override equals the reference (a genuine correction)
+ *   CONFLICTS_REFERENCE - override disagrees with the reference (override is wrong)
+ *   NO_REFERENCE_DATA   - reference has no value for this objective (can't judge)
+ */
+export type CrossCheckVerdict = 'MATCHES_REFERENCE' | 'CONFLICTS_REFERENCE' | 'NO_REFERENCE_DATA';
+
+export interface CrossCheckEntry {
+  taskId: string;
+  objectiveId: string;
+  field: 'description' | 'count';
+  verdict: CrossCheckVerdict;
+  override: string;
+  reference?: string;
+}
+
+/** Minimal shape of a task override's objective patch we cross-check. */
+interface OverrideObjectivePatch {
+  description?: unknown;
+  count?: unknown;
+}
+interface OverrideLike {
+  objectives?: Record<string, OverrideObjectivePatch>;
+}
+
+/**
+ * Cross-check objective `description`/`count` overrides against the reference
+ * file. Objectives the reference doesn't cover are reported as
+ * NO_REFERENCE_DATA so callers can surface "can't verify" honestly.
+ */
+export function crossCheckOverrides(
+  overrides: Record<string, OverrideLike>,
+  eftTasks: Map<string, EftTask>,
+): CrossCheckEntry[] {
+  const entries: CrossCheckEntry[] = [];
+
+  for (const [taskId, override] of Object.entries(overrides)) {
+    if (!override?.objectives) continue;
+    const eft = eftTasks.get(taskId);
+
+    for (const [objectiveId, patch] of Object.entries(override.objectives)) {
+      if (typeof patch?.description === 'string') {
+        const reference = eft?.descriptions.get(objectiveId);
+        entries.push({
+          taskId,
+          objectiveId,
+          field: 'description',
+          verdict:
+            reference === undefined
+              ? 'NO_REFERENCE_DATA'
+              : normalizeDescription(reference) === normalizeDescription(patch.description)
+                ? 'MATCHES_REFERENCE'
+                : 'CONFLICTS_REFERENCE',
+          override: patch.description,
+          reference,
+        });
+      }
+
+      if (typeof patch?.count === 'number') {
+        const reference = eft?.counts.get(objectiveId);
+        entries.push({
+          taskId,
+          objectiveId,
+          field: 'count',
+          verdict:
+            reference === undefined
+              ? 'NO_REFERENCE_DATA'
+              : reference === patch.count
+                ? 'MATCHES_REFERENCE'
+                : 'CONFLICTS_REFERENCE',
+          override: String(patch.count),
+          reference: reference === undefined ? undefined : String(reference),
+        });
+      }
+    }
+  }
+
+  return entries;
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+interface Options {
+  eftDir: string;
+  mode: GameMode;
+  jsonOut?: string;
+  descriptions: boolean;
+}
+
+function parseArgs(argv: string[]): Options {
+  let eftDir = 'eft';
+  let mode: GameMode = 'pve';
+  let jsonOut: string | undefined;
+  let descriptions = false;
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--mode') {
+      const value = argv[(i += 1)];
+      if (value !== 'pve' && value !== 'regular') {
+        throw new Error(`--mode must be 'pve' or 'regular', got '${value}'`);
+      }
+      mode = value;
+    } else if (arg === '--json') {
+      jsonOut = argv[(i += 1)];
+    } else if (arg === '--descriptions') {
+      descriptions = true;
+    } else if (!arg.startsWith('--')) {
+      eftDir = arg;
+    }
+  }
+
+  return {
+    eftDir: isAbsolute(eftDir) ? eftDir : join(process.cwd(), eftDir),
+    mode,
+    jsonOut,
+    descriptions,
+  };
+}
+
+function printReport(discrepancies: Discrepancy[], matched: number, apiMissing: number): void {
+  printHeader('REFERENCE vs TARKOV.DEV');
+
+  const isDescription = (d: Discrepancy) => d.field.endsWith('.description');
+  const isCount = (d: Discrepancy) => d.field.endsWith('.count');
+
+  const byField = new Map<string, Discrepancy[]>();
+  for (const d of discrepancies) {
+    const key = isCount(d)
+      ? 'objective.count'
+      : isDescription(d)
+        ? 'objective.description'
+        : d.field;
+    (byField.get(key) ?? byField.set(key, []).get(key)!).push(d);
+  }
+
+  for (const [field, items] of byField) {
+    console.log(bold(`\n${field} (${items.length})`));
+    for (const d of items) {
+      if (field === 'objective.description') {
+        const objId = d.field.replace(/^objective\[(.*)\]\.description$/, '$1');
+        console.log(
+          `  ${icons.warning} ${d.taskName} ${dim(`(${d.taskId})`)} ${dim(objId)}\n` +
+            `     api: ${colors.red}${d.api}${colors.reset}\n` +
+            `     eft: ${colors.green}${d.eft}${colors.reset}`,
+        );
+      } else {
+        console.log(
+          `  ${icons.warning} ${d.taskName} ${dim(`(${d.taskId})`)}\n` +
+            `     api: ${colors.red}${d.api}${colors.reset}  ` +
+            `eft: ${colors.green}${d.eft}${colors.reset}` +
+            (isCount(d) ? `  ${dim(d.field)}` : ''),
+        );
+      }
+    }
+  }
+
+  printHeader('SUMMARY');
+  console.log(`  Matched tasks (reference ∩ api): ${matched}`);
+  console.log(`  In reference but not in api:     ${apiMissing}`);
+  console.log(`  Discrepancies:              ${bold(String(discrepancies.length))}`);
+  console.log();
+}
+
+async function main(): Promise<void> {
+  try {
+    const opts = parseArgs(process.argv.slice(2));
+
+    printProgress(`Parsing quest reference file from ${opts.eftDir}...`);
+    const refFile = findReferenceFile(opts.eftDir);
+    const eftTasks = parseEftTasks(readQuestArray(refFile));
+    printSuccess(`Parsed ${eftTasks.size} quests from reference file`);
+
+    printProgress(`Fetching ${opts.mode} tasks from tarkov.dev...`);
+    const apiTasks = await fetchTasks(opts.mode);
+    printSuccess(`Fetched ${apiTasks.length} ${opts.mode} tasks from API\n`);
+
+    const { discrepancies, matched, apiMissing } = compare(eftTasks, apiTasks, {
+      descriptions: opts.descriptions,
+    });
+    printReport(discrepancies, matched, apiMissing);
+
+    if (opts.jsonOut) {
+      writeFileSync(opts.jsonOut, JSON.stringify(discrepancies, null, 2));
+      printSuccess(`Wrote ${discrepancies.length} discrepancies to ${opts.jsonOut}`);
+    }
+
+    process.exit(0);
+  } catch (error) {
+    printError('Error during EFT comparison:', error as Error);
+    process.exit(1);
+  }
+}
+
+function isDirectExecution(): boolean {
+  const entryFile = process.argv[1];
+  if (!entryFile) return false;
+  return import.meta.url === pathToFileURL(entryFile).href;
+}
+
+if (isDirectExecution()) {
+  main();
+}
+
+/**
+ * Convenience loader: find the quest reference file in `eftDir`, parse it, and
+ * return the normalized task map. Returns null when no reference file is present
+ * so callers can skip the cross-check cleanly instead of throwing.
+ */
+export function loadEftTasks(eftDir: string): Map<string, EftTask> | null {
+  let refFile: string;
+  try {
+    refFile = findReferenceFile(eftDir);
+  } catch {
+    return null;
+  }
+  return parseEftTasks(readQuestArray(refFile));
+}
+
+/**
+ * Detect which game mode a reference file represents from its request URL
+ * metadata. Returns null when no reference file is present or the mode can't be
+ * determined, so callers can decide how strict to be.
+ */
+export function detectReferenceMode(eftDir: string): GameMode | null {
+  let refFile: string;
+  try {
+    refFile = findReferenceFile(eftDir);
+  } catch {
+    return null;
+  }
+  const raw = JSON.parse(readFileSync(refFile, 'utf-8')) as any;
+  const url: string = raw?.request?.url ?? '';
+  if (url.includes('gw-pve')) return 'pve';
+  if (url.includes('gw-pvp')) return 'regular';
+  return null;
+}
+
+export { parseEftTasks, compare, readQuestArray, type EftTask, type Discrepancy };

--- a/scripts/eft-normalize.ts
+++ b/scripts/eft-normalize.ts
@@ -1,0 +1,410 @@
+#!/usr/bin/env tsx
+/**
+ * Normalize a raw EFT quest reference file into clean, minimal local files.
+ *
+ * The raw reference is a deeply nested response envelope full of fields
+ * irrelevant to data validation (mail settings, UI flags, raw reward item
+ * trees, per-language localization, etc). This script distills it into one tidy
+ * `quests.json` keyed by tarkov.dev-compatible quest id, keeping only the
+ * fields useful for cross-checking the overlay:
+ *
+ *   id, name, trader, map, type, side, flags, minPlayerLevel, experience,
+ *   prerequisite quests, and objectives (id, type, text, count).
+ *
+ * The enriched reference variant (`rollinglatest.modified`) inlines names as
+ * `[id] Name` and embeds a `localization.en` block; this script handles both
+ * the enriched and plain variants, preferring the enriched one.
+ *
+ * IMPORTANT: input reference files and this normalized output are LOCAL-ONLY.
+ * Both `eft/` and the default output dir are gitignored. Nothing here should be
+ * committed.
+ *
+ * Usage:
+ *   tsx scripts/eft-normalize.ts [eftDir] [--out data/eft] [--lang ru,fr,all]
+ *
+ * eftDir defaults to ./eft; output defaults to ./data/eft (both gitignored).
+ * --lang attaches localized quest names + objective text for the given
+ * language codes (comma-separated, or `all`). Codes are normalized to BCP47
+ * (the source's `ge`->`de`, `ch`->`zh`, etc). English is always the base.
+ */
+
+import { readFileSync, readdirSync, writeFileSync, mkdirSync } from 'fs';
+import { join, isAbsolute } from 'path';
+import { pathToFileURL } from 'url';
+import { printProgress, printSuccess, printError } from '../src/lib/index.js';
+
+/** Quest prereq status codes. */
+const STATUS_NAMES: Record<number, string> = {
+  2: 'started',
+  4: 'complete',
+  5: 'fail',
+};
+
+/**
+ * Map the source's localization language codes to standard BCP47 codes.
+ * The source uses a few nonstandard codes (`ge` for German, `ch` for Chinese,
+ * `po` for Portuguese, `kr` for Korean, etc). Codes not listed pass through
+ * unchanged.
+ */
+const LANG_CODE_MAP: Record<string, string> = {
+  ge: 'de', // German
+  ch: 'zh', // Chinese
+  cz: 'cs', // Czech
+  po: 'pt', // Portuguese
+  kr: 'ko', // Korean
+  jp: 'ja', // Japanese
+  in: 'id', // Indonesian
+  tu: 'tr', // Turkish
+  vi: 'vi', // Vietnamese
+  'es-mx': 'es-MX',
+};
+
+/** Normalize a source language code to BCP47. */
+function toBcp47(code: string): string {
+  return LANG_CODE_MAP[code] ?? code;
+}
+
+/** Finish-condition types that carry a player-facing objective with text. */
+const OBJECTIVE_CONDITIONS = new Set([
+  'CounterCreator',
+  'FindItem',
+  'HandoverItem',
+  'LeaveItemAtLocation',
+  'PlaceBeacon',
+  'SellItemToTrader',
+  'WeaponAssembly',
+  'Skill',
+  'TraderLoyalty',
+  'TraderStanding',
+  'LocationTrigger',
+  'VisitPlace',
+  'HasItem',
+  'CompletableItem',
+  'Quest',
+]);
+
+const ID_PATTERN = /[0-9a-f]{24}/;
+
+/** Extract a bare 24-hex id from a value that may be wrapped as `[id] Name`. */
+function bareId(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const match = ID_PATTERN.exec(value);
+  return match ? match[0] : undefined;
+}
+
+/** Strip a leading `[id] ` / `[id name] ` wrapper, returning just the label. */
+function inlineLabel(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const stripped = value.replace(/^\[[^\]]*\]\s*/, '').trim();
+  return stripped.length > 0 ? stripped : undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+interface CleanRef {
+  id?: string;
+  name?: string;
+}
+
+interface CleanObjective {
+  id: string;
+  type: string;
+  description?: string;
+  count?: number;
+  /** Localized objective text, keyed by BCP47 language code. Only present when
+   * languages are requested via --lang. */
+  locale?: Record<string, string>;
+}
+
+interface CleanQuestRequirement {
+  id?: string;
+  status?: string[];
+}
+
+interface CleanQuest {
+  id: string;
+  name?: string;
+  /** Localized quest name, keyed by BCP47 language code. Only present when
+   * languages are requested via --lang. */
+  nameLocale?: Record<string, string>;
+  type?: string;
+  side?: string;
+  trader?: CleanRef;
+  map?: CleanRef;
+  minPlayerLevel?: number;
+  experience?: number;
+  isKey?: boolean;
+  restartable?: boolean;
+  secretQuest?: boolean;
+  isStoryQuest?: boolean;
+  requires?: CleanQuestRequirement[];
+  objectives: CleanObjective[];
+}
+
+interface NormalizedOutput {
+  $meta: {
+    source: string;
+    mode: 'pve' | 'regular' | 'unknown';
+    appVersion?: string;
+    capturedAt?: string;
+    generated: string;
+    questCount: number;
+    /** BCP47 language codes included beyond English, when --lang is used. */
+    languages?: string[];
+  };
+  quests: Record<string, CleanQuest>;
+}
+
+/** Pull the quest array out of the reference-file envelope. */
+function readEnvelope(file: string): {
+  quests: Record<string, unknown>[];
+  url?: string;
+  appVersion?: string;
+  capturedAt?: string;
+} {
+  const raw = JSON.parse(readFileSync(file, 'utf-8')) as any;
+  const decoded = raw?.response?.decoded_response;
+  const data = decoded?.data ?? raw?.data ?? raw;
+  if (!Array.isArray(data)) {
+    throw new Error(`Unexpected quest reference shape in ${file}: expected an array of quests`);
+  }
+  return {
+    quests: data as Record<string, unknown>[],
+    url: raw?.request?.url,
+    appVersion: raw?.request?.headers?.['App-Version'],
+    capturedAt: raw?.request?.timestamp,
+  };
+}
+
+function normalizeStatus(status: unknown): string[] | undefined {
+  if (!Array.isArray(status) || status.length === 0) return undefined;
+  const names = status
+    .map((s) => STATUS_NAMES[Number(s)] ?? String(s))
+    .filter((s, i, arr) => arr.indexOf(s) === i);
+  return names.length > 0 ? names : undefined;
+}
+
+function normalizeQuest(raw: Record<string, any>, langs: string[] = []): CleanQuest | undefined {
+  const id = bareId(raw._id);
+  if (!id) return undefined;
+
+  const localization: Record<string, Record<string, string>> = raw.localization ?? {};
+  const en: Record<string, string> = localization.en ?? {};
+  const start: any[] = raw.conditions?.AvailableForStart ?? [];
+  const finish: any[] = raw.conditions?.AvailableForFinish ?? [];
+
+  // Only request languages the reference actually carries for this quest.
+  const extraLangs = langs.filter((lg) => lg !== 'en' && localization[lg]);
+
+  // name: prefer inline label, fall back to localized `<id> name`.
+  const name = inlineLabel(raw.name) ?? en[`${id} name`];
+  const nameLocale: Record<string, string> = {};
+  for (const lg of extraLangs) {
+    const localizedName = localization[lg]?.[`${id} name`];
+    if (typeof localizedName === 'string' && localizedName.trim()) {
+      nameLocale[toBcp47(lg)] = localizedName;
+    }
+  }
+
+  const minPlayerLevel = start
+    .filter((c) => c?.conditionType === 'Level')
+    .map((c) => asNumber(c.value))
+    .find((v) => v !== undefined);
+
+  const experience = (raw.rewards?.Success ?? [])
+    .filter((r: any) => r?.type === 'Experience')
+    .map((r: any) => asNumber(r.value))
+    .find((v: number | undefined) => v !== undefined);
+
+  const requires: CleanQuestRequirement[] = start
+    .filter((c) => c?.conditionType === 'Quest')
+    .map((c): CleanQuestRequirement | undefined => {
+      const reqId = bareId(c.target);
+      if (!reqId) return undefined;
+      const status = normalizeStatus(c.status);
+      return status ? { id: reqId, status } : { id: reqId };
+    })
+    .filter((r): r is CleanQuestRequirement => Boolean(r));
+
+  const objectives: CleanObjective[] = finish
+    .filter((c) => c?.conditionType && OBJECTIVE_CONDITIONS.has(c.conditionType))
+    .map((c) => {
+      const oid = bareId(c.id);
+      if (!oid) return undefined;
+      const obj: CleanObjective = { id: oid, type: c.conditionType };
+      const text = en[oid];
+      if (typeof text === 'string') obj.description = text;
+      const count = asNumber(c.value);
+      if (count !== undefined) obj.count = count;
+      const locale: Record<string, string> = {};
+      for (const lg of extraLangs) {
+        const localized = localization[lg]?.[oid];
+        if (typeof localized === 'string' && localized.trim()) {
+          locale[toBcp47(lg)] = localized;
+        }
+      }
+      if (Object.keys(locale).length > 0) obj.locale = locale;
+      return obj;
+    })
+    .filter((o): o is CleanObjective => Boolean(o));
+
+  const trader: CleanRef = {
+    id: bareId(raw.traderId),
+    name: inlineLabel(raw.traderId),
+  };
+  const map: CleanRef = {
+    id: bareId(raw.location),
+    name: inlineLabel(raw.location),
+  };
+
+  const quest: CleanQuest = { id, objectives };
+  if (name) quest.name = name;
+  if (Object.keys(nameLocale).length > 0) quest.nameLocale = nameLocale;
+  if (typeof raw.type === 'string') quest.type = raw.type;
+  const side = inlineLabel(raw.side);
+  if (side) quest.side = side;
+  if (trader.id || trader.name) quest.trader = compactRef(trader);
+  if (map.id || map.name) quest.map = compactRef(map);
+  if (minPlayerLevel !== undefined) quest.minPlayerLevel = minPlayerLevel;
+  if (experience !== undefined) quest.experience = experience;
+  if (raw.isKey === true) quest.isKey = true;
+  if (raw.restartable === true) quest.restartable = true;
+  if (raw.secretQuest === true) quest.secretQuest = true;
+  if (raw.isStoryQuest === true) quest.isStoryQuest = true;
+  if (requires.length > 0) quest.requires = requires;
+
+  return quest;
+}
+
+function compactRef(ref: CleanRef): CleanRef {
+  const out: CleanRef = {};
+  if (ref.id) out.id = ref.id;
+  if (ref.name) out.name = ref.name;
+  return out;
+}
+
+/** Locate the quest reference file, preferring the enriched variant. */
+function findReferenceFile(eftDir: string): string {
+  const candidates = readdirSync(eftDir).filter(
+    (f) => /quest[_-]list/i.test(f) && f.endsWith('.json'),
+  );
+  if (candidates.length === 0) {
+    throw new Error(`No quest reference file found in ${eftDir}`);
+  }
+  const enriched = candidates.find((f) => f.includes('rollinglatest.modified'));
+  return join(eftDir, enriched ?? candidates[0]);
+}
+
+function detectMode(url?: string): 'pve' | 'regular' | 'unknown' {
+  if (!url) return 'unknown';
+  if (url.includes('gw-pve')) return 'pve';
+  if (url.includes('gw-pvp')) return 'regular';
+  return 'unknown';
+}
+
+/** Collect the set of language codes present across all quests. */
+function collectLanguages(rawQuests: Record<string, unknown>[]): string[] {
+  const langs = new Set<string>();
+  for (const raw of rawQuests) {
+    const loc = (raw as any)?.localization;
+    if (loc && typeof loc === 'object') {
+      for (const lg of Object.keys(loc)) langs.add(lg);
+    }
+  }
+  return [...langs];
+}
+
+export function normalizeQuestData(file: string, langs: string[] = []): NormalizedOutput {
+  const { quests: rawQuests, url, appVersion, capturedAt } = readEnvelope(file);
+
+  // 'all' expands to every language the reference carries (minus English, the base).
+  const available = collectLanguages(rawQuests).filter((lg) => lg !== 'en');
+  const requested = langs.includes('all')
+    ? available
+    : langs.filter((lg) => lg !== 'en' && available.includes(lg));
+
+  const quests: Record<string, CleanQuest> = {};
+  for (const raw of rawQuests) {
+    const clean = normalizeQuest(raw as Record<string, any>, requested);
+    if (clean) quests[clean.id] = clean;
+  }
+
+  const includedLanguages = [...new Set(requested.map(toBcp47))].sort();
+
+  return {
+    $meta: {
+      source: 'eft-quest-reference',
+      mode: detectMode(url),
+      appVersion,
+      capturedAt,
+      generated: new Date().toISOString(),
+      questCount: Object.keys(quests).length,
+      ...(includedLanguages.length > 0 ? { languages: includedLanguages } : {}),
+    },
+    quests,
+  };
+}
+
+interface Options {
+  eftDir: string;
+  outDir: string;
+  langs: string[];
+}
+
+function parseArgs(argv: string[]): Options {
+  let eftDir = 'eft';
+  let outDir = 'data/eft';
+  let langs: string[] = [];
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--out') outDir = argv[(i += 1)];
+    else if (arg === '--lang') {
+      langs = (argv[(i += 1)] ?? '')
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean);
+    } else if (!arg.startsWith('--')) eftDir = arg;
+  }
+  const resolve = (p: string) => (isAbsolute(p) ? p : join(process.cwd(), p));
+  return { eftDir: resolve(eftDir), outDir: resolve(outDir), langs };
+}
+
+async function main(): Promise<void> {
+  try {
+    const opts = parseArgs(process.argv.slice(2));
+
+    printProgress(`Reading quest reference file from ${opts.eftDir}...`);
+    const refFile = findReferenceFile(opts.eftDir);
+    const output = normalizeQuestData(refFile, opts.langs);
+    const langNote = output.$meta.languages?.length
+      ? ` + ${output.$meta.languages.length} language(s)`
+      : '';
+    printSuccess(
+      `Normalized ${output.$meta.questCount} quests (mode: ${output.$meta.mode})${langNote}`
+    );
+
+    mkdirSync(opts.outDir, { recursive: true });
+    const outFile = join(opts.outDir, `quests.${output.$meta.mode}.json`);
+    writeFileSync(outFile, `${JSON.stringify(output, null, 2)}\n`);
+    printSuccess(`Wrote ${outFile}`);
+
+    process.exit(0);
+  } catch (error) {
+    printError('Error normalizing quest reference file:', error as Error);
+    process.exit(1);
+  }
+}
+
+function isDirectExecution(): boolean {
+  const entryFile = process.argv[1];
+  if (!entryFile) return false;
+  return import.meta.url === pathToFileURL(entryFile).href;
+}
+
+if (isDirectExecution()) {
+  main();
+}
+
+export type { CleanQuest, CleanObjective, NormalizedOutput };

--- a/scripts/eft-wiki-crosscheck.ts
+++ b/scripts/eft-wiki-crosscheck.ts
@@ -1,0 +1,271 @@
+#!/usr/bin/env tsx
+/**
+ * Cross-reference reference-vs-tarkov.dev discrepancies against the EFT wiki.
+ *
+ * `eft:compare` already finds where the local quest reference file (authoritative
+ * for numeric quest fields) disagrees with the tarkov.dev API. For each such
+ * discrepancy this script pulls the matching wiki page and shows what the wiki
+ * says, so you can see whether the wiki backs the reference (eft), the API, or
+ * neither. The wiki is largely PVP/regular data, so a wiki match against a PVE
+ * reference value is not guaranteed — that's exactly what we're checking.
+ *
+ * Only the two fields the wiki exposes cleanly are cross-checked:
+ *   - minPlayerLevel (wiki "Requirements" level line)
+ *   - experience     (wiki "Rewards" EXP line)
+ *
+ * Usage:
+ *   tsx scripts/eft-wiki-crosscheck.ts [eftDir] [--mode pve|regular] [--json out.json]
+ *
+ * eftDir defaults to ./eft. Reuses the wiki fetch/parse from wiki-compare and
+ * the reference parser from eft-compare; both are pure imports here.
+ */
+
+import { writeFileSync } from 'fs';
+import { isAbsolute, join } from 'path';
+import { pathToFileURL } from 'url';
+
+import {
+  fetchTasks,
+  findTaskById,
+  printHeader,
+  printProgress,
+  printSuccess,
+  printError,
+  bold,
+  dim,
+  colors,
+  icons,
+  type GameMode,
+  type TaskData,
+} from '../src/lib/index.js';
+import { loadEftTasks, type EftTask } from './eft-compare.js';
+import { parseWikiTask, buildMapAliasMap } from './wiki-compare.js';
+
+const WIKI_API = 'https://escapefromtarkov.fandom.com/api.php';
+const RATE_LIMIT_MS = 500;
+
+type Field = 'minPlayerLevel' | 'experience';
+
+interface Row {
+  taskId: string;
+  taskName: string;
+  field: Field;
+  api: number | undefined;
+  eft: number;
+  wiki: number | undefined;
+  /** which source(s) the wiki value agrees with */
+  wikiAgreesWith: 'eft' | 'api' | 'both' | 'neither' | 'no-wiki-value';
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** tarkov.dev wikiLink -> wiki page title. */
+function wikiTitleFor(task: TaskData): string {
+  if (task.wikiLink) {
+    const match = task.wikiLink.match(/\/wiki\/(.+)$/);
+    if (match?.[1]) return decodeURIComponent(match[1]);
+  }
+  return task.name;
+}
+
+async function fetchWikitext(title: string): Promise<string | undefined> {
+  const params = new URLSearchParams({
+    action: 'parse',
+    page: title,
+    prop: 'wikitext',
+    format: 'json',
+  });
+  const res = await fetch(`${WIKI_API}?${params.toString()}`);
+  if (!res.ok) return undefined;
+  const data = (await res.json()) as {
+    parse?: { wikitext?: { '*': string } };
+    error?: unknown;
+  };
+  return data.parse?.wikitext?.['*'];
+}
+
+/** Build the discrepant (field, eft, api) rows the same way eft:compare does. */
+function buildDiscrepancies(
+  eftTasks: Map<string, EftTask>,
+  apiTasks: TaskData[],
+): Array<{ task: TaskData; field: Field; api: number; eft: number }> {
+  const out: Array<{ task: TaskData; field: Field; api: number; eft: number }> = [];
+  for (const eft of eftTasks.values()) {
+    const api = findTaskById(apiTasks, eft.id);
+    if (!api) continue;
+    if (
+      eft.experience !== undefined &&
+      api.experience !== undefined &&
+      eft.experience !== api.experience
+    ) {
+      out.push({ task: api, field: 'experience', api: api.experience, eft: eft.experience });
+    }
+    if (
+      eft.minPlayerLevel !== undefined &&
+      api.minPlayerLevel !== undefined &&
+      eft.minPlayerLevel !== api.minPlayerLevel
+    ) {
+      out.push({
+        task: api,
+        field: 'minPlayerLevel',
+        api: api.minPlayerLevel,
+        eft: eft.minPlayerLevel,
+      });
+    }
+  }
+  return out;
+}
+
+function agreement(
+  api: number | undefined,
+  eft: number,
+  wiki: number | undefined,
+): Row['wikiAgreesWith'] {
+  if (wiki === undefined) return 'no-wiki-value';
+  const matchesEft = wiki === eft;
+  const matchesApi = api !== undefined && wiki === api;
+  if (matchesEft && matchesApi) return 'both';
+  if (matchesEft) return 'eft';
+  if (matchesApi) return 'api';
+  return 'neither';
+}
+
+interface Options {
+  eftDir: string;
+  mode: GameMode;
+  jsonOut?: string;
+}
+
+function parseArgs(argv: string[]): Options {
+  let eftDir = 'eft';
+  let mode: GameMode = 'pve';
+  let jsonOut: string | undefined;
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--mode') {
+      const v = argv[(i += 1)];
+      if (v !== 'pve' && v !== 'regular') throw new Error(`--mode must be 'pve' or 'regular'`);
+      mode = v;
+    } else if (arg === '--json') {
+      jsonOut = argv[(i += 1)];
+    } else if (!arg.startsWith('--')) {
+      eftDir = arg;
+    }
+  }
+  return { eftDir: isAbsolute(eftDir) ? eftDir : join(process.cwd(), eftDir), mode, jsonOut };
+}
+
+function colorFor(verdict: Row['wikiAgreesWith']): string {
+  switch (verdict) {
+    case 'eft':
+      return colors.green;
+    case 'api':
+      return colors.red;
+    case 'both':
+      return colors.cyan;
+    default:
+      return colors.yellow;
+  }
+}
+
+function printReport(rows: Row[]): void {
+  printHeader('REFERENCE vs TARKOV.DEV — WIKI CROSS-CHECK');
+
+  const byField = new Map<Field, Row[]>();
+  for (const r of rows) (byField.get(r.field) ?? byField.set(r.field, []).get(r.field)!).push(r);
+
+  for (const [field, items] of byField) {
+    console.log(bold(`\n${field} (${items.length})`));
+    for (const r of items) {
+      const wikiStr =
+        r.wiki === undefined ? dim('(no wiki value)') : `${colorFor(r.wikiAgreesWith)}${r.wiki}${colors.reset}`;
+      console.log(
+        `  ${icons.warning} ${r.taskName} ${dim(`(${r.taskId})`)}\n` +
+          `     api: ${colors.red}${r.api}${colors.reset}  ` +
+          `eft: ${colors.green}${r.eft}${colors.reset}  ` +
+          `wiki: ${wikiStr}  ${dim(`→ wiki backs ${r.wikiAgreesWith}`)}`,
+      );
+    }
+  }
+
+  const tally = (v: Row['wikiAgreesWith']) => rows.filter((r) => r.wikiAgreesWith === v).length;
+  printHeader('SUMMARY');
+  console.log(`  Discrepancies cross-checked: ${rows.length}`);
+  console.log(`  Wiki backs reference:        ${bold(String(tally('eft')))}`);
+  console.log(`  Wiki backs tarkov.dev API:   ${bold(String(tally('api')))}`);
+  console.log(`  Wiki agrees with both:       ${tally('both')} ${dim('(api==eft, not a real conflict)')}`);
+  console.log(`  Wiki agrees with neither:    ${tally('neither')}`);
+  console.log(`  No usable wiki value:        ${tally('no-wiki-value')}`);
+  console.log();
+}
+
+async function main(): Promise<void> {
+  try {
+    const opts = parseArgs(process.argv.slice(2));
+
+    printProgress(`Parsing quest reference file from ${opts.eftDir}...`);
+    const eftTasks = loadEftTasks(opts.eftDir);
+    if (!eftTasks) throw new Error(`No quest reference file found in ${opts.eftDir}`);
+    printSuccess(`Parsed ${eftTasks.size} quests from reference file`);
+
+    printProgress(`Fetching ${opts.mode} tasks from tarkov.dev...`);
+    const apiTasks = await fetchTasks(opts.mode);
+    printSuccess(`Fetched ${apiTasks.length} ${opts.mode} tasks from API`);
+
+    const discrepancies = buildDiscrepancies(eftTasks, apiTasks);
+    printSuccess(`Found ${discrepancies.length} numeric discrepancies to cross-check\n`);
+
+    // One wiki page per task (a task may have both fields discrepant); cache by id.
+    const mapAliasMap = buildMapAliasMap([]);
+    const wikitextCache = new Map<string, string | undefined>();
+    const rows: Row[] = [];
+
+    for (const d of discrepancies) {
+      const title = wikiTitleFor(d.task);
+      if (!wikitextCache.has(d.task.id)) {
+        printProgress(`Fetching wiki: ${title}...`);
+        wikitextCache.set(d.task.id, await fetchWikitext(title));
+        await sleep(RATE_LIMIT_MS);
+      }
+      const wikitext = wikitextCache.get(d.task.id);
+      let wiki: number | undefined;
+      if (wikitext) {
+        const parsed = parseWikiTask(title, wikitext, mapAliasMap);
+        wiki = d.field === 'minPlayerLevel' ? parsed.minPlayerLevel : parsed.rewards.xp;
+      }
+      rows.push({
+        taskId: d.task.id,
+        taskName: d.task.name,
+        field: d.field,
+        api: d.api,
+        eft: d.eft,
+        wiki,
+        wikiAgreesWith: agreement(d.api, d.eft, wiki),
+      });
+    }
+
+    printReport(rows);
+
+    if (opts.jsonOut) {
+      writeFileSync(opts.jsonOut, JSON.stringify(rows, null, 2));
+      printSuccess(`Wrote ${rows.length} cross-checked rows to ${opts.jsonOut}`);
+    }
+
+    process.exit(0);
+  } catch (error) {
+    printError('Error during EFT/wiki cross-check:', error as Error);
+    process.exit(1);
+  }
+}
+
+function isDirectExecution(): boolean {
+  const entryFile = process.argv[1];
+  if (!entryFile) return false;
+  return import.meta.url === pathToFileURL(entryFile).href;
+}
+
+if (isDirectExecution()) {
+  main();
+}

--- a/src/overrides/tasks.json5
+++ b/src/overrides/tasks.json5
@@ -84,16 +84,22 @@
     },
   },
 
-  // Small Business - Part 3 - objectives description were swapped incorrectly
-  // Proof: https://escapefromtarkov.fandom.com/wiki/Small_Business_-_Part_3
-  // Verified by TT map and Wiki review.
+  // Small Business - Part 3 - in-game localization bug: the two Woods objective
+  // texts are swapped relative to their actual map markers. The marker positions
+  // (zoneId -> coordinates) are CORRECT in the game data; only the description
+  // text BSG attached to each objective is wrong, and tarkov.dev mirrors it.
+  //   obj 666733e5... zoneId place_peacemaker_007_2_N2   -> marker at the Sawmill
+  //   obj 666733e7... zoneId place_peacemaker_007_2_N2_1 -> marker at the river/Sunken Village
+  // Fix = swap ONLY the description text so each names the place its marker sits.
+  // Do NOT "correct" this back against the raw game/API text: the game text is the bug.
+  // Proof: in-game map markers (verified on tarkov.dev interactive map) + Wiki.
   '66631493312343839d032d22': {
     objectives: {
       '666733e565831d5bafa18bbb': {
-        description: 'Stash a Cultist knife at the sawmill marked circle on Woods', // Was: Stash a Cultist knife at the river village marked circle on Woods
+        description: 'Stash a Cultist knife at the sawmill marked circle on Woods', // marker is at the Sawmill. Was (game): "...at the river village..."
       },
       '666733e7430c8972d6a5f438': {
-        description: 'Stash a Cultist knife at the river village marked circle on Woods', // Was: Stash a Cultist knife at the sawmill marked circle on Woods
+        description: 'Stash a Cultist knife at the river village marked circle on Woods', // marker is at the river/Sunken Village. Was (game): "...at the sawmill..."
       },
     },
   },

--- a/tests/eft-audit.test.ts
+++ b/tests/eft-audit.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+import { classify, buildRows } from '../scripts/eft-audit.js';
+import { parseEftTasks, type EftTask } from '../scripts/eft-compare.js';
+import type { TaskData, TaskOverride } from '../src/lib/index.js';
+
+describe('eft-audit classify (reference -> api -> override)', () => {
+  const REFERENCE = 10;
+
+  it('GAP: api wrong, no override', () => {
+    expect(classify(REFERENCE, 20, undefined)).toBe('GAP');
+  });
+
+  it('OK: api wrong, override matches client', () => {
+    expect(classify(REFERENCE, 20, 10)).toBe('OK');
+  });
+
+  it('STALE: override present but api now equals client', () => {
+    expect(classify(REFERENCE, 10, 10)).toBe('STALE');
+  });
+
+  it('CONFLICT: override disagrees with client', () => {
+    expect(classify(REFERENCE, 20, 15)).toBe('CONFLICT');
+  });
+
+  it('null (nothing to do): api correct, no override', () => {
+    expect(classify(REFERENCE, 10, undefined)).toBeNull();
+  });
+
+  it('null: api value unknown and no override (cannot judge a gap)', () => {
+    expect(classify(REFERENCE, undefined, undefined)).toBeNull();
+  });
+
+  it('CONFLICT even when api is missing, if override != client', () => {
+    expect(classify(REFERENCE, undefined, 15)).toBe('CONFLICT');
+  });
+});
+
+describe('eft-audit buildRows', () => {
+  // Reference (authoritative): level 10, xp 7500, objective count 36.
+  const quests = [
+    {
+      _id: 'aaaaaaaaaaaaaaaaaaaaaaaa',
+      name: 'aaaaaaaaaaaaaaaaaaaaaaaa name',
+      rewards: { Success: [{ type: 'Experience', value: 7500 }] },
+      conditions: {
+        AvailableForStart: [{ id: 'lvl', conditionType: 'Level', value: 10 }],
+        AvailableForFinish: [
+          { id: 'bbbbbbbbbbbbbbbbbbbbbbbb', conditionType: 'CounterCreator', value: 36 },
+        ],
+      },
+    },
+  ];
+  const eft: Map<string, EftTask> = parseEftTasks(quests as never);
+
+  const apiTask = (over: Partial<TaskData>): TaskData => ({
+    id: 'aaaaaaaaaaaaaaaaaaaaaaaa',
+    name: 'Test Task',
+    ...over,
+  });
+
+  it('flags a GAP when api is wrong and no override exists', () => {
+    const rows = buildRows(eft, [apiTask({ minPlayerLevel: 20, experience: 7500 })], {});
+    const gap = rows.find((r) => r.field === 'minPlayerLevel')!;
+    expect(gap.verdict).toBe('GAP');
+    expect(gap.reference).toBe(10);
+    expect(gap.api).toBe(20);
+    expect(gap.override).toBeUndefined();
+  });
+
+  it('flags OK when override corrects a still-wrong api value', () => {
+    const overrides: Record<string, TaskOverride> = {
+      aaaaaaaaaaaaaaaaaaaaaaaa: { minPlayerLevel: 10 },
+    };
+    const rows = buildRows(eft, [apiTask({ minPlayerLevel: 20, experience: 7500 })], overrides);
+    const ok = rows.find((r) => r.field === 'minPlayerLevel')!;
+    expect(ok.verdict).toBe('OK');
+    expect(ok.override).toBe(10);
+  });
+
+  it('flags STALE when api caught up but override is still present', () => {
+    const overrides: Record<string, TaskOverride> = {
+      aaaaaaaaaaaaaaaaaaaaaaaa: { experience: 7500 },
+    };
+    const rows = buildRows(eft, [apiTask({ minPlayerLevel: 10, experience: 7500 })], overrides);
+    const stale = rows.find((r) => r.field === 'experience')!;
+    expect(stale.verdict).toBe('STALE');
+  });
+
+  it('flags CONFLICT on an objective count override that disagrees with the client', () => {
+    const overrides: Record<string, TaskOverride> = {
+      aaaaaaaaaaaaaaaaaaaaaaaa: {
+        objectives: { bbbbbbbbbbbbbbbbbbbbbbbb: { count: 24 } },
+      },
+    };
+    const rows = buildRows(
+      eft,
+      [
+        apiTask({
+          minPlayerLevel: 10,
+          experience: 7500,
+          objectives: [{ id: 'bbbbbbbbbbbbbbbbbbbbbbbb', count: 36 }],
+        }),
+      ],
+      overrides,
+    );
+    const conflict = rows.find((r) => r.field.startsWith('objective['))!;
+    expect(conflict.verdict).toBe('CONFLICT');
+    expect(conflict.reference).toBe(36);
+    expect(conflict.override).toBe(24);
+  });
+
+  it('emits nothing when all three sources already agree', () => {
+    const rows = buildRows(eft, [apiTask({ minPlayerLevel: 10, experience: 7500 })], {});
+    expect(rows).toHaveLength(0);
+  });
+
+  it('skips tasks absent from the chosen api mode', () => {
+    const rows = buildRows(eft, [apiTask({ id: 'cccccccccccccccccccccccc' })], {});
+    expect(rows).toHaveLength(0);
+  });
+});

--- a/tests/eft-compare.test.ts
+++ b/tests/eft-compare.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+import { parseEftTasks, compare, crossCheckOverrides } from '../scripts/eft-compare.js';
+import type { TaskData } from '../src/lib/index.js';
+
+describe('eft-compare', () => {
+  const quests = [
+    {
+      _id: 'task1',
+      name: 'task1 name',
+      rewards: { Success: [{ type: 'Experience', value: 13000 }] },
+      conditions: {
+        AvailableForStart: [{ id: 'l1', conditionType: 'Level', value: 23 }],
+        AvailableForFinish: [{ id: 'obj1', conditionType: 'CounterCreator', value: 7 }],
+      },
+    },
+  ];
+
+  it('parses authoritative numeric fields from the reference file', () => {
+    const parsed = parseEftTasks(quests as never);
+    const t = parsed.get('task1')!;
+    expect(t.experience).toBe(13000);
+    expect(t.minPlayerLevel).toBe(23);
+    expect(t.counts.get('obj1')).toBe(7);
+  });
+
+  it('flags experience, minPlayerLevel and objective count discrepancies', () => {
+    const eft = parseEftTasks(quests as never);
+    const api: TaskData[] = [
+      {
+        id: 'task1',
+        name: 'Task One',
+        experience: 8500, // wrong upstream
+        minPlayerLevel: 24, // wrong upstream
+        objectives: [{ id: 'obj1', count: 5 }], // wrong upstream
+      },
+    ];
+    const { discrepancies, matched } = compare(eft, api);
+    expect(matched).toBe(1);
+    const fields = discrepancies.map((d) => d.field.replace(/\[.*\]/, '[]'));
+    expect(fields).toContain('experience');
+    expect(fields).toContain('minPlayerLevel');
+    expect(fields).toContain('objective[].count');
+    const exp = discrepancies.find((d) => d.field === 'experience')!;
+    expect(exp.api).toBe('8500');
+    expect(exp.eft).toBe('13000');
+  });
+
+  it('reports no discrepancies when values agree', () => {
+    const eft = parseEftTasks(quests as never);
+    const api: TaskData[] = [
+      {
+        id: 'task1',
+        name: 'Task One',
+        experience: 13000,
+        minPlayerLevel: 23,
+        objectives: [{ id: 'obj1', count: 7 }],
+      },
+    ];
+    expect(compare(eft, api).discrepancies).toHaveLength(0);
+  });
+});
+
+describe('crossCheckOverrides', () => {
+  // Enriched reference variant: wrapped `_id` + localization.en objective text.
+  // Uses realistic 24-hex ids (unwrapId only recognizes hex object ids).
+  const TASK = '5ae449c386f7744bde357697';
+  const OBJ = '5bb60cbc88a45011a8235cc5';
+  const enrichedQuests = [
+    {
+      _id: `[${TASK}] Sales Night`,
+      conditions: {
+        AvailableForStart: [],
+        AvailableForFinish: [{ id: OBJ, conditionType: 'CounterCreator', value: 7 }],
+      },
+      rewards: { Success: [] },
+      localization: {
+        en: {
+          [`${TASK} name`]: 'Sales Night',
+          [OBJ]: 'Survive and extract from Interchange',
+        },
+      },
+    },
+  ];
+
+  it('resolves the wrapped _id and extracts localized objective text', () => {
+    const eft = parseEftTasks(enrichedQuests as never);
+    const t = eft.get(TASK)!;
+    expect(t).toBeDefined();
+    expect(t.descriptions.get(OBJ)).toBe('Survive and extract from Interchange');
+    expect(t.counts.get(OBJ)).toBe(7);
+  });
+
+  it('classifies overrides against the reference file', () => {
+    const eft = parseEftTasks(enrichedQuests as never);
+    const overrides = {
+      [TASK]: {
+        objectives: {
+          // conflicts: client says "...from Interchange" with no count
+          [OBJ]: { description: 'Survive and extract on Interchange 7 times', count: 5 },
+        },
+      },
+    };
+    const entries = crossCheckOverrides(overrides, eft);
+    const desc = entries.find((e) => e.field === 'description')!;
+    const count = entries.find((e) => e.field === 'count')!;
+    expect(desc.verdict).toBe('CONFLICTS_REFERENCE');
+    expect(desc.reference).toBe('Survive and extract from Interchange');
+    expect(count.verdict).toBe('CONFLICTS_REFERENCE');
+    expect(count.reference).toBe('7');
+  });
+
+  it('marks overrides that equal the client as MATCHES_REFERENCE (ignoring punctuation/case)', () => {
+    const eft = parseEftTasks(enrichedQuests as never);
+    const overrides = {
+      [TASK]: {
+        objectives: {
+          [OBJ]: { description: 'survive and extract from interchange.', count: 7 },
+        },
+      },
+    };
+    const entries = crossCheckOverrides(overrides, eft);
+    expect(entries.every((e) => e.verdict === 'MATCHES_REFERENCE')).toBe(true);
+  });
+
+  it('reports NO_REFERENCE_DATA when the client has no value for the objective', () => {
+    const eft = parseEftTasks(enrichedQuests as never);
+    const overrides = {
+      [TASK]: { objectives: { ['666733e7430c8972d6a5f438']: { description: 'anything' } } },
+    };
+    const entries = crossCheckOverrides(overrides, eft);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].verdict).toBe('NO_REFERENCE_DATA');
+  });
+});

--- a/tests/eft-normalize.test.ts
+++ b/tests/eft-normalize.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, afterAll } from 'vitest';
+import { writeFileSync, mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { normalizeQuestData } from '../scripts/eft-normalize.js';
+
+// Minimal enriched reference fixture: wrapped ids + localization.en objective text.
+const FIXTURE = {
+  request: {
+    url: 'gw-pve',
+    headers: { 'App-Version': '1.0.5.0.45581' },
+    timestamp: '2026-06-30T00:02:34.289061',
+  },
+  response: {
+    decoded_response: {
+      data: [
+        {
+          _id: '[60e71dc0a94be721b065bbfc] Long Line',
+          traderId: '[5ac3b934156ae10c4430e83c] Ragman',
+          location: '[5714dbc024597771384a510d] Interchange',
+          type: 'Elimination',
+          side: '[Pmc] PMC',
+          isKey: false,
+          rewards: { Success: [{ type: 'Experience', value: 84000 }] },
+          conditions: {
+            AvailableForStart: [
+              { conditionType: 'Level', compareMethod: '>=', value: 45 },
+              {
+                conditionType: 'Quest',
+                target: '[5ae449d986f774453a54a7e1] Prereq',
+                status: [4],
+              },
+            ],
+            AvailableForFinish: [
+              { id: '60e73ee8b567ff641b129570', conditionType: 'CounterCreator', value: 20, isNecessary: false },
+              { id: 'aaaaaaaaaaaaaaaaaaaaaaaa', conditionType: 'Bonus', value: 1 },
+            ],
+          },
+          localization: {
+            en: {
+              '60e71dc0a94be721b065bbfc name': 'Long Line',
+              '60e73ee8b567ff641b129570': 'Eliminate PMC operatives inside the ULTRA mall on Interchange',
+            },
+            ru: {
+              '60e71dc0a94be721b065bbfc name': 'Длинная очередь',
+              '60e73ee8b567ff641b129570': 'Убить бойцов ЧВК в торговом центре',
+            },
+            ge: {
+              '60e71dc0a94be721b065bbfc name': 'Lange Leine',
+              '60e73ee8b567ff641b129570': 'Eliminiere PMCs im Einkaufszentrum',
+            },
+          },
+        },
+      ],
+    },
+  },
+};
+
+const dir = mkdtempSync(join(tmpdir(), 'eft-norm-'));
+const file = join(dir, 'quests.json');
+writeFileSync(file, JSON.stringify(FIXTURE));
+
+afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+describe('eft-normalize', () => {
+  const out = normalizeQuestData(file);
+  const quest = out.quests['60e71dc0a94be721b065bbfc'];
+
+  it('records provenance metadata', () => {
+    expect(out.$meta.mode).toBe('pve');
+    expect(out.$meta.appVersion).toContain('1.0.5.0');
+    expect(out.$meta.questCount).toBe(1);
+  });
+
+  it('unwraps ids and inline names', () => {
+    expect(quest.id).toBe('60e71dc0a94be721b065bbfc');
+    expect(quest.name).toBe('Long Line');
+    expect(quest.trader).toEqual({ id: '5ac3b934156ae10c4430e83c', name: 'Ragman' });
+    expect(quest.map).toEqual({ id: '5714dbc024597771384a510d', name: 'Interchange' });
+    expect(quest.side).toBe('PMC');
+  });
+
+  it('extracts level, experience and prerequisites', () => {
+    expect(quest.minPlayerLevel).toBe(45);
+    expect(quest.experience).toBe(84000);
+    expect(quest.requires).toEqual([{ id: '5ae449d986f774453a54a7e1', status: ['complete'] }]);
+  });
+
+  it('extracts objective text/count and does not emit a bogus optional flag', () => {
+    expect(quest.objectives).toHaveLength(1); // 'Bonus' condition type is excluded
+    const obj = quest.objectives[0];
+    expect(obj).toEqual({
+      id: '60e73ee8b567ff641b129570',
+      type: 'CounterCreator',
+      description: 'Eliminate PMC operatives inside the ULTRA mall on Interchange',
+      count: 20,
+    });
+    expect('optional' in obj).toBe(false);
+  });
+});
+
+describe('eft-normalize --lang', () => {
+  it('omits locale fields by default', () => {
+    const out = normalizeQuestData(file);
+    const quest = out.quests['60e71dc0a94be721b065bbfc'];
+    expect(out.$meta.languages).toBeUndefined();
+    expect(quest.nameLocale).toBeUndefined();
+    expect(quest.objectives[0].locale).toBeUndefined();
+  });
+
+  it('attaches localized name + objective text and maps codes to BCP47', () => {
+    const out = normalizeQuestData(file, ['ru', 'ge']);
+    const quest = out.quests['60e71dc0a94be721b065bbfc'];
+    // 'ge' (client) maps to 'de' (BCP47); english stays the base.
+    expect(out.$meta.languages).toEqual(['de', 'ru']);
+    expect(quest.nameLocale).toEqual({ ru: 'Длинная очередь', de: 'Lange Leine' });
+    expect(quest.objectives[0].locale).toEqual({
+      ru: 'Убить бойцов ЧВК в торговом центре',
+      de: 'Eliminiere PMCs im Einkaufszentrum',
+    });
+  });
+
+  it('expands `all` to every reference language except english', () => {
+    const out = normalizeQuestData(file, ['all']);
+    expect(out.$meta.languages).toEqual(['de', 'ru']);
+  });
+
+  it('ignores requested languages the reference does not carry', () => {
+    const out = normalizeQuestData(file, ['ru', 'kr']);
+    const quest = out.quests['60e71dc0a94be721b065bbfc'];
+    expect(out.$meta.languages).toEqual(['ru']); // 'kr' absent from fixture
+    expect(quest.nameLocale).toEqual({ ru: 'Длинная очередь' });
+  });
+});


### PR DESCRIPTION
## Summary

Adds local-only `eft:*` tooling that adjudicates objective overrides against a local quest reference file — the authority for numeric quest fields (experience, minPlayerLevel, objective counts) that the API-only validator cannot verify on its own. The API check can only say "override differs from API" (treated as "still needed"); the reference file tells us when the override itself is wrong.

### What's included
- `scripts/eft-normalize.ts` — distills a raw reference file into a clean tarkov.dev-shaped `data/eft/quests.<mode>.json`
- `scripts/eft-compare.ts` — lists where the reference disagrees with the live API
- `scripts/eft-audit.ts` — three-way `reference -> API -> overrides` check (GAP / STALE / CONFLICT / OK), mode-aware
- `scripts/eft-wiki-crosscheck.ts` — wiki cross-reference
- `check-overrides.ts` — reports CONFLICT / confirmed / unverifiable per override; no-ops cleanly when no reference file is present in `eft/`
- `.gitignore` — excludes `eft/` inputs and derived output (never committed)
- `tasks.json5` — clarifies the Small Business Part 3 localization-bug reasoning (game text is the bug; markers are correct)
- incidental `@types/node` 20.19.37 -> 20.19.43 lockfile bump

### Tested
- `npm run validate` — all files valid
- `npm run typecheck` — clean
- `npm test` — 188 passed (12 files), includes new tests for normalize/compare/audit

### Notes
Reference inputs and anything derived from them stay local (gitignored); this PR carries only tooling, tests, docs, and the JSON5 reasoning update.