### PR TITLE
fix(check-overrides): validate craftsAdd additions against the crafts endpoint

### DIFF
--- a/scripts/check-overrides.ts
+++ b/scripts/check-overrides.ts
@@ -188,6 +188,13 @@ const ENTITY_ADDITION_SPECS: EntityCheckSpec[] = [
     endpoint: 'items',
     collectionKey: 'items',
   },
+  {
+    label: 'craftsAdd',
+    segments: ['additions', 'craftsAdd.json5'],
+    endpoint: 'crafts',
+    // The crafts endpoint returns the collection directly under `data` as a
+    // top-level array (no wrapping collection key).
+  },
 ];
 
 const STATUS_ICONS: Record<ValidationResult['status'], string> = {

--- a/src/lib/tarkov-api.ts
+++ b/src/lib/tarkov-api.ts
@@ -421,6 +421,11 @@ export async function fetchRawEntities(
 ): Promise<Map<string, Record<string, unknown>>> {
   const cache: EndpointCache = new Map();
   const envelope = await fetchEnvelope(cache, `${mode}/${endpoint}`);
+  // Some endpoints (e.g. crafts) return the collection directly under `data`
+  // as a top-level array rather than an id-keyed object.
+  if (Array.isArray(envelope.data)) {
+    return toLookup(envelope.data);
+  }
   const data = isRecord(envelope.data) ? envelope.data : {};
   const collection = collectionKey ? data[collectionKey] : data;
   return toLookup(collection);

--- a/src/lib/tarkov-api.ts
+++ b/src/lib/tarkov-api.ts
@@ -422,8 +422,16 @@ export async function fetchRawEntities(
   const cache: EndpointCache = new Map();
   const envelope = await fetchEnvelope(cache, `${mode}/${endpoint}`);
   // Some endpoints (e.g. crafts) return the collection directly under `data`
-  // as a top-level array rather than an id-keyed object.
+  // as a top-level array rather than an id-keyed object. A top-level array
+  // cannot be keyed by name, so combining it with a `collectionKey` is a
+  // misconfiguration and fails loudly rather than silently indexing the
+  // wrong collection.
   if (Array.isArray(envelope.data)) {
+    if (collectionKey) {
+      throw new Error(
+        `fetchRawEntities: ${mode}/${endpoint} returned a top-level array but collectionKey '${collectionKey}' was provided`
+      );
+    }
     return toLookup(envelope.data);
   }
   const data = isRecord(envelope.data) ? envelope.data : {};

--- a/tests/tarkov-api.test.ts
+++ b/tests/tarkov-api.test.ts
@@ -480,6 +480,16 @@ describe('tarkov-api (json.tarkov.dev adapter)', () => {
       expect(entities.get('item-a')).toBeDefined();
     });
 
+    it('throws when a top-level array is combined with a collectionKey', async () => {
+      mockEndpoints({
+        'regular/crafts': { data: [{ id: 'craft-a' }] },
+      });
+
+      await expect(fetchRawEntities('regular', 'crafts', 'crafts')).rejects.toThrow(
+        /collectionKey 'crafts' was provided/
+      );
+    });
+
     it('treats the data object itself as the collection when no key is provided', async () => {
       mockEndpoints({
         'regular/traders': { data: { 'trader-a': { id: 'trader-a' } } },

--- a/tests/tarkov-api.test.ts
+++ b/tests/tarkov-api.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   fetchTasks,
   fetchLocaleBundle,
+  fetchRawEntities,
   findTaskById,
   USER_AGENT,
   type TaskData,
@@ -448,5 +449,46 @@ describe('tarkov-api (json.tarkov.dev adapter)', () => {
 
     expect(findTaskById(tasks, 'task-2')).toEqual({ id: 'task-2', name: 'Task 2' });
     expect(findTaskById(tasks, 'missing')).toBeUndefined();
+  });
+
+  describe('fetchRawEntities', () => {
+    it('indexes a top-level array collection by id (crafts endpoint shape)', async () => {
+      mockEndpoints({
+        'regular/crafts': {
+          data: [
+            { id: 'craft-a', station: 's1', level: 1 },
+            { id: 'craft-b', station: 's2', level: 2 },
+          ],
+        },
+      });
+
+      const entities = await fetchRawEntities('regular', 'crafts');
+
+      expect(entities.size).toBe(2);
+      expect(entities.get('craft-a')).toMatchObject({ id: 'craft-a', level: 1 });
+      expect(entities.get('craft-b')).toMatchObject({ id: 'craft-b', level: 2 });
+    });
+
+    it('drills into a nested collection when collectionKey is provided', async () => {
+      mockEndpoints({
+        'regular/items': { data: { items: { 'item-a': { id: 'item-a' } } } },
+      });
+
+      const entities = await fetchRawEntities('regular', 'items', 'items');
+
+      expect(entities.size).toBe(1);
+      expect(entities.get('item-a')).toBeDefined();
+    });
+
+    it('treats the data object itself as the collection when no key is provided', async () => {
+      mockEndpoints({
+        'regular/traders': { data: { 'trader-a': { id: 'trader-a' } } },
+      });
+
+      const entities = await fetchRawEntities('regular', 'traders');
+
+      expect(entities.size).toBe(1);
+      expect(entities.get('trader-a')).toBeDefined();
+    });
   });
 });


### PR DESCRIPTION
## **User description**
## Summary

`craftsAdd` was the only additions file not checked for upstream resolution. `itemsAdd` is wired into `ENTITY_ADDITION_SPECS`, but `craftsAdd` was missing, so a hideout craft addition could silently become stale once tarkov.dev shipped the craft natively.

## Changes

### `scripts/check-overrides.ts`
- Add `craftsAdd` to `ENTITY_ADDITION_SPECS` (`endpoint: crafts`, no `collectionKey`).

### `src/lib/tarkov-api.ts`
- `fetchRawEntities` now indexes top-level **array** collections directly. The `crafts` endpoint returns `data` as an array (not an id-keyed object like `items`), which the previous implementation dropped (treating non-record `data` as `{}`). Without this, `craftsAdd` validation would always report "still needed".

### `tests/tarkov-api.test.ts`
- New `fetchRawEntities` tests covering the three endpoint shapes: top-level array (`crafts`), nested collection key (`items`), and flat id-keyed object (`traders`).

## Verification

- `npm test` — 382 passed ✅
- `npm run typecheck` ✅
- `npm run check-overrides` — now emits a `CRAFTSADD OVERLAY CHECK` section (fetches 214 crafts, all 23 `craftsAdd` entries still needed) ✅

## Note (out of scope)

The entity-check summary counts display lines rather than entries, so "Still needed (N)" reads as 2× the entry count (e.g. 23 crafts show as "46"). This is pre-existing and affects `itemsAdd` too; left untouched to keep this PR focused.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tarkovtracker-org/tarkov-data-overlay/pull/271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Validate hideout craft additions against the upstream crafts data

### What Changed
- Craft additions are now checked against the upstream crafts endpoint, so entries that have become available upstream can be identified.
- Craft data returned as a top-level list is now recognized instead of being ignored.
- Added coverage for craft, item, and trader response formats to ensure entity checks continue to resolve correctly.

### Impact
`✅ Fewer stale craft additions`
`✅ Accurate upstream resolution checks`
`✅ Reliable validation across API response formats`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
