### PR TITLE
fix(check-overrides): report true entry counts in entity check summaries

### DIFF
--- a/scripts/check-overrides.ts
+++ b/scripts/check-overrides.ts
@@ -859,12 +859,19 @@ function printEntityResults(
     grouped.removedFromApi.map((r) => r.id),
     icons.error
   );
-  printCountSection('Still needed', 'yellow', lines(grouped.stillNeeded), icons.warning);
+  printCountSection(
+    'Still needed',
+    'yellow',
+    lines(grouped.stillNeeded),
+    icons.warning,
+    grouped.stillNeeded.length
+  );
   printCountSection(
     'Fixed upstream - safe to retire',
     'green',
     lines(grouped.fixed),
-    icons.success
+    icons.success,
+    grouped.fixed.length
   );
 
   // REMOVED_FROM_API results carry their own 'error' detail and are already

--- a/src/lib/terminal.ts
+++ b/src/lib/terminal.ts
@@ -106,14 +106,20 @@ export function formatCountLabel(label: string, count: number, color: keyof type
  * Print a "label (count) : status" header followed by one line per item, or a
  * dim "None" placeholder when the list is empty. This is the standard summary
  * section shape used by the maintenance reports.
+ *
+ * When `count` is supplied it is shown in the header instead of `items.length`.
+ * This lets callers display one line per entry (e.g. an entry title plus a
+ * nested detail line) while still reporting the true number of entries.
  */
 export function printCountSection(
   label: string,
   color: keyof typeof colors,
   items: string[],
-  icon?: string
+  icon?: string,
+  count?: number
 ): void {
-  console.log(`${formatCountLabel(label, items.length, color)}${icon ? ` : ${icon}` : ''}`);
+  const total = count ?? items.length;
+  console.log(`${formatCountLabel(label, total, color)}${icon ? ` : ${icon}` : ''}`);
   if (items.length > 0) {
     for (const item of items) {
       console.log(`  - ${item}`);

--- a/tests/terminal.test.ts
+++ b/tests/terminal.test.ts
@@ -2,8 +2,16 @@
  * Tests for terminal formatting utilities
  */
 
-import { describe, it, expect } from 'vitest';
-import { colors, icons, colorize, bold, dim, formatCountLabel } from '../src/lib/index.js';
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import {
+  colors,
+  icons,
+  colorize,
+  bold,
+  dim,
+  formatCountLabel,
+  printCountSection,
+} from '../src/lib/index.js';
 
 describe('colors', () => {
   it('contains expected color codes', () => {
@@ -80,5 +88,36 @@ describe('formatCountLabel', () => {
     const result = formatCountLabel('Empty', 0, 'yellow');
 
     expect(result).toContain('(0)');
+  });
+});
+
+describe('printCountSection', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('shows the override count in the header instead of the number of display lines', () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    // Four display lines (entry title + nested detail), but only two entries.
+    printCountSection(
+      'Still needed',
+      'yellow',
+      ['entry-a', '   detail-a', 'entry-b', '   detail-b'],
+      undefined,
+      2
+    );
+
+    const header = String(logSpy.mock.calls[0][0]);
+    expect(header).toContain('Still needed (2)');
+  });
+
+  it('falls back to the number of items when no count override is provided', () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    printCountSection('Items', 'green', ['a', 'b', 'c']);
+
+    const header = String(logSpy.mock.calls[0][0]);
+    expect(header).toContain('Items (3)');
   });
 });


### PR DESCRIPTION
## **User description**
## Summary

The entity-check summaries in `npm run check-overrides` reported the wrong count for "Still needed" and "Fixed upstream - safe to retire". Each entry renders two display lines (an id line plus a nested detail line), so the header showed 2× the real number of entries — e.g. 16 `itemsAdd` entries displayed as "Still needed (32)".

This was called out as out-of-scope in #271; this PR addresses it.

## Changes

### `src/lib/terminal.ts`
- `printCountSection` gains an optional `count` override. When provided it is shown in the header instead of `items.length`, while still printing every display line.

### `scripts/check-overrides.ts`
- `printEntityResults` now passes `grouped.stillNeeded.length` and `grouped.fixed.length` as the reported count.

### `tests/terminal.test.ts`
- New `printCountSection` tests: the `count` override wins over display-line count, and the fallback to `items.length` still works.

## Verification

- `npm test` — 381 passed ✅
- `npm run typecheck` ✅
- `npm run check-overrides` — `itemsAdd` now reports "Still needed (16)" instead of "(32)" ✅

## Note
Independent of #271 (different files/lines; no conflict). #271 adds the `craftsAdd` section that also benefits from this corrected count once both merge.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tarkovtracker-org/tarkov-data-overlay/pull/272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Report accurate entry counts in entity check summaries

### What Changed
- “Still needed” and “Fixed upstream - safe to retire” now show the number of entries instead of counting each entry’s detail lines
- Summary sections can display detailed lines while reporting the corresponding entry total
- Added coverage for custom counts and the existing default count behavior

### Impact
`✅ Accurate entity-check totals`
`✅ Clearer maintenance reports`
`✅ Reliable count formatting`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
