### PR TITLE
feat: add Network Provider - Part 1 unlock wiring

### DIFF
--- a/dist/overlay.json
+++ b/dist/overlay.json
@@ -3596,6 +3596,128 @@
     },
     "666314b0acf8442f8b0531a1": {
       "experience": 3000
+    },
+    "625d6ff5ddc94657c21a1625": {
+      "taskRequirements": [
+        {
+          "task": {
+            "id": "5ae4493d86f7744b8e15aa8f",
+            "name": "A Big Loss"
+          },
+          "status": [
+            "complete"
+          ]
+        },
+        {
+          "task": {
+            "id": "608974d01a66564e74191fc0",
+            "name": "A Fuel Matter"
+          },
+          "status": [
+            "complete"
+          ]
+        },
+        {
+          "task": {
+            "id": "63913715f8e5dd32bf4e3aaa",
+            "name": "Broadcast - Part 2"
+          },
+          "status": [
+            "complete"
+          ]
+        },
+        {
+          "task": {
+            "id": "597a0f5686f774273b74f676",
+            "name": "Chemical - Part 4"
+          },
+          "status": [
+            "complete",
+            "failed"
+          ]
+        },
+        {
+          "task": {
+            "id": "5d25e48186f77443e625e386",
+            "name": "Courtesy Visit"
+          },
+          "status": [
+            "complete"
+          ]
+        },
+        {
+          "task": {
+            "id": "61958c366726521dd96828ec",
+            "name": "Gifts from Tarkov"
+          },
+          "status": [
+            "complete"
+          ]
+        },
+        {
+          "task": {
+            "id": "5ae327c886f7745c7b3f2f3f",
+            "name": "Gunsmith - AK-105"
+          },
+          "status": [
+            "complete"
+          ]
+        },
+        {
+          "task": {
+            "id": "639135c3744e452011470807",
+            "name": "House Arrest"
+          },
+          "status": [
+            "complete"
+          ]
+        },
+        {
+          "task": {
+            "id": "6179afd0bca27a099552e040",
+            "name": "Lost Contact"
+          },
+          "status": [
+            "complete"
+          ]
+        },
+        {
+          "task": {
+            "id": "6179ad56c760af5ad2053587",
+            "name": "Seaside Vacation"
+          },
+          "status": [
+            "complete"
+          ]
+        },
+        {
+          "task": {
+            "id": "5a27b9de86f77464e5044585",
+            "name": "The Cult"
+          },
+          "status": [
+            "complete"
+          ]
+        },
+        {
+          "task": {
+            "id": "5d25e2cc86f77443e47ae019",
+            "name": "The Huntsman Path - Forest Cleaning"
+          },
+          "status": [
+            "complete"
+          ]
+        },
+        {
+          "task": {
+            "id": "59ca264786f77445a80ed044",
+            "name": "The Punisher - Part 4"
+          },
+          "status": [
+            "complete"
+          ]
+        }
+      ]
     }
   },
   "craftsAdd": {
@@ -6652,7 +6774,13 @@
       ],
       "rewards": null,
       "mapUnlocks": [],
-      "traderUnlocks": []
+      "traderUnlocks": [],
+      "questUnlocks": [
+        {
+          "id": "625d6ff5ddc94657c21a1625",
+          "name": "Network Provider - Part 1"
+        }
+      ]
     },
     "the-unheard": {
       "id": "the-unheard",
@@ -7848,6 +7976,12 @@
         {
           "id": "688246518448b05efd61d461",
           "name": "Mr. Kerman"
+        }
+      ],
+      "questUnlocks": [
+        {
+          "id": "625d6ff5ddc94657c21a1625",
+          "name": "Network Provider - Part 1"
         }
       ]
     },
@@ -9472,7 +9606,7 @@
   },
   "$meta": {
     "version": "1.60",
-    "generated": "2026-08-14T09:00:35.315Z",
-    "sha256": "22b9e87c965f72a4ee2206079a8376cf7923b0956affcb8265cf3390a9411ed9"
+    "generated": "2026-08-14T09:46:17.513Z",
+    "sha256": "263033ad00547a645a69801ea144cffadbc02b7754e708d501f50e3002b2258f"
   }
 }

--- a/scripts/eft-story-generate.ts
+++ b/scripts/eft-story-generate.ts
@@ -209,6 +209,9 @@ function main(): void {
     chapter.rewards = meta.rewards ?? null;
     chapter.mapUnlocks = meta.mapUnlocks ?? [];
     chapter.traderUnlocks = meta.traderUnlocks ?? [];
+    if (meta.questUnlocks) {
+      chapter.questUnlocks = meta.questUnlocks;
+    }
     out[chapterId] = chapter;
   }
 

--- a/scripts/story-chapter-meta.json
+++ b/scripts/story-chapter-meta.json
@@ -111,7 +111,13 @@
     "notes": null,
     "rewards": null,
     "mapUnlocks": [],
-    "traderUnlocks": []
+    "traderUnlocks": [],
+    "questUnlocks": [
+      {
+        "id": "625d6ff5ddc94657c21a1625",
+        "name": "Network Provider - Part 1"
+      }
+    ]
   },
   "the-unheard": {
     "id": "the-unheard",
@@ -232,6 +238,12 @@
       {
         "id": "688246518448b05efd61d461",
         "name": "Mr. Kerman"
+      }
+    ],
+    "questUnlocks": [
+      {
+        "id": "625d6ff5ddc94657c21a1625",
+        "name": "Network Provider - Part 1"
       }
     ],
     "objectives": [

--- a/src/additions/storyChapters.json5
+++ b/src/additions/storyChapters.json5
@@ -929,6 +929,12 @@
       rewards: null,
       mapUnlocks: [],
       traderUnlocks: [],
+      questUnlocks: [
+          {
+              id: '625d6ff5ddc94657c21a1625',
+              name: 'Network Provider - Part 1',
+          },
+      ],
   },
 
   // The Unheard
@@ -2142,6 +2148,12 @@
           {
               id: '688246518448b05efd61d461',
               name: 'Mr. Kerman',
+          },
+      ],
+      questUnlocks: [
+          {
+              id: '625d6ff5ddc94657c21a1625',
+              name: 'Network Provider - Part 1',
           },
       ],
   },

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -323,6 +323,8 @@ export interface StoryChapter {
   activation?: StoryChapterActivation;
   mapUnlocks?: Array<{ id: string; name: string }>;
   traderUnlocks?: Array<{ id: string; name: string }>;
+  /** Quests unlocked by progressing through this chapter (alternative to taskRequirements) */
+  questUnlocks?: Array<{ id: string; name: string }>;
   description?: string | null;
   notes?: string | null;
   objectives?: StoryObjective[];

--- a/src/overrides/tasks.json5
+++ b/src/overrides/tasks.json5
@@ -3620,4 +3620,44 @@
   '666314b0acf8442f8b0531a1': {
     experience: 3000, // Was: 2300 (all modes, stale pre-1.1 value)
   },
+
+  // Network Provider - Part 1 - missing task prerequisites
+  //
+  // tarkov.dev serves taskRequirements: [] (empty), so the quest appears
+  // available before any of its in-game prerequisites are met (issue #254).
+  // The wiki's Requirements section lists a Scav karma +2 gate (already
+  // correctly served as a traderRequirements reputation >= 2) plus a
+  // quest-completion unlock path:
+  //
+  //   A Big Loss, A Fuel Matter, Broadcast - Part 2,
+  //   Chemical - Part 4 *or* Out of Curiosity *or* Big Customer,
+  //   Courtesy Visit, Gifts from Tarkov, Gunsmith - AK-105, House Arrest,
+  //   Lost Contact, Seaside Vacation, The Cult,
+  //   The Huntsman Path - Forest Cleaning, The Punisher - Part 4
+  //
+  // The story-chapter unlock paths (Batya / The Ticket) are wired separately
+  // as storyChapters[].questUnlocks; consumers evaluate those as an
+  // ALTERNATIVE to this taskRequirements list (OR between the two paths).
+  // Proof: https://escapefromtarkov.fandom.com/wiki/Network_Provider_-_Part_1
+  '625d6ff5ddc94657c21a1625': {
+    taskRequirements: [
+      { task: { id: '5ae4493d86f7744b8e15aa8f', name: 'A Big Loss' }, status: ['complete'] },
+      { task: { id: '608974d01a66564e74191fc0', name: 'A Fuel Matter' }, status: ['complete'] },
+      { task: { id: '63913715f8e5dd32bf4e3aaa', name: 'Broadcast - Part 2' }, status: ['complete'] },
+      // Chemical chain: wiki lists "Chemical - Part 4 or Out of Curiosity or
+      // Big Customer" (any one of the three). Modeled like tarkov.dev's
+      // Collector, which uses ['complete', 'failed'] on Chemical - Part 4 to
+      // mean "chain resolved to a terminal state".
+      { task: { id: '597a0f5686f774273b74f676', name: 'Chemical - Part 4' }, status: ['complete', 'failed'] },
+      { task: { id: '5d25e48186f77443e625e386', name: 'Courtesy Visit' }, status: ['complete'] },
+      { task: { id: '61958c366726521dd96828ec', name: 'Gifts from Tarkov' }, status: ['complete'] },
+      { task: { id: '5ae327c886f7745c7b3f2f3f', name: 'Gunsmith - AK-105' }, status: ['complete'] },
+      { task: { id: '639135c3744e452011470807', name: 'House Arrest' }, status: ['complete'] },
+      { task: { id: '6179afd0bca27a099552e040', name: 'Lost Contact' }, status: ['complete'] },
+      { task: { id: '6179ad56c760af5ad2053587', name: 'Seaside Vacation' }, status: ['complete'] },
+      { task: { id: '5a27b9de86f77464e5044585', name: 'The Cult' }, status: ['complete'] },
+      { task: { id: '5d25e2cc86f77443e47ae019', name: 'The Huntsman Path - Forest Cleaning' }, status: ['complete'] },
+      { task: { id: '59ca264786f77445a80ed044', name: 'The Punisher - Part 4' }, status: ['complete'] },
+    ],
+  },
 }

--- a/src/overrides/tasks.json5
+++ b/src/overrides/tasks.json5
@@ -3643,12 +3643,18 @@
     taskRequirements: [
       { task: { id: '5ae4493d86f7744b8e15aa8f', name: 'A Big Loss' }, status: ['complete'] },
       { task: { id: '608974d01a66564e74191fc0', name: 'A Fuel Matter' }, status: ['complete'] },
-      { task: { id: '63913715f8e5dd32bf4e3aaa', name: 'Broadcast - Part 2' }, status: ['complete'] },
+      {
+        task: { id: '63913715f8e5dd32bf4e3aaa', name: 'Broadcast - Part 2' },
+        status: ['complete'],
+      },
       // Chemical chain: wiki lists "Chemical - Part 4 or Out of Curiosity or
       // Big Customer" (any one of the three). Modeled like tarkov.dev's
       // Collector, which uses ['complete', 'failed'] on Chemical - Part 4 to
       // mean "chain resolved to a terminal state".
-      { task: { id: '597a0f5686f774273b74f676', name: 'Chemical - Part 4' }, status: ['complete', 'failed'] },
+      {
+        task: { id: '597a0f5686f774273b74f676', name: 'Chemical - Part 4' },
+        status: ['complete', 'failed'],
+      },
       { task: { id: '5d25e48186f77443e625e386', name: 'Courtesy Visit' }, status: ['complete'] },
       { task: { id: '61958c366726521dd96828ec', name: 'Gifts from Tarkov' }, status: ['complete'] },
       { task: { id: '5ae327c886f7745c7b3f2f3f', name: 'Gunsmith - AK-105' }, status: ['complete'] },
@@ -3656,8 +3662,14 @@
       { task: { id: '6179afd0bca27a099552e040', name: 'Lost Contact' }, status: ['complete'] },
       { task: { id: '6179ad56c760af5ad2053587', name: 'Seaside Vacation' }, status: ['complete'] },
       { task: { id: '5a27b9de86f77464e5044585', name: 'The Cult' }, status: ['complete'] },
-      { task: { id: '5d25e2cc86f77443e47ae019', name: 'The Huntsman Path - Forest Cleaning' }, status: ['complete'] },
-      { task: { id: '59ca264786f77445a80ed044', name: 'The Punisher - Part 4' }, status: ['complete'] },
-    ],
+      {
+        task: { id: '5d25e2cc86f77443e47ae019', name: 'The Huntsman Path - Forest Cleaning' },
+        status: ['complete'],
+      },
+      {
+        task: { id: '59ca264786f77445a80ed044', name: 'The Punisher - Part 4' },
+        status: ['complete'],
+      },
+    ], // Was: []
   },
 }

--- a/src/schemas/story-chapter.schema.json
+++ b/src/schemas/story-chapter.schema.json
@@ -102,6 +102,19 @@
           "additionalProperties": false
         }
       },
+      "questUnlocks": {
+        "description": "Quests unlocked by progressing through this chapter (tarkov.dev task IDs). Consumers treat these as an alternative unlock path to the quest's taskRequirements.",
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": ["id", "name"],
+          "properties": {
+            "id": { "type": "string" },
+            "name": { "type": "string" }
+          },
+          "additionalProperties": false
+        }
+      },
       "description": {
         "description": "Brief description or guidance for the chapter",
         "type": ["string", "null"]

--- a/tests/story-chapters.test.ts
+++ b/tests/story-chapters.test.ts
@@ -66,4 +66,13 @@ describe('story chapters (EFT-sourced)', () => {
     expect(objs.some((o) => o.endingId)).toBe(true);
     expect(objs.some((o) => (o.mutuallyExclusiveWith?.length ?? 0) > 0)).toBe(true);
   });
+
+  it('wires Network Provider - Part 1 as a story-chapter unlock for Batya and The Ticket', () => {
+    const unlock = { id: '625d6ff5ddc94657c21a1625', name: 'Network Provider - Part 1' };
+    for (const cid of ['batya', 'the-ticket']) {
+      const ch = chapters[cid];
+      expect(ch, `chapter ${cid}`).toBeDefined();
+      expect(ch.questUnlocks ?? [], `${cid} questUnlocks`).toContainEqual(unlock);
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Fixes the *data* half of #254 (Network Provider - Part 1 becomes available before The Punisher - Part 4).

tarkov.dev serves `Network Provider - Part 1` (`625d6ff5ddc94657c21a1625`) with an empty `taskRequirements` list, so it appears available before any of its in-game prerequisites are met. The wiki's Requirements section lists a Scav karma +2 gate (already correctly served as `traderRequirements`) plus two unlock paths:

1. **Story-chapter path** — progressing through *Batya* or *The Ticket*.
2. **Quest-completion path** — 13 quests (with one internal OR group).

## Changes

- **`taskRequirements` override** (`src/overrides/tasks.json5`): the 13-quest legacy path. The `Chemical - Part 4 / Out of Curiosity / Big Customer` OR-group is modeled as `['complete', 'failed']` on Chemical - Part 4, matching tarkov.dev's own `Collector` convention for "chain resolved to a terminal state".
- **`storyChapters[].questUnlocks`** (new field): schema + types + data wiring *Batya* and *The Ticket* → `Network Provider - Part 1`. This gives consumers a machine-readable way to treat the story-chapter path as an alternative to `taskRequirements`.

## Consumer follow-up

The *logic* half (OR between the story-chapter path and the `taskRequirements` path) is intentionally out of scope here — it belongs in the consumer. See the linked issue and the data contract documented on the new `questUnlocks` schema field.

## Verification

- `npm run validate` — all files valid
- `npm run build` — overlay built
- `npm run typecheck` — clean
- `npm run check-overrides` — `taskRequirements: API=[] (empty), Override has 13 requirement(s) - STILL NEEDED` (expected)

## Proof

- https://escapefromtarkov.fandom.com/wiki/Network_Provider_-_Part_1

Closes #254 (data half). Related: #23 (consumer-side story-chapter unlock evaluation).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tarkovtracker-org/tarkov-data-overlay/pull/269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

