### PR TITLE
fix: prestige 5/6 storyline requirement + prestige override capability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,8 @@ jobs:
             'items': 'items', 'itemsAdd': 'itemsAdd',
             'tasks': 'tasks', 'tasksAdd': 'tasksAdd',
             'traders': 'traders', 'hideout': 'hideout',
-            'editions': 'editions', 'storyChapters': 'storyChapters'
+            'editions': 'editions', 'storyChapters': 'storyChapters',
+            'prestige': 'prestige'
           };
           
           const lines = [];

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -57,6 +57,18 @@ async function fetchOverlay() {
       "name": "Tour"
     }
   },
+  "prestige": {
+    "<prestige-id>": {
+      "prestigeLevel": 5,
+      "conditions": {
+        "<condition-id>": {
+          "type": "taskStatus",
+          "task": "new_beginning_prestige_5",
+          "status": ["complete"]
+        }
+      }
+    }
+  },
   "modes": {
     "regular": {
       "tasks": {
@@ -208,6 +220,47 @@ function getTaskAdditionsForMode(overlay: Overlay, gameMode: GameMode): TaskAddi
 
 ---
 
+## Applying Prestige Corrections
+
+tarkov.dev exposes prestige levels as a `prestige` array, each item shaped like
+`{ id, prestigeLevel, conditions: [{ id, type, ... }] }`. Some of these are
+wrong: because tarkov.dev does not carry the New Beginning (Prestige 5) and
+(Prestige 6) quests, its Prestige 5/6 `taskStatus` condition points at Collector
+(`5c51aac186f77432ea65c552`) as a stand-in. The matching quests are provided in
+`tasksAdd` (`new_beginning_prestige_5` / `new_beginning_prestige_6`).
+
+The overlay's `prestige` section is keyed by prestige ID. Each entry patches the
+matching prestige item; `conditions` is keyed by the condition ID inside that
+item's `conditions` array. Apply it by merging top-level fields, then patching
+conditions by ID:
+
+```typescript
+type PrestigeCondition = { id: string; type: string; task?: string; status?: string[]; [k: string]: unknown };
+type Prestige = { id: string; prestigeLevel: number; conditions: PrestigeCondition[]; [k: string]: unknown };
+
+function applyPrestigeOverlay(base: Prestige, overlay: Overlay): Prestige {
+  const override = overlay.prestige?.[base.id];
+  if (!override) return base;
+
+  const { conditions: condPatches, ...topLevel } = override;
+  const result: Prestige = { ...base, ...topLevel };
+
+  if (condPatches) {
+    result.conditions = base.conditions.map((cond) => {
+      const patch = condPatches[cond.id];
+      return patch ? { ...cond, ...patch } : cond;
+    });
+  }
+  return result;
+}
+```
+
+The corrected `task` may be an overlay `tasksAdd` id (e.g.
+`new_beginning_prestige_5`) rather than a tarkov.dev task id, so resolve prestige
+task references against the merged task list (`tasksFromApi` + `tasksAdd`).
+
+---
+
 ## Using Additions (New Data)
 
 For data not in tarkov.dev (like game editions):
@@ -340,6 +393,7 @@ interface Overlay {
   hideout?: Record<string, HideoutOverride>;
   editions?: Record<string, Edition>;
   storyChapters?: Record<string, StoryChapter>;
+  prestige?: Record<string, PrestigeOverride>;
   $meta: {
     version: string;
     generated: string;
@@ -438,5 +492,19 @@ interface StoryChapter {
   id: string;
   name: string;
   normalizedName: string;
+}
+
+interface PrestigeOverride {
+  prestigeLevel?: number;
+  name?: string;
+  // Per-condition patches keyed by the prestige condition id
+  conditions?: Record<string, {
+    type?: string;
+    task?: string;      // corrected taskStatus target (tarkov.dev or tasksAdd id)
+    status?: string[];
+    playerLevel?: number;
+    skill?: string;
+    level?: number;
+  }>;
 }
 ```

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -340,6 +340,25 @@ export interface ModeOverlay {
   tasksAdd?: Record<string, TaskAddition>;
 }
 
+/** Correction to a single condition within a prestige level's requirements */
+export interface PrestigeConditionOverride {
+  type?: string;
+  /** Corrected task reference for a taskStatus condition (tarkov.dev task id or overlay tasksAdd id) */
+  task?: string;
+  status?: string[];
+  playerLevel?: number;
+  skill?: string;
+  level?: number;
+}
+
+/** Correction to a single prestige level, keyed by tarkov.dev prestige id */
+export interface PrestigeOverride {
+  prestigeLevel?: number;
+  name?: string;
+  /** Per-condition patches keyed by the prestige condition id */
+  conditions?: Record<string, PrestigeConditionOverride>;
+}
+
 /** Built overlay output structure */
 export interface OverlayOutput {
   tasks?: Record<string, TaskOverride>;
@@ -349,6 +368,7 @@ export interface OverlayOutput {
   hideout?: Record<string, unknown>;
   editions?: Record<string, unknown>;
   storyChapters?: Record<string, StoryChapter>;
+  prestige?: Record<string, PrestigeOverride>;
   modes?: Partial<Record<GameMode, ModeOverlay>>;
   $meta: OverlayMeta;
 }
@@ -384,5 +404,6 @@ export const SCHEMA_CONFIGS: SchemaConfig[] = [
   { pattern: 'additions/editions.json5', schemaFile: 'edition.schema.json' },
   { pattern: 'additions/storyChapters.json5', schemaFile: 'story-chapter.schema.json' },
   { pattern: 'additions/itemsAdd.json5', schemaFile: 'item-additions.schema.json' },
+  { pattern: 'overrides/prestige.json5', schemaFile: 'prestige-override.schema.json' },
   { pattern: 'suppressions/tasks.json5', schemaFile: 'task-suppressions.schema.json' },
 ];

--- a/src/overrides/prestige.json5
+++ b/src/overrides/prestige.json5
@@ -1,0 +1,45 @@
+{
+  // Prestige-level requirement corrections.
+  //
+  // The built `prestige` section is keyed by tarkov.dev prestige ID. Each entry
+  // patches the matching item of the API `prestige` array; `conditions` is keyed
+  // by the tarkov.dev condition ID inside that prestige item's `conditions` array.
+  //
+  // Why this exists: tarkov.dev does not carry the New Beginning (Prestige 5) or
+  // (Prestige 6) quests, so the live `prestige` array points the Prestige 5 and
+  // Prestige 6 `taskStatus` requirement at Collector (5c51aac186f77432ea65c552)
+  // as a stand-in. The overlay supplies the missing quests via tasksAdd
+  // (new_beginning_prestige_5 / new_beginning_prestige_6); these corrections
+  // repoint the prestige requirement at them so consumers stop showing Collector
+  // as the Prestige 5/6 storyline requirement (issue #207).
+  //
+  // Proof: https://escapefromtarkov.fandom.com/wiki/Prestige
+  //   Prestige 5 requires "New Beginning (Prestige 5)"
+  //   Prestige 6 requires "New Beginning (Prestige 6)"
+
+  // Prestige 5
+  '68d3ddb4fc101237e601d774': {
+    prestigeLevel: 5,
+    conditions: {
+      // taskStatus requirement: should be New Beginning (Prestige 5), not Collector
+      '68d3ddb415034199b86b8d68': {
+        type: 'taskStatus',
+        task: 'new_beginning_prestige_5', // Was: 5c51aac186f77432ea65c552 (Collector)
+        status: ['complete'],
+      },
+    },
+  },
+
+  // Prestige 6
+  '68d3e6f46a7ba36646713fa6': {
+    prestigeLevel: 6,
+    conditions: {
+      // taskStatus requirement: should be New Beginning (Prestige 6), not Collector
+      '68d3e6f40b976d94f72dde5e': {
+        type: 'taskStatus',
+        task: 'new_beginning_prestige_6', // Was: 5c51aac186f77432ea65c552 (Collector)
+        status: ['complete'],
+      },
+    },
+  },
+}

--- a/src/schemas/overlay.schema.json
+++ b/src/schemas/overlay.schema.json
@@ -35,6 +35,9 @@
     "itemsAdd": {
       "$ref": "item-additions.schema.json"
     },
+    "prestige": {
+      "$ref": "prestige-override.schema.json"
+    },
     "storyChapters": {
       "$ref": "story-chapter.schema.json"
     },

--- a/src/schemas/prestige-override.schema.json
+++ b/src/schemas/prestige-override.schema.json
@@ -1,0 +1,67 @@
+{
+  "$id": "prestige-override.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Prestige Override",
+  "description": "Schema for correcting tarkov.dev prestige-level data. Keyed by tarkov.dev prestige ID. Each entry patches fields on the matching item of the API `prestige` array; `conditions` is an ID-keyed object of per-condition patches (e.g. fixing a `taskStatus` condition that points at the wrong storyline quest).",
+  "type": "object",
+  "additionalProperties": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "prestigeLevel": {
+        "description": "Prestige level this entry corresponds to (documentation/sanity aid; must match the API value)",
+        "type": "integer",
+        "minimum": 1
+      },
+      "name": {
+        "description": "Corrected display name for the prestige level",
+        "type": "string"
+      },
+      "conditions": {
+        "description": "Per-condition corrections, keyed by the tarkov.dev condition ID found in the prestige item's `conditions` array",
+        "type": "object",
+        "additionalProperties": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "description": "Condition type (e.g. taskStatus, playerLevel, skill, hideoutStation, haveItem)",
+              "type": "string"
+            },
+            "task": {
+              "description": "Corrected task reference for a taskStatus condition (tarkov.dev task ID, or an overlay tasksAdd id like new_beginning_prestige_5)",
+              "type": "string"
+            },
+            "status": {
+              "description": "Corrected status array for a taskStatus condition",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1
+            },
+            "playerLevel": {
+              "description": "Corrected player level for a playerLevel condition",
+              "type": "integer",
+              "minimum": 1
+            },
+            "skill": {
+              "description": "Skill name for a skill condition",
+              "type": "string"
+            },
+            "level": {
+              "description": "Corrected level for a skill condition",
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        }
+      }
+    },
+    "anyOf": [
+      { "required": ["conditions"] },
+      { "required": ["name"] },
+      { "required": ["prestigeLevel"] }
+    ]
+  }
+}

--- a/tests/overlay-schema.test.ts
+++ b/tests/overlay-schema.test.ts
@@ -91,6 +91,7 @@ describe('overlay.schema.json', () => {
     const referencedSchemas = [
       'edition.schema.json',
       'item-additions.schema.json',
+      'prestige-override.schema.json',
       'task-override.schema.json',
       'task-additions.schema.json',
       'story-chapter.schema.json',

--- a/tests/prestige-override.test.ts
+++ b/tests/prestige-override.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Tests for the prestige override capability (issue #207)
+ *
+ * tarkov.dev does not carry New Beginning (Prestige 5/6), so its `prestige`
+ * array points the Prestige 5/6 taskStatus requirement at Collector
+ * (5c51aac186f77432ea65c552). The overlay supplies the missing quests via
+ * tasksAdd and repoints the prestige requirement at them.
+ */
+
+import { describe, expect, it } from 'vitest';
+import Ajv from 'ajv';
+import { join } from 'path';
+import {
+  getProjectPaths,
+  loadAllJson5FromDir,
+  loadJsonFile,
+} from '../src/lib/index.js';
+import { initializeValidators, getValidator } from '../scripts/validate.js';
+
+const COLLECTOR_ID = '5c51aac186f77432ea65c552';
+
+function loadPrestigeOverride(): Record<string, any> {
+  const { srcDir } = getProjectPaths();
+  const overrides = loadAllJson5FromDir(join(srcDir, 'overrides'));
+  return (overrides.prestige ?? {}) as Record<string, any>;
+}
+
+describe('prestige override (issue #207)', () => {
+  it('is registered with a schema validator', () => {
+    const validators = initializeValidators();
+    expect(getValidator('overrides/prestige.json5', validators)).not.toBeNull();
+  });
+
+  it('repoints Prestige 5 and 6 storyline requirement off Collector', () => {
+    const prestige = loadPrestigeOverride();
+
+    const p5 = prestige['68d3ddb4fc101237e601d774'];
+    const p6 = prestige['68d3e6f46a7ba36646713fa6'];
+    expect(p5?.prestigeLevel).toBe(5);
+    expect(p6?.prestigeLevel).toBe(6);
+
+    const p5cond = p5.conditions['68d3ddb415034199b86b8d68'];
+    const p6cond = p6.conditions['68d3e6f40b976d94f72dde5e'];
+
+    // Corrected to the overlay-added New Beginning quests...
+    expect(p5cond.task).toBe('new_beginning_prestige_5');
+    expect(p6cond.task).toBe('new_beginning_prestige_6');
+    // ...and no longer the Collector stand-in.
+    expect(p5cond.task).not.toBe(COLLECTOR_ID);
+    expect(p6cond.task).not.toBe(COLLECTOR_ID);
+  });
+
+  it('points each prestige condition at a quest the overlay actually provides', () => {
+    const { srcDir } = getProjectPaths();
+    const prestige = loadPrestigeOverride();
+    const additions = loadAllJson5FromDir(join(srcDir, 'additions'), false);
+    const addedTaskIds = new Set(Object.keys(additions.tasksAdd ?? {}));
+
+    for (const entry of Object.values(prestige)) {
+      for (const cond of Object.values(entry.conditions ?? {}) as any[]) {
+        if (cond.type === 'taskStatus' && cond.task?.startsWith('new_beginning_prestige_')) {
+          expect(addedTaskIds.has(cond.task)).toBe(true);
+        }
+      }
+    }
+  });
+
+  it('rejects an unknown field via the prestige schema', () => {
+    const { schemasDir } = getProjectPaths();
+    const ajv = new Ajv({ allErrors: true, strict: false });
+    const schema = loadJsonFile(join(schemasDir, 'prestige-override.schema.json'));
+    const validate = ajv.compile(schema as object);
+
+    expect(validate({ abc: { bogusField: true } })).toBe(false);
+    expect(
+      validate({ abc: { conditions: { def: { task: 'new_beginning_prestige_5' } } } })
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## **User description**
Fixes #207.

## Problem

tarkov.dev does not carry the *New Beginning (Prestige 5)* and *(Prestige 6)* quests. As a result, its `prestige` array points the **Prestige 5 and 6** `taskStatus` requirement at **Collector** (`5c51aac186f77432ea65c552`) as a stand-in, so consumers show the wrong storyline quest for the top two prestige tiers.

Verified against the live API and the EFT wiki [Prestige page](https://escapefromtarkov.fandom.com/wiki/Prestige):
- Player levels (25/30/35/40/47/47) and skill gates (Str/End/Cha per tier) are **correct** for all six tiers.
- Only the **P5/P6 storyline quest reference** is wrong (Collector instead of New Beginning P5/P6).

## Why the overlay could not fix it before

The overlay already *adds* the two missing quests (`new_beginning_prestige_5` / `new_beginning_prestige_6` in `tasksAdd`), but there was no overlay section for the `prestige` array, so the requirement could not be repointed off Collector.

## Changes

- **New `prestige` overlay capability**
  - `src/schemas/prestige-override.schema.json` — keyed by tarkov.dev prestige ID; `conditions` is an ID-keyed object of per-condition patches (matches the repo "ID-keyed objects, not arrays" convention).
  - Registered in `SCHEMA_CONFIGS` (`src/lib/types.ts`) and the root `src/schemas/overlay.schema.json`; added `OverlayOutput.prestige` + `PrestigeOverride` types.
- **The fix** — `src/overrides/prestige.json5` repoints the P5/P6 `taskStatus` conditions from Collector to `new_beginning_prestige_5` / `new_beginning_prestige_6`, with proof link and `Was:` comments.
- **Docs** — `docs/INTEGRATION.md` gains structure example, an `applyPrestigeOverlay` merge snippet, and the `PrestigeOverride` type.
- **Tests** — `tests/prestige-override.test.ts` (4 focused tests); `tests/overlay-schema.test.ts` registers the new ref.
- **CI** — added `prestige` to the release-notes source-map so prestige changes show in generated notes.

## Testing

- `npm run validate` — pass
- `npm run build` — pass (`dist/overlay.json` gains a `prestige` section with 2 entries)
- `npm run typecheck` — pass
- `npm test` — 196 passing (4 new)

`dist/overlay.json` is intentionally **not** included; CI rebuilds and commits it on merge to `main` per the existing `chore: build overlay [skip ci]` flow.

## Consumer note

This is a new public overlay section. Full on-site correctness on TarkovTracker depends on the consumer applying the `prestige` section (patch top-level fields, then patch `conditions` by condition ID) and resolving the corrected `task` against the merged API + `tasksAdd` list.


___

## **CodeAnt-AI Description**
**Fix Prestige 5 and 6 showing the wrong storyline quest**

### What Changed
- Prestige 5 and Prestige 6 now point to their correct storyline quests instead of using Collector as a stand-in
- The overlay can now patch prestige requirements directly, so missing prestige quest references can be corrected without changing the base data
- Integration docs and validation tests were updated to cover the new prestige overlay format

### Impact
`✅ Correct Prestige 5/6 quest requirements`
`✅ Fewer wrong storyline labels in prestige views`
`✅ Support for fixing future prestige data gaps`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
