### PR TITLE
fix: correct Cultist Circle starting level

### DIFF
--- a/dist/overlay.json
+++ b/dist/overlay.json
@@ -3686,7 +3686,7 @@
       "value": 5,
       "title": "The Unheard",
       "defaultStashLevel": 5,
-      "defaultCultistCircleLevel": 3,
+      "defaultCultistCircleLevel": 1,
       "traderRepBonus": {
         "prapor": 0.2,
         "therapist": 0.2,
@@ -3706,7 +3706,7 @@
       "value": 6,
       "title": "Edge of Darkness + Unheard",
       "defaultStashLevel": 5,
-      "defaultCultistCircleLevel": 3,
+      "defaultCultistCircleLevel": 1,
       "traderRepBonus": {
         "prapor": 0.2,
         "therapist": 0.2,
@@ -7387,7 +7387,7 @@
   },
   "$meta": {
     "version": "1.57",
-    "generated": "2026-08-11T14:27:26.972Z",
-    "sha256": "9dcebc5cefb9d11528fd4508b0c8ad617792c9f62208a02b92f356ae598363ee"
+    "generated": "2026-08-12T00:47:12.582Z",
+    "sha256": "d88fe120f1885ea205f69893e95c82ea5a845a94749bd0991ab7407234a57802"
   }
 }

--- a/src/additions/editions.json5
+++ b/src/additions/editions.json5
@@ -7,7 +7,7 @@
   // - value: Numeric ID used by TarkovTracker (1-6)
   // - title: Display name
   // - defaultStashLevel: Starting stash level (1-5)
-  // - defaultCultistCircleLevel: Starting cultist circle level (0 or 3)
+  // - defaultCultistCircleLevel: Starting cultist circle level (0 or 1)
   // - traderRepBonus: Starting reputation bonus per trader (0.0 or 0.2)
   // - exclusiveTaskIds: Task IDs only available to this edition (tarkov.dev IDs)
   // - excludedTaskIds: Task IDs not available to this edition (edition already grants the perk)
@@ -111,7 +111,7 @@
     value: 5,
     title: 'The Unheard',
     defaultStashLevel: 5,
-    defaultCultistCircleLevel: 3,
+    defaultCultistCircleLevel: 1,
     traderRepBonus: {
       prapor: 0.2,
       therapist: 0.2,
@@ -135,7 +135,7 @@
     value: 6,
     title: 'Edge of Darkness + Unheard',
     defaultStashLevel: 5,
-    defaultCultistCircleLevel: 3,
+    defaultCultistCircleLevel: 1,
     traderRepBonus: {
       prapor: 0.2,
       therapist: 0.2,

--- a/src/schemas/edition.schema.json
+++ b/src/schemas/edition.schema.json
@@ -5,8 +5,8 @@
     "additionalProperties": true,
     "properties": {
       "defaultCultistCircleLevel": {
-        "description": "Starting Cultist Circle level (0-3)",
-        "maximum": 3,
+        "description": "Starting Cultist Circle level (0-1)",
+        "maximum": 1,
         "minimum": 0,
         "type": "integer"
       },


### PR DESCRIPTION
## Summary

- Set the Unheard and Edge of Darkness + Unheard Cultist Circle starting level from 3 to its only in-game level, 1.
- Restrict the edition schema to valid Cultist Circle levels 0–1.
- Regenerate dist/overlay.json.

## Why

Current json.tarkov.dev hideout data defines the Cultist Circle as a single-level station. The previous edition metadata incorrectly represented the Unheard grant as level 3.

## Validation

- npm run validate
- npm run build
- npm test — 345 tests passed
- npm run typecheck

The existing repository-wide Prettier baseline is tracked separately in #265.