### PR TITLE
refactor: simplify mode-dir loading and remove needless template literal

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -27,15 +27,9 @@ function loadModeFiles(): Partial<Record<string, Record<string, Record<string, u
   for (const mode of SUPPORTED_GAME_MODES) {
     const modeData: Record<string, Record<string, unknown>> = {};
 
-    const overridesDir = join(srcDir, 'overrides', 'modes', mode);
-    if (existsSync(overridesDir)) {
-      Object.assign(modeData, loadAllJson5FromDir(overridesDir));
-    }
-
-    const additionsDir = join(srcDir, 'additions', 'modes', mode);
-    if (existsSync(additionsDir)) {
-      Object.assign(modeData, loadAllJson5FromDir(additionsDir, false));
-    }
+    // loadAllJson5FromDir no-ops on missing directories (listJson5Files returns []).
+    Object.assign(modeData, loadAllJson5FromDir(join(srcDir, 'overrides', 'modes', mode)));
+    Object.assign(modeData, loadAllJson5FromDir(join(srcDir, 'additions', 'modes', mode), false));
 
     if (Object.keys(modeData).length > 0) {
       modes[mode] = modeData;

--- a/src/lib/task-validator.ts
+++ b/src/lib/task-validator.ts
@@ -223,7 +223,7 @@ const validateMap: FieldValidator = (override, apiTask) => {
     field: 'map',
     status: isMatch ? 'fixed' : 'needed',
     message: isMatch
-      ? `${'map'}: ${formatValue(apiValue)} - FIXED IN API`
+      ? `map: ${formatValue(apiValue)} - FIXED IN API`
       : `map: API=${formatValue(apiValue)}, Override=${formatValue(overrideValue)} - STILL NEEDED`,
   };
 };


### PR DESCRIPTION
## **User description**
## Summary

Two small behavior-preserving cleanups:

- `scripts/build.ts` — drop the redundant `existsSync` guards around the per-mode `loadAllJson5FromDir` calls in `loadModeFiles()`. `listJson5Files` already returns `[]` for missing directories, so the guards were dead weight. A comment documents the no-op behavior. (`existsSync` is still imported/used for the `dist/` dir creation.)
- `src/lib/task-validator.ts` — replace the odd `${'map'}` template-literal interpolation with a plain `map:` string literal in the FIXED-IN-API message.

No data changes; `dist/overlay.json` untouched (CI owns the build commit).

## Commands run

- `npm run validate` — all files valid
- `npm run build` — builds cleanly, identical entity output
- `npm test` — 202/202 passing
- `npx tsc --noEmit` — clean


___

## **CodeAnt-AI Description**
**Simplify mode file loading and clean up the map validation message**

### What Changed
- Mode files are still loaded the same way, including when a mode folder is missing
- The build script now relies on the loader’s existing no-op behavior instead of checking folders first
- The task validation message for a fixed map now uses plain `map:` text

### Impact
`✅ No change in build output`
`✅ Same mode data loading when folders are missing`
`✅ Clearer validation message text`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
