### PR TITLE
feat: locale-aware stale detection in check-overrides

### DIFF
--- a/scripts/check-overrides.ts
+++ b/scripts/check-overrides.ts
@@ -20,6 +20,7 @@ import { pathToFileURL } from 'url';
 import {
   getProjectPaths,
   loadJson5File,
+  loadAllJson5FromDir,
   colors,
   icons,
   bold,
@@ -30,8 +31,10 @@ import {
   printError,
   formatCountLabel,
   fetchTasks,
+  fetchLocaleBundle,
   SUPPORTED_GAME_MODES,
   validateAllOverrides,
+  validateLocaleOverrides,
   categorizeResults,
   type TaskOverride,
   type TaskAddition,
@@ -39,6 +42,9 @@ import {
   type GameMode,
   type ValidationResult,
   type ValidationDetail,
+  type LocaleOverlay,
+  type LocaleValidationResult,
+  type LocaleVerdict,
 } from '../src/lib/index.js';
 import {
   loadEftTasks,
@@ -503,6 +509,90 @@ function printEditionReferenceResults(missing: EditionTaskReference[]): void {
   console.log();
 }
 
+const LOCALE_VERDICT_ORDER: LocaleVerdict[] = ['STALE', 'REMOVED', 'NEEDED', 'UNVERIFIABLE'];
+
+const LOCALE_VERDICT_META: Record<
+  LocaleVerdict,
+  { icon: string; color: keyof typeof colors; label: string }
+> = {
+  STALE: {
+    icon: icons.sync,
+    color: 'yellow',
+    label: 'Bundle fixed upstream, can remove',
+  },
+  REMOVED: {
+    icon: icons.trash,
+    color: 'red',
+    label: 'Entity removed from API, delete from overlay',
+  },
+  NEEDED: {
+    icon: icons.success,
+    color: 'green',
+    label: 'Bundle still broken, override required',
+  },
+  UNVERIFIABLE: {
+    icon: icons.info,
+    color: 'cyan',
+    label: 'Overlay-authored (storyChapters), cannot verify',
+  },
+};
+
+export function printLocaleResults(locale: string, results: LocaleValidationResult[]): void {
+  printHeader(`LOCALE OVERRIDES CHECK (${locale})`);
+
+  for (const verdict of LOCALE_VERDICT_ORDER) {
+    const subset = results.filter((r) => r.verdict === verdict);
+    const meta = LOCALE_VERDICT_META[verdict];
+    console.log(formatCountLabel(`${meta.icon} ${meta.label}`, subset.length, meta.color));
+    for (const r of subset) {
+      console.log(`  - ${r.entityType}/${r.entityId} ${bold(r.field)}`);
+      if (r.overrideValue !== undefined) {
+        console.log(`      override: ${r.overrideValue}`);
+        console.log(`      bundle:   ${r.bundleValue ?? dim('(not found)')}`);
+      }
+      console.log(`      ${dim(r.message)}`);
+    }
+    if (subset.length === 0) console.log(`  ${dim('None')}`);
+    console.log();
+  }
+
+  const obsolete = results.filter(
+    (r) => r.verdict === 'STALE' || r.verdict === 'REMOVED'
+  ).length;
+  if (obsolete > 0) {
+    console.log(`${icons.lightbulb} ${bold('RECOMMENDATION:')}`);
+    console.log(
+      `   Update src/overrides/locales/${locale}.json5 to remove ${obsolete} obsolete patch(es)`
+    );
+    console.log();
+  }
+}
+
+/**
+ * Check every locale override file against the live tarkov.dev bundle for the
+ * same locale. Locale bundles are shared across game modes, so 'regular' is
+ * fetched once per locale.
+ */
+async function checkLocaleOverrides(): Promise<void> {
+  const localesDir = join(srcDir, 'overrides', 'locales');
+  const localeOverrides = loadAllJson5FromDir(localesDir);
+  const locales = Object.keys(localeOverrides).sort();
+  if (locales.length === 0) return;
+
+  for (const locale of locales) {
+    printProgress(`Fetching ${locale} locale bundle from tarkov.dev...`);
+    const bundle = await fetchLocaleBundle('regular', locale);
+    printSuccess(`Fetched ${locale} bundle\n`);
+
+    const results = validateLocaleOverrides(
+      locale,
+      localeOverrides[locale] as LocaleOverlay,
+      bundle
+    );
+    printLocaleResults(locale, results);
+  }
+}
+
 /**
  * Cross-check objective overrides against the local quest reference file
  * (authoritative source). The API-only validator can only say "override differs
@@ -675,6 +765,9 @@ async function main(): Promise<void> {
     printEditionReferenceResults(missingEditionRefs);
 
     printReferenceCrossCheck(crossCheckGroups);
+
+    printProgress('Checking locale overrides against tarkov.dev bundles...\n');
+    await checkLocaleOverrides();
 
     process.exit(0);
   } catch (error) {

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -7,3 +7,4 @@ export * from './terminal.js';
 export * from './types.js';
 export * from './tarkov-api.js';
 export * from './task-validator.js';
+export * from './locale-validator.js';

--- a/src/lib/locale-validator.ts
+++ b/src/lib/locale-validator.ts
@@ -1,0 +1,301 @@
+/**
+ * Locale override validation
+ *
+ * Determines whether per-locale overrides (src/overrides/locales/<locale>.json5)
+ * are still needed by comparing them against the live tarkov.dev bundles.
+ *
+ * Resolution strategy: translation key formats differ per entity type (tasks
+ * use `"<id> name"`, items use `"<id> Name"`, traders use `"<id> Nickname"`,
+ * ...), so key formats are never hardcoded. Instead, the core endpoint stores
+ * the translation key as the field value (e.g. `task.name === "<id> name"`),
+ * and we resolve that key against the `_<locale>` translation map — the same
+ * way `tarkov-api.ts` resolves english strings. `wikiLink` is the exception:
+ * it lives directly on the core endpoint as a URL string, not in the
+ * translation bundle.
+ *
+ * Verdicts:
+ * - STALE:        bundle now matches the override — fixed upstream, remove it
+ * - NEEDED:       bundle still differs (or can't be confirmed) — keep it
+ * - REMOVED:      entity (or objective) no longer exists in the API — delete it
+ * - UNVERIFIABLE: overlay-authored entity (storyChapters) absent from
+ *                 tarkov.dev — cannot be checked, skip
+ */
+
+import type { LocaleOverlay, ObjectiveLocaleOverride } from './types.js';
+import type { LocaleBundle, TranslationMap } from './tarkov-api.js';
+
+export type LocaleVerdict = 'STALE' | 'NEEDED' | 'REMOVED' | 'UNVERIFIABLE';
+
+export type LocaleEntityType =
+  | 'tasks'
+  | 'items'
+  | 'traders'
+  | 'maps'
+  | 'prestige'
+  | 'storyChapters';
+
+export interface LocaleValidationResult {
+  locale: string;
+  entityType: LocaleEntityType;
+  entityId: string;
+  /** Patched field, e.g. 'name', 'wikiLink', or 'objectives[<objId>].description' */
+  field: string;
+  overrideValue?: string;
+  bundleValue?: string;
+  verdict: LocaleVerdict;
+  message: string;
+}
+
+type JsonRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is JsonRecord {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+/**
+ * Resolve a translation key against a locale map. Returns undefined when the
+ * key is not a string or has no entry — the caller treats that as "cannot
+ * confirm an upstream fix". Own-property check guards prototype keys.
+ */
+function resolveTranslation(key: unknown, map: TranslationMap): string | undefined {
+  if (typeof key !== 'string') return undefined;
+  if (!Object.prototype.hasOwnProperty.call(map, key)) return undefined;
+  const value = map[key];
+  return typeof value === 'string' ? value : undefined;
+}
+
+type ResultBase = Pick<LocaleValidationResult, 'locale' | 'entityType' | 'entityId'>;
+
+/** Compare an override string against the resolved bundle value. */
+function compareValues(
+  base: ResultBase,
+  field: string,
+  overrideValue: string,
+  bundleValue: string | undefined
+): LocaleValidationResult {
+  if (bundleValue === undefined) {
+    return {
+      ...base,
+      field,
+      overrideValue,
+      bundleValue,
+      verdict: 'NEEDED',
+      message: `translation not found in ${base.locale} bundle - cannot confirm upstream fix, keep override`,
+    };
+  }
+  if (bundleValue === overrideValue) {
+    return {
+      ...base,
+      field,
+      overrideValue,
+      bundleValue,
+      verdict: 'STALE',
+      message: 'bundle now matches override - fixed upstream, remove override',
+    };
+  }
+  return {
+    ...base,
+    field,
+    overrideValue,
+    bundleValue,
+    verdict: 'NEEDED',
+    message: 'bundle still differs from override - keep override',
+  };
+}
+
+function removedResult(base: ResultBase, field: string, overrideValue?: string): LocaleValidationResult {
+  return {
+    ...base,
+    field,
+    overrideValue,
+    verdict: 'REMOVED',
+    message: 'entity no longer exists in the API - delete override',
+  };
+}
+
+/** Enumerate every patched field of an entity patch (for REMOVED reporting). */
+function listPatchedFields(patch: JsonRecord): string[] {
+  const fields: string[] = [];
+  for (const [key, value] of Object.entries(patch)) {
+    if (key === 'objectives' && isRecord(value)) {
+      for (const objectiveId of Object.keys(value)) {
+        fields.push(`objectives[${objectiveId}].description`);
+      }
+    } else if (typeof value === 'string') {
+      fields.push(key);
+    }
+  }
+  return fields;
+}
+
+/** Per-entity-type validation config. */
+type EntityCheck = {
+  entityType: Exclude<LocaleEntityType, 'storyChapters'>;
+  lookup: Map<string, JsonRecord>;
+  translations: TranslationMap;
+  /** Fields whose core value is a translation key resolved via `translations` */
+  translatedFields: string[];
+  /** Fields stored directly on the core endpoint (URL strings, not keys) */
+  directFields?: string[];
+  /** Whether the entity supports ID-keyed objective description patches */
+  hasObjectives?: boolean;
+};
+
+function checkObjectivePatches(
+  base: ResultBase,
+  core: JsonRecord,
+  objectives: Record<string, ObjectiveLocaleOverride>,
+  translations: TranslationMap
+): LocaleValidationResult[] {
+  const results: LocaleValidationResult[] = [];
+  const coreObjectives = Array.isArray(core.objectives)
+    ? core.objectives.filter(isRecord)
+    : [];
+
+  for (const [objectiveId, patch] of Object.entries(objectives)) {
+    const field = `objectives[${objectiveId}].description`;
+    if (typeof patch.description !== 'string') continue;
+
+    const coreObjective = coreObjectives.find((entry) => entry.id === objectiveId);
+    if (!coreObjective) {
+      results.push({
+        ...base,
+        field,
+        overrideValue: patch.description,
+        verdict: 'REMOVED',
+        message: 'objective no longer exists in the API - delete override',
+      });
+      continue;
+    }
+
+    const bundleValue = resolveTranslation(coreObjective.description, translations);
+    results.push(compareValues(base, field, patch.description, bundleValue));
+  }
+
+  return results;
+}
+
+function checkEntityPatches(
+  locale: string,
+  check: EntityCheck,
+  patches: Record<string, JsonRecord>
+): LocaleValidationResult[] {
+  const results: LocaleValidationResult[] = [];
+
+  for (const [entityId, patch] of Object.entries(patches)) {
+    if (!isRecord(patch)) continue;
+    const base: ResultBase = { locale, entityType: check.entityType, entityId };
+    const core = check.lookup.get(entityId);
+
+    if (!core) {
+      for (const field of listPatchedFields(patch)) {
+        const overrideValue = field.startsWith('objectives[')
+          ? undefined
+          : (patch[field] as string);
+        results.push(removedResult(base, field, overrideValue));
+      }
+      continue;
+    }
+
+    for (const field of check.translatedFields) {
+      const overrideValue = patch[field];
+      if (typeof overrideValue !== 'string') continue;
+      const bundleValue = resolveTranslation(core[field], check.translations);
+      results.push(compareValues(base, field, overrideValue, bundleValue));
+    }
+
+    for (const field of check.directFields ?? []) {
+      const overrideValue = patch[field];
+      if (typeof overrideValue !== 'string') continue;
+      const bundleValue = typeof core[field] === 'string' ? (core[field] as string) : undefined;
+      results.push(compareValues(base, field, overrideValue, bundleValue));
+    }
+
+    if (check.hasObjectives && isRecord(patch.objectives)) {
+      results.push(
+        ...checkObjectivePatches(
+          base,
+          core,
+          patch.objectives as Record<string, ObjectiveLocaleOverride>,
+          check.translations
+        )
+      );
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Validate one locale's overrides against the live tarkov.dev bundle for the
+ * same locale, producing a per-field verdict for every patch.
+ */
+export function validateLocaleOverrides(
+  locale: string,
+  overrides: LocaleOverlay,
+  bundle: LocaleBundle
+): LocaleValidationResult[] {
+  const results: LocaleValidationResult[] = [];
+
+  const checks: EntityCheck[] = [
+    {
+      entityType: 'tasks',
+      lookup: bundle.tasksById,
+      translations: bundle.tasksLocale,
+      translatedFields: ['name'],
+      directFields: ['wikiLink'],
+      hasObjectives: true,
+    },
+    {
+      entityType: 'items',
+      lookup: bundle.itemsById,
+      translations: bundle.itemsLocale,
+      translatedFields: ['name', 'shortName', 'description'],
+      directFields: ['wikiLink'],
+    },
+    {
+      entityType: 'traders',
+      lookup: bundle.tradersById,
+      translations: bundle.tradersLocale,
+      translatedFields: ['name', 'description'],
+    },
+    {
+      entityType: 'maps',
+      lookup: bundle.mapsById,
+      translations: bundle.mapsLocale,
+      translatedFields: ['name', 'description'],
+    },
+    {
+      // Prestige records live in the tasks payload; their names resolve via
+      // the tasks translation map.
+      entityType: 'prestige',
+      lookup: bundle.prestigeById,
+      translations: bundle.tasksLocale,
+      translatedFields: ['name'],
+    },
+  ];
+
+  for (const check of checks) {
+    const patches = overrides[check.entityType];
+    if (!patches) continue;
+    results.push(
+      ...checkEntityPatches(locale, check, patches as Record<string, JsonRecord>)
+    );
+  }
+
+  // Story chapters are overlay-authored additions with no tarkov.dev
+  // counterpart, so their locale patches can never be verified against a
+  // bundle. One result per chapter keeps the summary honest without noise.
+  for (const chapterId of Object.keys(overrides.storyChapters ?? {})) {
+    results.push({
+      locale,
+      entityType: 'storyChapters',
+      entityId: chapterId,
+      field: '*',
+      verdict: 'UNVERIFIABLE',
+      message: 'storyChapters are overlay-authored and absent from tarkov.dev - cannot verify, keep override',
+    });
+  }
+
+  return results;
+}

--- a/src/lib/tarkov-api.ts
+++ b/src/lib/tarkov-api.ts
@@ -43,8 +43,8 @@ type Envelope = {
   translations?: string[];
 };
 
-/** Flat translation map: key -> english string. */
-type TranslationMap = Record<string, string>;
+/** Flat translation map: key -> translated string for one locale. */
+export type TranslationMap = Record<string, string>;
 
 const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
 
@@ -163,13 +163,14 @@ function fetchEnvelope(cache: EndpointCache, path: string): Promise<Envelope> {
   return promise;
 }
 
-/** Fetch an `_en` endpoint and return its flat translation map. */
+/** Fetch an `_<locale>` endpoint and return its flat translation map. */
 async function fetchTranslations(
   cache: EndpointCache,
   mode: GameMode,
-  endpoint: string
+  endpoint: string,
+  locale = 'en'
 ): Promise<TranslationMap> {
-  const envelope = await fetchEnvelope(cache, `${mode}/${endpoint}_en`);
+  const envelope = await fetchEnvelope(cache, `${mode}/${endpoint}_${locale}`);
   return isRecord(envelope.data) ? (envelope.data as TranslationMap) : {};
 }
 
@@ -425,6 +426,79 @@ export async function fetchTasks(gameMode?: GameMode): Promise<TaskData[]> {
   return Object.values(tasksData.tasks)
     .filter(isRecord)
     .map((task) => adaptTask(task, ctx));
+}
+
+/**
+ * Raw per-locale bundle used by the locale-override validator.
+ *
+ * Unlike `fetchTasks`, this deliberately does NOT adapt or translate the core
+ * records: the core endpoints store translation keys as field values (e.g.
+ * `task.name === "<id> name"`), and the validator resolves those keys against
+ * the `_<locale>` translation map itself so it can distinguish "bundle fixed
+ * upstream" from "translation key missing".
+ */
+export interface LocaleBundle {
+  /** Locale code the translation maps were fetched for (en, de, fr, ...) */
+  locale: string;
+  tasksById: Map<string, Record<string, unknown>>;
+  itemsById: Map<string, Record<string, unknown>>;
+  tradersById: Map<string, Record<string, unknown>>;
+  mapsById: Map<string, Record<string, unknown>>;
+  /** Prestige records live in the tasks payload's `prestige` array */
+  prestigeById: Map<string, Record<string, unknown>>;
+  tasksLocale: TranslationMap;
+  itemsLocale: TranslationMap;
+  tradersLocale: TranslationMap;
+  mapsLocale: TranslationMap;
+}
+
+/**
+ * Fetch the core entity endpoints plus the `_<locale>` translation maps for a
+ * game mode, returning the raw lookups the locale-override validator needs.
+ */
+export async function fetchLocaleBundle(
+  gameMode?: GameMode,
+  locale = 'en'
+): Promise<LocaleBundle> {
+  const mode: GameMode = gameMode ?? 'regular';
+  const cache: EndpointCache = new Map();
+
+  const [
+    tasksEnvelope,
+    itemsEnvelope,
+    mapsEnvelope,
+    tradersEnvelope,
+    tasksLocale,
+    itemsLocale,
+    mapsLocale,
+    tradersLocale,
+  ] = await Promise.all([
+    fetchEnvelope(cache, `${mode}/tasks`),
+    fetchEnvelope(cache, `${mode}/items`),
+    fetchEnvelope(cache, `${mode}/maps`),
+    fetchEnvelope(cache, `${mode}/traders`),
+    fetchTranslations(cache, mode, 'tasks', locale),
+    fetchTranslations(cache, mode, 'items', locale),
+    fetchTranslations(cache, mode, 'maps', locale),
+    fetchTranslations(cache, mode, 'traders', locale),
+  ]);
+
+  const tasksData = isRecord(tasksEnvelope.data) ? tasksEnvelope.data : {};
+  const itemsData = isRecord(itemsEnvelope.data) ? itemsEnvelope.data : {};
+  const mapsData = isRecord(mapsEnvelope.data) ? mapsEnvelope.data : {};
+
+  return {
+    locale,
+    tasksById: toLookup(tasksData.tasks),
+    itemsById: toLookup(itemsData.items),
+    mapsById: toLookup(mapsData.maps),
+    tradersById: toLookup(tradersEnvelope.data),
+    prestigeById: toLookup(tasksData.prestige),
+    tasksLocale,
+    itemsLocale,
+    mapsLocale,
+    tradersLocale,
+  };
 }
 
 /**

--- a/tests/locale-validator.test.ts
+++ b/tests/locale-validator.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Tests for the locale-override validator (locale-validator module)
+ *
+ * Verdicts are exercised with hand-built LocaleBundle fixtures: STALE (bundle
+ * fixed upstream), NEEDED (bundle still broken or unresolvable), REMOVED
+ * (entity/objective gone from the API), and UNVERIFIABLE (storyChapters).
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  validateLocaleOverrides,
+  type LocaleBundle,
+  type LocaleOverlay,
+  type LocaleValidationResult,
+} from '../src/lib/index.js';
+
+function makeBundle(overrides: Partial<LocaleBundle> = {}): LocaleBundle {
+  return {
+    locale: 'en',
+    tasksById: new Map(),
+    itemsById: new Map(),
+    tradersById: new Map(),
+    mapsById: new Map(),
+    prestigeById: new Map(),
+    tasksLocale: {},
+    itemsLocale: {},
+    tradersLocale: {},
+    mapsLocale: {},
+    ...overrides,
+  };
+}
+
+function byField(results: LocaleValidationResult[]): Record<string, LocaleValidationResult> {
+  return Object.fromEntries(results.map((r) => [`${r.entityType}/${r.entityId}/${r.field}`, r]));
+}
+
+describe('validateLocaleOverrides', () => {
+  it('returns no results for an empty overlay', () => {
+    expect(validateLocaleOverrides('en', {}, makeBundle())).toEqual([]);
+  });
+
+  it('marks a task name STALE when the bundle now matches the override', () => {
+    const bundle = makeBundle({
+      tasksById: new Map([['t1', { id: 't1', name: 't1 name' }]]),
+      tasksLocale: { 't1 name': 'New Beginning' },
+    });
+    const overrides: LocaleOverlay = {
+      tasks: { t1: { name: 'New Beginning' } },
+    };
+
+    const [result] = validateLocaleOverrides('en', overrides, bundle);
+
+    expect(result.verdict).toBe('STALE');
+    expect(result.bundleValue).toBe('New Beginning');
+    expect(result.field).toBe('name');
+  });
+
+  it('marks a task name NEEDED when the bundle still differs', () => {
+    // The seeded en.json5 case: en bundle resolves to the German string.
+    const bundle = makeBundle({
+      tasksById: new Map([['t1', { id: 't1', name: 't1 name' }]]),
+      tasksLocale: { 't1 name': 'Neuanfang' },
+    });
+    const overrides: LocaleOverlay = {
+      tasks: { t1: { name: 'New Beginning' } },
+    };
+
+    const [result] = validateLocaleOverrides('en', overrides, bundle);
+
+    expect(result.verdict).toBe('NEEDED');
+    expect(result.bundleValue).toBe('Neuanfang');
+  });
+
+  it('marks NEEDED (not STALE) when the translation key is missing from the locale map', () => {
+    const bundle = makeBundle({
+      tasksById: new Map([['t1', { id: 't1', name: 't1 name' }]]),
+      tasksLocale: {},
+    });
+    const overrides: LocaleOverlay = {
+      tasks: { t1: { name: 'New Beginning' } },
+    };
+
+    const [result] = validateLocaleOverrides('en', overrides, bundle);
+
+    expect(result.verdict).toBe('NEEDED');
+    expect(result.bundleValue).toBeUndefined();
+    expect(result.message).toContain('cannot confirm');
+  });
+
+  it('marks every patched field REMOVED when the entity is gone from the API', () => {
+    const overrides: LocaleOverlay = {
+      tasks: {
+        gone: {
+          name: 'Ghost Task',
+          wikiLink: 'https://wiki/Ghost',
+          objectives: { o1: { description: 'Do it' } },
+        },
+      },
+    };
+
+    const results = validateLocaleOverrides('en', overrides, makeBundle());
+
+    expect(results).toHaveLength(3);
+    expect(results.every((r) => r.verdict === 'REMOVED')).toBe(true);
+    expect(results.map((r) => r.field).sort()).toEqual([
+      'name',
+      'objectives[o1].description',
+      'wikiLink',
+    ]);
+  });
+
+  it('compares wikiLink against the core endpoint, not the translation bundle', () => {
+    const bundle = makeBundle({
+      tasksById: new Map([
+        ['fixed', { id: 'fixed', name: 'fixed name', wikiLink: 'https://wiki/Correct' }],
+        ['broken', { id: 'broken', name: 'broken name', wikiLink: 'https://wiki/Wrong' }],
+      ]),
+      // Deliberately empty tasksLocale: wikiLink must not consult it.
+      tasksLocale: {},
+    });
+    const overrides: LocaleOverlay = {
+      tasks: {
+        fixed: { wikiLink: 'https://wiki/Correct' },
+        broken: { wikiLink: 'https://wiki/Correct' },
+      },
+    };
+
+    const results = byField(validateLocaleOverrides('en', overrides, bundle));
+
+    expect(results['tasks/fixed/wikiLink'].verdict).toBe('STALE');
+    expect(results['tasks/broken/wikiLink'].verdict).toBe('NEEDED');
+    expect(results['tasks/broken/wikiLink'].bundleValue).toBe('https://wiki/Wrong');
+  });
+
+  it('resolves objective descriptions via the core objective translation key', () => {
+    const bundle = makeBundle({
+      tasksById: new Map([
+        [
+          't1',
+          {
+            id: 't1',
+            name: 't1 name',
+            objectives: [
+              { id: 'o1', description: 'o1' },
+              { id: 'o2', description: 'o2' },
+            ],
+          },
+        ],
+      ]),
+      tasksLocale: { o1: 'Eliminate Scavs', o2: 'Falsche Beschreibung' },
+    });
+    const overrides: LocaleOverlay = {
+      tasks: {
+        t1: {
+          objectives: {
+            o1: { description: 'Eliminate Scavs' },
+            o2: { description: 'Correct description' },
+            gone: { description: 'Objective removed upstream' },
+          },
+        },
+      },
+    };
+
+    const results = byField(validateLocaleOverrides('en', overrides, bundle));
+
+    expect(results['tasks/t1/objectives[o1].description'].verdict).toBe('STALE');
+    expect(results['tasks/t1/objectives[o2].description'].verdict).toBe('NEEDED');
+    expect(results['tasks/t1/objectives[gone].description'].verdict).toBe('REMOVED');
+  });
+
+  it('checks item name, shortName, description via itemsLocale and wikiLink directly', () => {
+    const bundle = makeBundle({
+      itemsById: new Map([
+        [
+          'i1',
+          {
+            id: 'i1',
+            name: 'i1 Name',
+            shortName: 'i1 ShortName',
+            description: 'i1 Description',
+            wikiLink: 'https://wiki/Roubles',
+          },
+        ],
+      ]),
+      itemsLocale: {
+        'i1 Name': 'Roubles',
+        'i1 ShortName': 'RUB',
+        'i1 Description': 'Old text',
+      },
+    });
+    const overrides: LocaleOverlay = {
+      items: {
+        i1: {
+          name: 'Roubles',
+          shortName: 'RUB',
+          description: 'New text',
+          wikiLink: 'https://wiki/Roubles',
+        },
+      },
+    };
+
+    const results = byField(validateLocaleOverrides('en', overrides, bundle));
+
+    expect(results['items/i1/name'].verdict).toBe('STALE');
+    expect(results['items/i1/shortName'].verdict).toBe('STALE');
+    expect(results['items/i1/description'].verdict).toBe('NEEDED');
+    expect(results['items/i1/wikiLink'].verdict).toBe('STALE');
+  });
+
+  it('checks trader and map fields via their own translation maps', () => {
+    const bundle = makeBundle({
+      tradersById: new Map([['tr1', { id: 'tr1', name: 'tr1 Nickname' }]]),
+      tradersLocale: { 'tr1 Nickname': 'Prapor' },
+      mapsById: new Map([['m1', { id: 'm1', name: 'm1 Name' }]]),
+      mapsLocale: { 'm1 Name': 'Fabrik' },
+    });
+    const overrides: LocaleOverlay = {
+      traders: { tr1: { name: 'Prapor' } },
+      maps: { m1: { name: 'Factory' } },
+    };
+
+    const results = byField(validateLocaleOverrides('en', overrides, bundle));
+
+    expect(results['traders/tr1/name'].verdict).toBe('STALE');
+    expect(results['maps/m1/name'].verdict).toBe('NEEDED');
+    expect(results['maps/m1/name'].bundleValue).toBe('Fabrik');
+  });
+
+  it('resolves prestige names from prestigeById via the tasks translation map', () => {
+    const bundle = makeBundle({
+      prestigeById: new Map([['p1', { id: 'p1', name: 'p1 name', prestigeLevel: 1 }]]),
+      tasksLocale: { 'p1 name': 'Prestige 1' },
+    });
+    const overrides: LocaleOverlay = {
+      prestige: { p1: { name: 'Prestige 1' } },
+    };
+
+    const [result] = validateLocaleOverrides('en', overrides, bundle);
+
+    expect(result.entityType).toBe('prestige');
+    expect(result.verdict).toBe('STALE');
+  });
+
+  it('marks storyChapter patches UNVERIFIABLE', () => {
+    const overrides: LocaleOverlay = {
+      storyChapters: {
+        tour: { name: 'Tour', objectives: { 'tour-main-1': { description: 'Visit' } } },
+      },
+    };
+
+    const results = validateLocaleOverrides('en', overrides, makeBundle());
+
+    expect(results).toHaveLength(1);
+    expect(results[0].verdict).toBe('UNVERIFIABLE');
+    expect(results[0].entityType).toBe('storyChapters');
+    expect(results[0].entityId).toBe('tour');
+  });
+
+  it('does not treat prototype keys as translations', () => {
+    const bundle = makeBundle({
+      tasksById: new Map([['t1', { id: 't1', name: 'toString' }]]),
+      tasksLocale: {},
+    });
+    const overrides: LocaleOverlay = {
+      tasks: { t1: { name: 'Anything' } },
+    };
+
+    const [result] = validateLocaleOverrides('en', overrides, bundle);
+
+    // Object.prototype.toString must not leak in as a resolved translation.
+    expect(result.verdict).toBe('NEEDED');
+    expect(result.bundleValue).toBeUndefined();
+  });
+});

--- a/tests/tarkov-api.test.ts
+++ b/tests/tarkov-api.test.ts
@@ -3,7 +3,12 @@
  */
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { fetchTasks, findTaskById, type TaskData } from '../src/lib/index.js';
+import {
+  fetchTasks,
+  fetchLocaleBundle,
+  findTaskById,
+  type TaskData,
+} from '../src/lib/index.js';
 
 type Routes = Record<string, unknown>;
 
@@ -358,6 +363,57 @@ describe('tarkov-api (json.tarkov.dev adapter)', () => {
     await expect(fetchTasks()).rejects.toThrow(
       'Invalid json.tarkov.dev response for regular/tasks: expected data.tasks object'
     );
+  });
+
+  it('fetchLocaleBundle fetches the requested locale endpoints and builds raw lookups', async () => {
+    const fetchMock = mockEndpoints({
+      'regular/tasks': {
+        data: {
+          tasks: { t1: { id: 't1', name: 't1 name', wikiLink: 'https://wiki/T1' } },
+          prestige: [{ id: 'p1', name: 'p1 name', prestigeLevel: 1 }],
+        },
+      },
+      'regular/items': { data: { items: { i1: { id: 'i1', name: 'i1 Name' } } } },
+      'regular/maps': { data: { maps: { m1: { id: 'm1', name: 'm1 Name' } } } },
+      'regular/traders': { data: { tr1: { id: 'tr1', name: 'tr1 Nickname' } } },
+      'regular/tasks_de': { data: { 't1 name': 'Neuanfang' } },
+      'regular/items_de': { data: { 'i1 Name': 'Rubel' } },
+      'regular/maps_de': { data: {} },
+      'regular/traders_de': { data: {} },
+    });
+
+    const bundle = await fetchLocaleBundle('regular', 'de');
+
+    expect(bundle.locale).toBe('de');
+    // Core records stay raw (translation keys as field values, wikiLink inline)
+    expect(bundle.tasksById.get('t1')).toEqual({
+      id: 't1',
+      name: 't1 name',
+      wikiLink: 'https://wiki/T1',
+    });
+    expect(bundle.prestigeById.get('p1')?.prestigeLevel).toBe(1);
+    expect(bundle.itemsById.get('i1')?.name).toBe('i1 Name');
+    expect(bundle.mapsById.has('m1')).toBe(true);
+    expect(bundle.tradersById.has('tr1')).toBe(true);
+    // Locale maps come from the _<locale> endpoints
+    expect(bundle.tasksLocale['t1 name']).toBe('Neuanfang');
+    expect(bundle.itemsLocale['i1 Name']).toBe('Rubel');
+
+    const requested = fetchMock.mock.calls.map((call) => String(call[0]));
+    expect(requested).toContain('https://json.tarkov.dev/regular/tasks_de');
+    expect(requested).toContain('https://json.tarkov.dev/regular/items_de');
+    expect(requested.every((url) => !url.endsWith('_en'))).toBe(true);
+  });
+
+  it('fetchLocaleBundle defaults to regular mode and the en locale', async () => {
+    const fetchMock = mockEndpoints(baseRoutes('regular'));
+
+    const bundle = await fetchLocaleBundle();
+
+    expect(bundle.locale).toBe('en');
+    const requested = fetchMock.mock.calls.map((call) => String(call[0]));
+    expect(requested).toContain('https://json.tarkov.dev/regular/tasks_en');
+    expect(requested.every((url) => !url.includes('/pve/'))).toBe(true);
   });
 
   it('findTaskById returns matching task', () => {


### PR DESCRIPTION
## Summary

Builds on #251. Adds locale-aware stale detection so `npm run check-overrides` now audits every patch in `src/overrides/locales/<locale>.json5` against the live tarkov.dev bundle for the same locale.

Without this, a locale override silently becomes redundant the moment tarkov.dev fixes the bundle upstream. Now each patch gets a per-field verdict:

| Verdict | Meaning | Action |
|---------|---------|--------|
| STALE | bundle now matches the override | remove the patch |
| NEEDED | bundle still broken (or key unresolvable) | keep |
| REMOVED | entity/objective gone from the API | delete the patch |
| UNVERIFIABLE | overlay-authored (`storyChapters`) | skip |

## Design notes

- **No hardcoded translation key formats.** The API is inconsistent (tasks use `"<id> name"", items `"<id> Name"", traders `"<id> Nickname""). The core endpoints store the translation key as the field value, so the validator resolves keys the same way `tarkov-api.ts` already translates english strings.
- **`wikiLink` compares against the core endpoint directly** — it is a URL on `regular/tasks`/`regular/items`, not in the translation bundles.
- **Missing translation key → NEEDED**, never STALE: an upstream fix can't be confirmed, so the override is kept.
- **No separate script.** Locale overrides are overrides against the live API, so this lives in `check-overrides` alongside the existing data-override/additions/editions sections. `fetchLocaleBundle()` in the lib makes a standalone `check-locales` trivial later if wanted.
- `fetchTasks()` signature untouched; `fetchTranslations` gained a locale parameter defaulting to `en`.

## Changes

- `src/lib/locale-validator.ts` (new): `validateLocaleOverrides()` + verdict types
- `src/lib/tarkov-api.ts`: `fetchLocaleBundle(mode, locale)`, exported `TranslationMap`, locale-parameterized `fetchTranslations`
- `src/lib/index.ts`: re-export the new module
- `scripts/check-overrides.ts`: `LOCALE OVERRIDES CHECK (<locale>)` section with per-verdict summary and removal recommendation
- `tests/locale-validator.test.ts` (new): 12 unit tests covering all verdicts, all entity types, wikiLink core-endpoint comparison, bare-key objective resolution, prototype-key safety
- `tests/tarkov-api.test.ts`: `fetchLocaleBundle` endpoint/lookup coverage

## Commands run

- `npm run validate` — all files valid
- `npm test` — 229 passed (17 files)
- `npm run check-overrides` — live run: all 8 `en` New Beginning patches correctly report **NEEDED** (bundle still resolves to `Neuanfang` / German wikiLink)