### PR TITLE
fix(tasks): preserve tarkov.dev trader-requirement discriminators

### DIFF
--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -240,6 +240,68 @@ handles this by appending `objectivesAdd` to the objective list.
 
 ---
 
+## Applying Trader Requirements
+
+Trader requirements use json.tarkov.dev's **discriminated** shape. Every entry
+identifies whether it is a Loyalty Level (`level`, LL1-LL4) or a trader
+reputation threshold (`reputation`, incl. scav karma), because the value range
+alone is ambiguous — reputation entries serve positive, zero, and negative
+values, with `>=`, `<=`, and `<` comparators.
+
+```typescript
+interface TraderRequirement {
+  id: string; // upstream requirement id, or a stable 'overlay.'-prefixed synthetic id
+  requirementType: 'level' | 'reputation';
+  compareMethod: '>=' | '<=' | '>' | '<' | '=';
+  value: number;
+  trader: { id: string; name: string };
+}
+```
+
+### Merge semantics (patch-by-id)
+
+Merge requirements by `id`, not by array position, so an overlay cannot
+accidentally strip the `level`/`reputation` discriminator that was present
+upstream:
+
+```typescript
+function applyTraderRequirements(
+  baseReqs: TraderRequirement[],
+  overrideReqs: TraderRequirement[]
+): TraderRequirement[] {
+  const byId = new Map(baseReqs.map((r) => [r.id, r]));
+  for (const req of overrideReqs) {
+    byId.set(req.id, { ...byId.get(req.id), ...req }); // patch existing, else append
+  }
+  return [...byId.values()];
+}
+```
+
+- **Overlay-only requirements** carry a synthetic id prefixed `overlay.` (e.g.
+  `overlay.<taskId>.<traderId>.<type>.<method>.<value>`), deterministic and
+  stable across builds. They never collide with a tarkov.dev 24-hex id, so they
+  append instead of patch.
+- **Upstream-preserved requirements** keep their upstream `id`, so a correction
+  patches the existing requirement in place.
+- **Clearing requirements** is expressed by an empty array
+  (`traderRequirements: []`), which replaces the upstream array.
+- **Do not** re-derive the semantic from `trader` + `value`: Fence LL1 and Fence
+  `reputation >= 1` are distinct requirements. Switch evaluation on
+  `requirementType`, not on value range or trader identity.
+
+### Migration / compatibility
+
+The new fields (`id`, `requirementType`, `compareMethod`) are additive: existing
+consumers that only read `trader` + `value` keep working, and a wholesale
+`{ ...baseTask, ...override }` replace-array merge is still correct for the
+current data. To benefit from the discriminated schema, migrate the
+`traderRequirements` merge to patch-by-id as shown above. Requirements that were
+mislabeled as Loyalty Level but are actually reputation gates were removed from
+the overlay (upstream already serves the correct discriminated entries), so a
+consumer that switches on `requirementType` will not see them regress.
+
+---
+
 ## Applying Mode-Specific Data (PVP vs PVE vs Seasonal)
 
 Some corrections differ by game mode. The overlay stores these under

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -252,8 +252,8 @@ values, with `>=`, `<=`, and `<` comparators.
 interface TraderRequirement {
   id: string; // upstream requirement id, or a stable 'overlay.'-prefixed synthetic id
   requirementType: 'level' | 'reputation';
-  compareMethod: '>=' | '<=' | '>' | '<' | '=';
-  value: number;
+  compareMethod: '>=' | '<=' | '>' | '<' | '='; // level requires '>='
+  value: number; // level requires an integer from 1 through 4
   trader: { id: string; name: string };
 }
 ```
@@ -280,14 +280,19 @@ function applyTraderRequirements(
 }
 ```
 
-- **Overlay-only requirements** carry a synthetic id prefixed `overlay.` (e.g.
-  `overlay.<taskId>.<traderId>.<type>.<method>.<value>`), deterministic and
-  stable across builds. They never collide with an upstream id (`<24-hex>`, or
-  the composite `<24-hex taskId>-<24-hex traderId>` tarkov.dev emits for some
-  reputation gates), so they append instead of patch. Both id shapes are
-  enforced by the task schemas, and `npm run validate` additionally checks that
-  each synthetic id is derived from the entry it labels (and that no two
-  requirements in one task share an id), so a malformed or drifted id fails
+- **Synthetic requirement IDs** use the `overlay.` prefix (for example,
+  `overlay.<taskId>.<traderId>.<type>.<method>.<value>`). The prefix identifies
+  the ID as synthetic; it does not imply that the requirement itself was
+  authored by the overlay. Overlay-only requirements use this form, and the
+  API adapter also assigns it when an upstream requirement is missing an ID.
+  Semantically identical repeated id-less upstream entries keep the base ID for
+  the first occurrence and add `.occurrence.<n>` from the second occurrence so
+  they remain distinct and deterministic. Synthetic IDs never collide with an
+  upstream ID (`<24-hex>`, or the composite `<24-hex taskId>-<24-hex traderId>`
+  tarkov.dev emits for some reputation gates). Both ID shapes are enforced by
+  the task schemas, and `npm run validate` additionally checks that each
+  synthetic ID is derived from the entry it labels (and that no two
+  requirements in one task share an ID), so a malformed or drifted ID fails
   validation.
 - **Upstream-preserved requirements** keep their upstream `id`, so a correction
   patches the existing requirement in place.

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -265,10 +265,13 @@ accidentally strip the `level`/`reputation` discriminator that was present
 upstream:
 
 ```typescript
+// Call only when `override.traderRequirements !== undefined`: an absent field
+// means "no change", an empty array means "clear".
 function applyTraderRequirements(
   baseReqs: TraderRequirement[],
   overrideReqs: TraderRequirement[]
 ): TraderRequirement[] {
+  if (overrideReqs.length === 0) return []; // clears the upstream requirements
   const byId = new Map(baseReqs.map((r) => [r.id, r]));
   for (const req of overrideReqs) {
     byId.set(req.id, { ...byId.get(req.id), ...req }); // patch existing, else append
@@ -279,12 +282,15 @@ function applyTraderRequirements(
 
 - **Overlay-only requirements** carry a synthetic id prefixed `overlay.` (e.g.
   `overlay.<taskId>.<traderId>.<type>.<method>.<value>`), deterministic and
-  stable across builds. They never collide with a tarkov.dev 24-hex id, so they
-  append instead of patch.
+  stable across builds. They never collide with an upstream id (`<24-hex>`, or
+  the composite `<24-hex taskId>-<24-hex traderId>` tarkov.dev emits for some
+  reputation gates), so they append instead of patch. Both id shapes are
+  enforced by the task schemas, so a malformed id fails `npm run validate`.
 - **Upstream-preserved requirements** keep their upstream `id`, so a correction
   patches the existing requirement in place.
 - **Clearing requirements** is expressed by an empty array
-  (`traderRequirements: []`), which replaces the upstream array.
+  (`traderRequirements: []`), which replaces the upstream array. An absent
+  `traderRequirements` field means "no change".
 - **Do not** re-derive the semantic from `trader` + `value`: Fence LL1 and Fence
   `reputation >= 1` are distinct requirements. Switch evaluation on
   `requirementType`, not on value range or trader identity.

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -285,7 +285,10 @@ function applyTraderRequirements(
   stable across builds. They never collide with an upstream id (`<24-hex>`, or
   the composite `<24-hex taskId>-<24-hex traderId>` tarkov.dev emits for some
   reputation gates), so they append instead of patch. Both id shapes are
-  enforced by the task schemas, so a malformed id fails `npm run validate`.
+  enforced by the task schemas, and `npm run validate` additionally checks that
+  each synthetic id is derived from the entry it labels (and that no two
+  requirements in one task share an id), so a malformed or drifted id fails
+  validation.
 - **Upstream-preserved requirements** keep their upstream `id`, so a correction
   patches the existing requirement in place.
 - **Clearing requirements** is expressed by an empty array

--- a/docs/MASTER_SAMPLES.md
+++ b/docs/MASTER_SAMPLES.md
@@ -48,7 +48,7 @@ Notes:
         id: '6a5672392ee61bd094c49e28', // Required | Console-only; upstream id, or stable 'overlay.'-prefixed synthetic id
         requirementType: 'level', // Required | Console-only; "level" (LL1-LL4) or "reputation" (trader rep / scav karma)
         compareMethod: '>=', // Required | Console-only; ">=" | "<=" | ">" | "<" | "="
-        value: 2, // Required | Console-only; integer 0-4 for "level", any number for "reputation"
+        value: 2, // Required | Console-only; integer 1-4 for "level", any number for "reputation"
         trader: { id: 'trader-id-1', name: 'Trader Name 1' }, // Required | Console-only when entry exists
       },
     ], // Optional | Console-only
@@ -270,7 +270,7 @@ Notes:
         id: '6a5672392ee61bd094c49e28', // Required | Console-only; upstream id, or stable 'overlay.'-prefixed synthetic id
         requirementType: 'level', // Required | Console-only; "level" (LL1-LL4) or "reputation" (trader rep / scav karma)
         compareMethod: '>=', // Required | Console-only; ">=" | "<=" | ">" | "<" | "="
-        value: 2, // Required | Console-only; integer 0-4 for "level", any number for "reputation"
+        value: 2, // Required | Console-only; integer 1-4 for "level", any number for "reputation"
         trader: { id: 'trader-id-2', name: 'Trader Name 2' }, // Required | Console-only when entry exists
       },
     ], // Optional | Console-only

--- a/docs/MASTER_SAMPLES.md
+++ b/docs/MASTER_SAMPLES.md
@@ -45,9 +45,11 @@ Notes:
     ], // Optional | UI (logic); used by the dependency graph (previous/next tasks)
     traderRequirements: [
       {
+        id: '6a5672392ee61bd094c49e28', // Required | Console-only; upstream id, or stable 'overlay.'-prefixed synthetic id
+        requirementType: 'level', // Required | Console-only; "level" (LL1-LL4) or "reputation" (trader rep / scav karma)
+        compareMethod: '>=', // Required | Console-only; ">=" | "<=" | ">" | "<" | "="
+        value: 2, // Required | Console-only; integer 0-4 for "level", any number for "reputation"
         trader: { id: 'trader-id-1', name: 'Trader Name 1' }, // Required | Console-only when entry exists
-        value: 2, // Required | Console-only (0-4)
-        compareMethod: '>=', // Optional | Console-only; likely one of: ">" | ">=" | "=" | "<=" | "<" (not schema-enforced)
       },
     ], // Optional | Console-only
     startRewards: {
@@ -265,9 +267,11 @@ Notes:
     ], // Optional | UI (logic)
     traderRequirements: [
       {
+        id: '6a5672392ee61bd094c49e28', // Required | Console-only; upstream id, or stable 'overlay.'-prefixed synthetic id
+        requirementType: 'level', // Required | Console-only; "level" (LL1-LL4) or "reputation" (trader rep / scav karma)
+        compareMethod: '>=', // Required | Console-only; ">=" | "<=" | ">" | "<" | "="
+        value: 2, // Required | Console-only; integer 0-4 for "level", any number for "reputation"
         trader: { id: 'trader-id-2', name: 'Trader Name 2' }, // Required | Console-only when entry exists
-        value: 2, // Required | Console-only (0-4)
-        compareMethod: '>=', // Optional | Console-only; likely one of: ">" | ">=" | "=" | "<=" | "<" (not schema-enforced)
       },
     ], // Optional | Console-only
     startRewards: {

--- a/scripts/check-overrides.ts
+++ b/scripts/check-overrides.ts
@@ -253,6 +253,27 @@ function getPrestigeLevel(task: { requiredPrestige?: { prestigeLevel: number } |
   return task.requiredPrestige?.prestigeLevel ?? 0;
 }
 
+/** Count of trader requirements by semantic type. */
+export type RequirementTypeCounts = { level: number; reputation: number };
+
+/**
+ * Count trader requirements by semantic type for a task list.
+ *
+ * Exported for tests; `check-overrides` prints this per game mode so the
+ * level/reputation split is visible (issue #274 acceptance: "CI reports
+ * requirement counts by semantic type and mode").
+ */
+export function countRequirementTypes(tasks: TaskData[]): RequirementTypeCounts {
+  const counts: RequirementTypeCounts = { level: 0, reputation: 0 };
+  for (const task of tasks) {
+    for (const req of task.traderRequirements ?? []) {
+      if (req.requirementType === 'level') counts.level += 1;
+      else if (req.requirementType === 'reputation') counts.reputation += 1;
+    }
+  }
+  return counts;
+}
+
 function buildApiIndexes(apiTasks: TaskData[]) {
   const byWikiLink = new Map<string, TaskData>();
   const byName = new Map<string, TaskData[]>();
@@ -677,6 +698,23 @@ function printReferenceCrossCheck(
       'cyan'
     )} : ${icons.info}`
   );
+  console.log();
+}
+
+/**
+ * Report upstream trader-requirement counts by semantic type and mode.
+ *
+ * Surfaces the level/reputation split so a consumer's requirement evaluation
+ * can be kept in sync with the discriminated upstream schema.
+ */
+function printRequirementTypeCounts(apiTasksByMode: Partial<Record<GameMode, TaskData[]>>): void {
+  printHeader('TRADER REQUIREMENT TYPE COUNTS (UPSTREAM)');
+  for (const mode of SUPPORTED_GAME_MODES) {
+    const tasks = apiTasksByMode[mode];
+    if (!tasks) continue;
+    const counts = countRequirementTypes(tasks);
+    console.log(`  ${mode}: ${counts.level} level, ${counts.reputation} reputation`);
+  }
   console.log();
 }
 
@@ -1115,6 +1153,8 @@ async function main(): Promise<void> {
         printAdditionResults(modeAdditionResults, mode.toUpperCase());
       }
     }
+
+    printRequirementTypeCounts(apiTasksByMode);
 
     // Base overrides apply to every mode, so validate them against every mode.
     const baseResultsByMode: Partial<Record<GameMode, ValidationResult[]>> = {};

--- a/scripts/validate.ts
+++ b/scripts/validate.ts
@@ -165,14 +165,12 @@ export function validateFile(
   }
 }
 
-/**
- * Task files whose `traderRequirements` carry overlay-authored merge identities.
- */
+/** Task files whose `traderRequirements` may carry synthetic merge identities. */
 const TASK_REQUIREMENT_FILE_PATTERN =
   /^(?:overrides|additions)\/(?:modes\/[^/]+\/)?(?:tasks|tasksAdd)\.json5$/;
 
 /**
- * Cross-check overlay-authored trader-requirement ids against the entry they identify.
+ * Cross-check synthetic trader-requirement ids against the entry they identify.
  *
  * The schema pattern proves a synthetic id's *shape*
  * (`overlay.<taskId>.<traderId>.<type>.<method>.<value>`); this proves its
@@ -209,9 +207,18 @@ export function validateTraderRequirementIds(
 
         if (!id.startsWith(SYNTHETIC_REQUIREMENT_ID_PREFIX)) return;
 
-        // `value` is the last segment and may itself contain a '.' (decimals).
-        const [, encodedTaskId, encodedTraderId, encodedType, encodedMethod, ...valueParts] =
-          id.split('.');
+        // Remove the prefix before decoding fields. `value` is the last field
+        // and may itself contain a '.' (decimals).
+        const encodedFields = id.slice(SYNTHETIC_REQUIREMENT_ID_PREFIX.length);
+        const [encodedTaskId, encodedTraderId, encodedType, encodedMethod, ...valueParts] =
+          encodedFields.split('.');
+        if (
+          valueParts.length >= 3 &&
+          valueParts.at(-2) === 'occurrence' &&
+          /^\d+$/.test(valueParts.at(-1) ?? '')
+        ) {
+          valueParts.splice(-2);
+        }
         const encodedValue = valueParts.join('.');
         const traderId = isRecord(requirement.trader) ? requirement.trader.id : undefined;
 
@@ -251,7 +258,7 @@ export function validateTraderRequirementIds(
  * Validate a task source file against its schema, then cross-check the
  * merge identities its trader requirements declare.
  */
-function validateTaskSourceFile(
+export function validateTaskSourceFile(
   filePath: string,
   displayPath: string,
   validators: ValidatorCache

--- a/scripts/validate.ts
+++ b/scripts/validate.ts
@@ -84,6 +84,14 @@ export function initializeValidators(): ValidatorCache {
   const cache: ValidatorCache = new Map();
   const schemaCache = new Map<string, ReturnType<Ajv['compile']>>();
 
+  // Task source schemas share this contract. Register it once so both resolve
+  // the same constraints and cannot drift independently.
+  const traderRequirementSchemaFile = 'trader-requirement.schema.json';
+  ajv.addSchema(
+    loadJsonFile(join(schemasDir, traderRequirementSchemaFile)) as object,
+    traderRequirementSchemaFile
+  );
+
   for (const config of SCHEMA_CONFIGS) {
     let validator = schemaCache.get(config.schemaFile);
     if (!validator) {

--- a/scripts/validate.ts
+++ b/scripts/validate.ts
@@ -16,6 +16,7 @@ import {
   listJson5Files,
   SCHEMA_CONFIGS,
   SUPPORTED_GAME_MODES,
+  SYNTHETIC_REQUIREMENT_ID_PREFIX,
   icons,
   type LocaleOverlay,
   type SchemaValidationResult,
@@ -156,6 +157,104 @@ export function validateFile(
   }
 }
 
+/**
+ * Task files whose `traderRequirements` carry overlay-authored merge identities.
+ */
+const TASK_REQUIREMENT_FILE_PATTERN =
+  /^(?:overrides|additions)\/(?:modes\/[^/]+\/)?(?:tasks|tasksAdd)\.json5$/;
+
+/**
+ * Cross-check overlay-authored trader-requirement ids against the entry they identify.
+ *
+ * The schema pattern proves a synthetic id's *shape*
+ * (`overlay.<taskId>.<traderId>.<type>.<method>.<value>`); this proves its
+ * *content*. The id is only a stable merge identity if it is derived from the
+ * requirement it labels - an id that encodes `level.>=.2` next to
+ * `requirementType: 'reputation'` would silently change identity the next time
+ * it is regenerated from the fields, turning a consumer's patch into an append.
+ * Duplicate ids within one task are rejected for the same reason: patch-by-id
+ * would collapse them into a single requirement.
+ */
+export function validateTraderRequirementIds(
+  filePath: string,
+  displayPath: string
+): SchemaValidationResult {
+  try {
+    const data = loadJson5File(filePath);
+    if (!isRecord(data)) return { file: displayPath, valid: true };
+
+    const errors: string[] = [];
+
+    for (const [taskId, task] of Object.entries(data)) {
+      if (!isRecord(task) || !Array.isArray(task.traderRequirements)) continue;
+
+      const seen = new Set<string>();
+      task.traderRequirements.forEach((requirement, index) => {
+        if (!isRecord(requirement) || typeof requirement.id !== 'string') return;
+        const { id } = requirement;
+        const path = `/${taskId}/traderRequirements/${index}/id`;
+
+        if (seen.has(id)) {
+          errors.push(`${path}: duplicate requirement id '${id}' within the same task`);
+        }
+        seen.add(id);
+
+        if (!id.startsWith(SYNTHETIC_REQUIREMENT_ID_PREFIX)) return;
+
+        // `value` is the last segment and may itself contain a '.' (decimals).
+        const [, encodedTaskId, encodedTraderId, encodedType, encodedMethod, ...valueParts] =
+          id.split('.');
+        const encodedValue = valueParts.join('.');
+        const traderId = isRecord(requirement.trader) ? requirement.trader.id : undefined;
+
+        const mismatches: Array<[string, unknown, string]> = [
+          ['task id', taskId, encodedTaskId],
+          ['trader.id', traderId, encodedTraderId],
+          ['requirementType', requirement.requirementType, encodedType],
+          ['compareMethod', requirement.compareMethod, encodedMethod],
+          ['value', requirement.value, encodedValue],
+        ];
+
+        for (const [field, actual, encoded] of mismatches) {
+          if (String(actual) !== encoded) {
+            errors.push(
+              `${path}: synthetic id encodes ${field} '${encoded}' but the entry declares '${String(actual)}'`
+            );
+          }
+        }
+      });
+    }
+
+    return {
+      file: displayPath,
+      valid: errors.length === 0,
+      errors: errors.length ? errors : undefined,
+    };
+  } catch (error) {
+    return {
+      file: displayPath,
+      valid: false,
+      errors: [(error as Error).message],
+    };
+  }
+}
+
+/**
+ * Validate a task source file against its schema, then cross-check the
+ * merge identities its trader requirements declare.
+ */
+function validateTaskSourceFile(
+  filePath: string,
+  displayPath: string,
+  validators: ValidatorCache
+): SchemaValidationResult {
+  const result = validateFile(filePath, displayPath, validators);
+  if (!result.valid || !TASK_REQUIREMENT_FILE_PATTERN.test(displayPath)) return result;
+
+  const idResult = validateTraderRequirementIds(filePath, displayPath);
+  return idResult.valid ? result : idResult;
+}
+
 function addJson5Keys(index: Set<string>, relPath: string): void {
   const filePath = join(srcDir, relPath);
   if (!existsSync(filePath)) return;
@@ -285,14 +384,14 @@ export async function validateSourceFiles(): Promise<SchemaValidationResult[]> {
   const overridesDir = join(srcDir, 'overrides');
   for (const file of listJson5Files(overridesDir)) {
     const filePath = join(overridesDir, file);
-    results.push(validateFile(filePath, `overrides/${file}`, validators));
+    results.push(validateTaskSourceFile(filePath, `overrides/${file}`, validators));
   }
 
   // Validate additions directory
   const additionsDir = join(srcDir, 'additions');
   for (const file of listJson5Files(additionsDir)) {
     const filePath = join(additionsDir, file);
-    results.push(validateFile(filePath, `additions/${file}`, validators));
+    results.push(validateTaskSourceFile(filePath, `additions/${file}`, validators));
   }
 
   // Validate per-locale overrides (one file per locale, filename = locale code)
@@ -324,13 +423,13 @@ export async function validateSourceFiles(): Promise<SchemaValidationResult[]> {
     const modeOverridesDir = join(srcDir, 'overrides', 'modes', mode);
     for (const file of listJson5Files(modeOverridesDir)) {
       const filePath = join(modeOverridesDir, file);
-      results.push(validateFile(filePath, `overrides/modes/${mode}/${file}`, validators));
+      results.push(validateTaskSourceFile(filePath, `overrides/modes/${mode}/${file}`, validators));
     }
 
     const modeAdditionsDir = join(srcDir, 'additions', 'modes', mode);
     for (const file of listJson5Files(modeAdditionsDir)) {
       const filePath = join(modeAdditionsDir, file);
-      results.push(validateFile(filePath, `additions/modes/${mode}/${file}`, validators));
+      results.push(validateTaskSourceFile(filePath, `additions/modes/${mode}/${file}`, validators));
     }
   }
 

--- a/src/lib/tarkov-api.ts
+++ b/src/lib/tarkov-api.ts
@@ -28,6 +28,7 @@ import type {
   TaskObjective,
   TaskRewards,
   TaskRequirement,
+  TraderRequirement,
   GameMode,
 } from './types.js';
 import {
@@ -311,9 +312,17 @@ function adaptTaskRequirement(raw: unknown, ctx: Context): TaskRequirement {
   return compact({ ...raw, task: resolveTaskRef(raw.task, ctx) }) as unknown as TaskRequirement;
 }
 
-function adaptTraderRequirement(raw: unknown, ctx: Context): unknown {
-  if (!isRecord(raw)) return raw;
-  return compact({ ...raw, trader: resolveTraderRef(raw.trader, ctx) });
+function adaptTraderRequirement(raw: unknown, ctx: Context): TraderRequirement {
+  if (!isRecord(raw)) return raw as TraderRequirement;
+  // Preserve the upstream discriminated schema (id, requirementType,
+  // compareMethod, value) and resolve the trader reference. `id` is normalized
+  // explicitly so the merge identity survives adaptation even if upstream ever
+  // moves it into an inline object.
+  return compact({
+    ...raw,
+    id: stringId(raw) ?? '',
+    trader: resolveTraderRef(raw.trader, ctx),
+  }) as unknown as TraderRequirement;
 }
 
 function adaptTask(raw: JsonRecord, ctx: Context): TaskData {

--- a/src/lib/tarkov-api.ts
+++ b/src/lib/tarkov-api.ts
@@ -22,6 +22,7 @@
  * once. Across calls the cache is not shared, mirroring the monitor's pattern.
  */
 
+import { SYNTHETIC_REQUIREMENT_ID_PREFIX } from './types.js';
 import type {
   TaskData,
   TaskItemRef,
@@ -312,16 +313,27 @@ function adaptTaskRequirement(raw: unknown, ctx: Context): TaskRequirement {
   return compact({ ...raw, task: resolveTaskRef(raw.task, ctx) }) as unknown as TaskRequirement;
 }
 
-function adaptTraderRequirement(raw: unknown, ctx: Context): TraderRequirement {
+function adaptTraderRequirement(raw: unknown, taskId: string, ctx: Context): TraderRequirement {
   if (!isRecord(raw)) return raw as TraderRequirement;
-  // Preserve the upstream discriminated schema (id, requirementType,
-  // compareMethod, value) and resolve the trader reference. `id` is normalized
-  // explicitly so the merge identity survives adaptation even if upstream ever
-  // moves it into an inline object.
+
+  const trader = resolveTraderRef(raw.trader, ctx);
+  const upstreamId = stringId(raw);
+  const generatedId = [
+    SYNTHETIC_REQUIREMENT_ID_PREFIX.slice(0, -1),
+    taskId,
+    trader?.id,
+    raw.requirementType,
+    raw.compareMethod,
+    raw.value,
+  ].join('.');
+
+  // Preserve an upstream merge identity when present. If upstream regresses and
+  // omits it, derive the same deterministic identity used by overlay-authored
+  // requirements so multiple id-less entries cannot collapse onto `id: ''`.
   return compact({
     ...raw,
-    id: stringId(raw) ?? '',
-    trader: resolveTraderRef(raw.trader, ctx),
+    id: upstreamId ?? generatedId,
+    trader,
   }) as unknown as TraderRequirement;
 }
 
@@ -343,7 +355,7 @@ function adaptTask(raw: JsonRecord, ctx: Context): TaskData {
       ? raw.taskRequirements.map((req) => adaptTaskRequirement(req, ctx))
       : undefined,
     traderRequirements: Array.isArray(raw.traderRequirements)
-      ? raw.traderRequirements.map((req) => adaptTraderRequirement(req, ctx))
+      ? raw.traderRequirements.map((req) => adaptTraderRequirement(req, id, ctx))
       : undefined,
     objectives: Array.isArray(raw.objectives)
       ? raw.objectives.filter(isRecord).map((objective) => adaptObjective(objective, ctx))

--- a/src/lib/tarkov-api.ts
+++ b/src/lib/tarkov-api.ts
@@ -313,12 +313,17 @@ function adaptTaskRequirement(raw: unknown, ctx: Context): TaskRequirement {
   return compact({ ...raw, task: resolveTaskRef(raw.task, ctx) }) as unknown as TaskRequirement;
 }
 
-function adaptTraderRequirement(raw: unknown, taskId: string, ctx: Context): TraderRequirement {
+function adaptTraderRequirement(
+  raw: unknown,
+  taskId: string,
+  ctx: Context,
+  syntheticIdOccurrences: Map<string, number>
+): TraderRequirement {
   if (!isRecord(raw)) return raw as TraderRequirement;
 
   const trader = resolveTraderRef(raw.trader, ctx);
   const upstreamId = stringId(raw);
-  const generatedId = [
+  const syntheticIdBase = [
     SYNTHETIC_REQUIREMENT_ID_PREFIX.slice(0, -1),
     taskId,
     trader?.id,
@@ -326,10 +331,15 @@ function adaptTraderRequirement(raw: unknown, taskId: string, ctx: Context): Tra
     raw.compareMethod,
     raw.value,
   ].join('.');
+  const occurrence = upstreamId ? 0 : (syntheticIdOccurrences.get(syntheticIdBase) ?? 0) + 1;
+  if (!upstreamId) syntheticIdOccurrences.set(syntheticIdBase, occurrence);
+  const generatedId =
+    occurrence <= 1 ? syntheticIdBase : `${syntheticIdBase}.occurrence.${occurrence}`;
 
   // Preserve an upstream merge identity when present. If upstream regresses and
-  // omits it, derive the same deterministic identity used by overlay-authored
-  // requirements so multiple id-less entries cannot collapse onto `id: ''`.
+  // omits it, derive a deterministic identity from its fields. Repeated id-less
+  // entries retain the original identity for the first occurrence and receive
+  // stable occurrence suffixes thereafter instead of collapsing during merge.
   return compact({
     ...raw,
     id: upstreamId ?? generatedId,
@@ -339,6 +349,7 @@ function adaptTraderRequirement(raw: unknown, taskId: string, ctx: Context): Tra
 
 function adaptTask(raw: JsonRecord, ctx: Context): TaskData {
   const id = stringId(raw) ?? '';
+  const syntheticRequirementIdOccurrences = new Map<string, number>();
   return compact({
     id,
     name: translate(ctx.tasksEn, raw.name) ?? id,
@@ -355,7 +366,9 @@ function adaptTask(raw: JsonRecord, ctx: Context): TaskData {
       ? raw.taskRequirements.map((req) => adaptTaskRequirement(req, ctx))
       : undefined,
     traderRequirements: Array.isArray(raw.traderRequirements)
-      ? raw.traderRequirements.map((req) => adaptTraderRequirement(req, id, ctx))
+      ? raw.traderRequirements.map((req) =>
+          adaptTraderRequirement(req, id, ctx, syntheticRequirementIdOccurrences)
+        )
       : undefined,
     objectives: Array.isArray(raw.objectives)
       ? raw.objectives.filter(isRecord).map((objective) => adaptObjective(objective, ctx))

--- a/src/lib/task-validator.ts
+++ b/src/lib/task-validator.ts
@@ -165,6 +165,11 @@ function traderRequirementKey(req: TraderRequirementLike): string {
  * `trader.id + requirementType + compareMethod + value` keeps Fence LL1 and
  * Fence reputation `>= 1` distinguishable while treating an id-only difference
  * as "already fixed upstream".
+ *
+ * This holds even if an upstream entry ever arrives without an id: an override
+ * cannot address an id-less upstream requirement, so keeping it would append a
+ * duplicate under a patch-by-id merge. `fixed` ("remove it") stays the correct
+ * verdict there.
  */
 const validateTraderRequirements: FieldValidator = (override, apiTask) => {
   if (override.traderRequirements === undefined) return null;

--- a/src/lib/task-validator.ts
+++ b/src/lib/task-validator.ts
@@ -137,6 +137,91 @@ const validateMap: FieldValidator = (override, apiTask) => {
   };
 };
 
+type TraderRequirementLike = {
+  id?: string;
+  requirementType?: string;
+  compareMethod?: string;
+  value?: number;
+  trader?: { id?: string; name?: string };
+};
+
+/**
+ * Semantic identity of a trader requirement: everything a consumer uses to
+ * evaluate it, excluding the `id` (which differs between upstream and
+ * overlay-authored entries).
+ */
+function traderRequirementKey(req: TraderRequirementLike): string {
+  return [req.trader?.id ?? '', req.requirementType ?? '', req.compareMethod ?? '', req.value].join(
+    '|'
+  );
+}
+
+/**
+ * Validate trader requirements by semantic identity.
+ *
+ * The `id` field is deliberately excluded from the comparison: overlay-authored
+ * requirements carry a synthetic `overlay.*` id that will never match upstream,
+ * and upstream-preserved ids are only merge identity, not semantics. Comparing
+ * `trader.id + requirementType + compareMethod + value` keeps Fence LL1 and
+ * Fence reputation `>= 1` distinguishable while treating an id-only difference
+ * as "already fixed upstream".
+ */
+const validateTraderRequirements: FieldValidator = (override, apiTask) => {
+  if (override.traderRequirements === undefined) return null;
+
+  const apiReqs = apiTask.traderRequirements ?? [];
+  const overrideReqs = override.traderRequirements;
+
+  // An empty override array means "no requirements" and replaces upstream
+  // entries; surface it as needed rather than letting a vacuous subset match
+  // hide the fact that requirements are being cleared.
+  if (overrideReqs.length === 0) {
+    if (apiReqs.length === 0) return null;
+    return {
+      field: 'traderRequirements',
+      status: 'needed',
+      message: `traderRequirements: API has ${apiReqs.length} requirement(s), Override=[] (clears all) - STILL NEEDED`,
+    };
+  }
+
+  if (apiReqs.length === 0) {
+    return {
+      field: 'traderRequirements',
+      status: 'needed',
+      message: `traderRequirements: API=[] (empty), Override has ${overrideReqs.length} requirement(s) - STILL NEEDED`,
+    };
+  }
+
+  const remaining = apiReqs.map((req) => traderRequirementKey(req));
+  const unmatched: string[] = [];
+
+  for (const overrideReq of overrideReqs) {
+    const key = traderRequirementKey(overrideReq);
+    const index = remaining.indexOf(key);
+    if (index === -1) {
+      unmatched.push(
+        `${overrideReq.trader?.name ?? overrideReq.trader?.id ?? '?'} ${overrideReq.requirementType} ${overrideReq.compareMethod} ${overrideReq.value}`
+      );
+    } else {
+      remaining.splice(index, 1);
+    }
+  }
+
+  if (unmatched.length > 0) {
+    return {
+      field: 'traderRequirements',
+      status: 'needed',
+      message: `traderRequirements: ${unmatched.length} requirement(s) differ from API (${unmatched.join('; ')}) - STILL NEEDED`,
+    };
+  }
+
+  return {
+    field: 'traderRequirements',
+    status: 'fixed',
+    message: 'traderRequirements: FIXED IN API',
+  };
+};
+
 /**
  * Validate task requirements field
  */
@@ -197,7 +282,7 @@ const FIELD_VALIDATORS: FieldValidator[] = [
   createFieldValidator('kappaRequired'),
   createFieldValidator('lightkeeperRequired'),
   validateTaskRequirements,
-  createFieldValidator('traderRequirements', { arrayMode: 'subset' }),
+  validateTraderRequirements,
 ];
 
 /**

--- a/src/lib/task-validator.ts
+++ b/src/lib/task-validator.ts
@@ -220,6 +220,17 @@ const validateTraderRequirements: FieldValidator = (override, apiTask) => {
     };
   }
 
+  // A non-empty override remains a whole-array replacement for consumers that
+  // have not migrated to patch-by-id. Matching only a strict subset therefore
+  // intentionally clears the omitted API requirements and is still needed.
+  if (remaining.length > 0) {
+    return {
+      field: 'traderRequirements',
+      status: 'needed',
+      message: `traderRequirements: override omits ${remaining.length} API requirement(s) (${remaining.join('; ')}) - STILL NEEDED`,
+    };
+  }
+
   return {
     field: 'traderRequirements',
     status: 'fixed',

--- a/src/lib/task-validator.ts
+++ b/src/lib/task-validator.ts
@@ -156,6 +156,10 @@ function traderRequirementKey(req: TraderRequirementLike): string {
   );
 }
 
+function formatTraderRequirement(req: TraderRequirementLike): string {
+  return `${req.trader?.name ?? req.trader?.id ?? '?'} ${req.requirementType} ${req.compareMethod} ${req.value}`;
+}
+
 /**
  * Validate trader requirements by semantic identity.
  *
@@ -197,16 +201,14 @@ const validateTraderRequirements: FieldValidator = (override, apiTask) => {
     };
   }
 
-  const remaining = apiReqs.map((req) => traderRequirementKey(req));
+  const remaining = [...apiReqs];
   const unmatched: string[] = [];
 
   for (const overrideReq of overrideReqs) {
     const key = traderRequirementKey(overrideReq);
-    const index = remaining.indexOf(key);
+    const index = remaining.findIndex((apiReq) => traderRequirementKey(apiReq) === key);
     if (index === -1) {
-      unmatched.push(
-        `${overrideReq.trader?.name ?? overrideReq.trader?.id ?? '?'} ${overrideReq.requirementType} ${overrideReq.compareMethod} ${overrideReq.value}`
-      );
+      unmatched.push(formatTraderRequirement(overrideReq));
     } else {
       remaining.splice(index, 1);
     }
@@ -227,7 +229,7 @@ const validateTraderRequirements: FieldValidator = (override, apiTask) => {
     return {
       field: 'traderRequirements',
       status: 'needed',
-      message: `traderRequirements: override omits ${remaining.length} API requirement(s) (${remaining.join('; ')}) - STILL NEEDED`,
+      message: `traderRequirements: override omits ${remaining.length} API requirement(s) (${remaining.map(formatTraderRequirement).join('; ')}) - STILL NEEDED`,
     };
   }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -165,27 +165,40 @@ export type TraderRequirementCompareMethod = '>=' | '<=' | '>' | '<' | '=';
  */
 export type TraderRequirementType = 'level' | 'reputation';
 
-/**
- * Trader requirement in json.tarkov.dev's discriminated shape.
- *
- * `id` is the upstream requirement id, or a deterministic synthetic id (see
- * `SYNTHETIC_REQUIREMENT_ID_PREFIX`) for overlay-authored requirements absent
- * upstream. The id is the merge identity consumers use to patch-by-id rather
- * than replace the whole array.
- */
-export interface TraderRequirement {
+/** Shared fields for trader requirements in json.tarkov.dev's discriminated shape. */
+interface TraderRequirementBase {
   id: string;
-  requirementType: TraderRequirementType;
-  compareMethod: TraderRequirementCompareMethod;
-  value: number;
   trader: { id: string; name: string };
 }
 
+/** Trader Loyalty Level requirement (LL1-LL4). */
+export interface TraderLevelRequirement extends TraderRequirementBase {
+  requirementType: 'level';
+  compareMethod: '>=';
+  value: 1 | 2 | 3 | 4;
+}
+
+/** Trader reputation threshold requirement (trader rep / scav karma). */
+export interface TraderReputationRequirement extends TraderRequirementBase {
+  requirementType: 'reputation';
+  compareMethod: TraderRequirementCompareMethod;
+  value: number;
+}
+
 /**
- * Prefix for synthetic requirement ids authored into the overlay for
- * requirements that have no upstream counterpart. Kept distinct from
- * tarkov.dev's 24-hex ids so consumers can tell overlay-authored requirements
- * apart at a glance.
+ * Trader requirement in json.tarkov.dev's discriminated shape.
+ *
+ * `id` is an upstream requirement id or a deterministic synthetic id (see
+ * `SYNTHETIC_REQUIREMENT_ID_PREFIX`). The adapter also assigns synthetic ids
+ * when an upstream requirement has no id. The id is the merge identity
+ * consumers use to patch-by-id rather than replace the whole array.
+ */
+export type TraderRequirement = TraderLevelRequirement | TraderReputationRequirement;
+
+/**
+ * Prefix identifying deterministic synthetic requirement ids. Synthetic ids
+ * may be authored in overlay data or assigned by the API adapter when an
+ * upstream requirement omits its id.
  */
 export const SYNTHETIC_REQUIREMENT_ID_PREFIX = 'overlay.';
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -19,11 +19,7 @@ export interface TaskOverride {
   objectives?: Record<string, ObjectiveOverride>;
   objectivesAdd?: ObjectiveAdd[];
   taskRequirements?: TaskRequirement[];
-  traderRequirements?: Array<{
-    trader: { id: string; name: string };
-    value: number;
-    compareMethod?: string;
-  }>;
+  traderRequirements?: TraderRequirement[];
   experience?: number;
   startRewards?: TaskRewards;
   finishRewards?: TaskRewards;
@@ -154,6 +150,45 @@ export interface TaskRequirement {
   status?: string[];
 }
 
+/**
+ * Comparison methods json.tarkov.dev serves for trader requirements. Loyalty
+ * Level (`level`) entries use `>=`; reputation entries use `>=`, `<=`, and `<`.
+ */
+export type TraderRequirementCompareMethod = '>=' | '<=' | '>' | '<' | '=';
+
+/**
+ * The discriminated trader-requirement semantics served by json.tarkov.dev:
+ * `level` is a trader Loyalty Level (LL1-LL4); `reputation` is a trader
+ * reputation threshold (scav karma / trader rep). Consumers must switch their
+ * requirement evaluation on this field - the value range alone is ambiguous
+ * (reputation serves positive, zero, and negative values).
+ */
+export type TraderRequirementType = 'level' | 'reputation';
+
+/**
+ * Trader requirement in json.tarkov.dev's discriminated shape.
+ *
+ * `id` is the upstream requirement id, or a deterministic synthetic id (see
+ * `SYNTHETIC_REQUIREMENT_ID_PREFIX`) for overlay-authored requirements absent
+ * upstream. The id is the merge identity consumers use to patch-by-id rather
+ * than replace the whole array.
+ */
+export interface TraderRequirement {
+  id: string;
+  requirementType: TraderRequirementType;
+  compareMethod: TraderRequirementCompareMethod;
+  value: number;
+  trader: { id: string; name: string };
+}
+
+/**
+ * Prefix for synthetic requirement ids authored into the overlay for
+ * requirements that have no upstream counterpart. Kept distinct from
+ * tarkov.dev's 24-hex ids so consumers can tell overlay-authored requirements
+ * apart at a glance.
+ */
+export const SYNTHETIC_REQUIREMENT_ID_PREFIX = 'overlay.';
+
 /** Task addition structure for new tasks not in tarkov.dev */
 export interface TaskAddition {
   id: string;
@@ -166,11 +201,7 @@ export interface TaskAddition {
   requiredPrestige?: { id?: string; name: string; prestigeLevel: number };
   objectives: TaskObjectiveAdd[];
   taskRequirements?: TaskRequirement[];
-  traderRequirements?: Array<{
-    trader: { id: string; name: string };
-    value: number;
-    compareMethod?: string;
-  }>;
+  traderRequirements?: TraderRequirement[];
   experience?: number;
   startRewards?: TaskRewards;
   finishRewards?: TaskRewards;
@@ -202,11 +233,7 @@ export interface TaskData {
   factionName?: string;
   requiredPrestige?: { id?: string; name: string; prestigeLevel: number };
   taskRequirements?: TaskRequirement[];
-  traderRequirements?: Array<{
-    trader: { id: string; name: string };
-    value: number;
-    compareMethod?: string;
-  }>;
+  traderRequirements?: TraderRequirement[];
   objectives?: TaskObjective[];
   experience?: number;
   startRewards?: TaskRewards;

--- a/src/overrides/tasks.json5
+++ b/src/overrides/tasks.json5
@@ -28,6 +28,16 @@
   // (verified: normalized item-id sets are identical; only ordering differed).
   // Proof: https://escapefromtarkov.fandom.com/wiki/Setup
   //
+  // Establish Contact, Collector, Is This a Reference? - REMOVED (issue #274):
+  // these were authored as "Fence LL1" but are actually Fence *reputation*
+  // (scav karma) gates. json.tarkov.dev now serves the correct discriminated
+  // requirement (reputation >= 4 / >= 3 / >= 1) and the wiki agrees, so the
+  // ambiguous LL1 entry would both mislabel the semantic and - under
+  // replace-array semantics - strip the upstream requirement. Proof:
+  //   https://escapefromtarkov.fandom.com/wiki/Establish_Contact (scav karma +4)
+  //   https://escapefromtarkov.fandom.com/wiki/Collector (scav karma +3 + 7x LL4)
+  //   https://escapefromtarkov.fandom.com/wiki/Is_This_a_Reference%3F (scav karma +1)
+  //
   // minPlayerLevel overrides (A Fuel Matter, Inventory Check, Psycho Sniper,
   // Bullshit, Chumming, ...) - REMOVED: the Season 1 patch replaced
   // player-level quest requirements with trader loyalty levels; the 1.1.0.0
@@ -46,7 +56,13 @@
   // 2026-08-10 - S1: now requires Prapor LL1 instead of player level
   '657315e1dccd301f1301416a': {
     traderRequirements: [
-      { trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 1)
+      {
+        id: 'overlay.657315e1dccd301f1301416a.54cb50c76803fa8b248b4571.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 1)
     ],
   },
 
@@ -56,7 +72,13 @@
   // 2026-08-10 - S1: now requires Prapor LL1 instead of player level
   '59674cd986f7744ab26e32f2': {
     traderRequirements: [
-      { trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 3)
+      {
+        id: 'overlay.59674cd986f7744ab26e32f2.54cb50c76803fa8b248b4571.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 3)
     ],
   },
 
@@ -66,7 +88,13 @@
   // 2026-08-10 - S1: now requires Prapor LL1 instead of player level
   '5fd9fad9c1ce6b1a3b486d00': {
     traderRequirements: [
-      { trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 5)
+      {
+        id: 'overlay.5fd9fad9c1ce6b1a3b486d00.54cb50c76803fa8b248b4571.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 5)
     ],
   },
 
@@ -76,7 +104,13 @@
   // 2026-08-10 - S1: now requires Prapor LL1 instead of player level
   '5967530a86f77462ba22226b': {
     traderRequirements: [
-      { trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 6)
+      {
+        id: 'overlay.5967530a86f77462ba22226b.54cb50c76803fa8b248b4571.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 6)
     ],
   },
 
@@ -87,7 +121,13 @@
   '5967725e86f774601a446662': {
     traderRequirements: [
       // Was: [{ id: "59a9280b86f77477925e27cb", requirementType: "level", compareMethod: ">=", value: 2, trader: Prapor }]
-      { trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }, value: 1 },
+      {
+        id: 'overlay.5967725e86f774601a446662.54cb50c76803fa8b248b4571.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+        value: 1,
+      },
     ],
   },
 
@@ -97,7 +137,13 @@
   // 2026-08-10 - S1: now requires Prapor LL1 instead of player level
   '5936da9e86f7742d65037edf': {
     traderRequirements: [
-      { trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 2)
+      {
+        id: 'overlay.5936da9e86f7742d65037edf.54cb50c76803fa8b248b4571.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 2)
     ],
   },
 
@@ -107,7 +153,13 @@
   // 2026-08-10 - S1: now requires Prapor LL1 instead of player level
   '675c3507a06634b5110e3c18': {
     traderRequirements: [
-      { trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 5)
+      {
+        id: 'overlay.675c3507a06634b5110e3c18.54cb50c76803fa8b248b4571.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 5)
     ],
   },
 
@@ -117,7 +169,13 @@
   // 2026-08-10 - S1: now requires Prapor LL1 instead of player level
   '59c124d686f774189b3c843f': {
     traderRequirements: [
-      { trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 5)
+      {
+        id: 'overlay.59c124d686f774189b3c843f.54cb50c76803fa8b248b4571.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 5)
     ],
   },
 
@@ -127,7 +185,13 @@
   // 2026-08-10 - S1: now requires Prapor LL1 instead of player level
   '5936d90786f7742b1420ba5b': {
     traderRequirements: [
-      { trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 1)
+      {
+        id: 'overlay.5936d90786f7742b1420ba5b.54cb50c76803fa8b248b4571.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 1)
     ],
   },
 
@@ -137,7 +201,13 @@
   // 2026-08-10 - S1: now requires Prapor LL1 instead of player level
   '657315df034d76585f032e01': {
     traderRequirements: [
-      { trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 1)
+      {
+        id: 'overlay.657315df034d76585f032e01.54cb50c76803fa8b248b4571.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 1)
     ],
   },
 
@@ -166,7 +236,13 @@
       },
     },
     traderRequirements: [
-      { trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 22)
+      {
+        id: 'overlay.63a5cf262964a7488f5243ce.54cb50c76803fa8b248b4571.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 22)
     ],
   },
 
@@ -180,7 +256,13 @@
   // 2026-08-10 - S1: now requires Prapor LL2 instead of player level
   '6573397ef3f8344c4575cd87': {
     traderRequirements: [
-      { trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 22)
+      {
+        id: 'overlay.6573397ef3f8344c4575cd87.54cb50c76803fa8b248b4571.level.>=.2',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 22)
     ],
   },
 
@@ -190,7 +272,13 @@
   // 2026-08-10 - S1: now requires Prapor LL2 instead of player level
   '5c0d190cd09282029f5390d8': {
     traderRequirements: [
-      { trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 10)
+      {
+        id: '6a268caf84124948db9ab8f0',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 10)
     ],
   },
 
@@ -200,7 +288,13 @@
   // 2026-08-10 - S1: now requires Prapor LL2 instead of player level
   '6391359b9444fb141f4e6ee6': {
     traderRequirements: [
-      { trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 15)
+      {
+        id: 'overlay.6391359b9444fb141f4e6ee6.54cb50c76803fa8b248b4571.level.>=.2',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 15)
     ],
   },
 
@@ -214,7 +308,13 @@
   '64e7b9bffd30422ed03dad38': {
     name: 'District Patrol', // Was: Gendarmerie - District Patrol
     traderRequirements: [
-      { trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 20)
+      {
+        id: 'overlay.64e7b9bffd30422ed03dad38.54cb50c76803fa8b248b4571.level.>=.2',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 20)
     ],
     experience: 10000, // Was: 8300 (all modes, stale pre-1.1 value)
   },
@@ -225,7 +325,13 @@
   // 2026-08-10 - S1: now requires Prapor LL2 instead of player level
   '639136f086e646067c176a8b': {
     traderRequirements: [
-      { trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 22)
+      {
+        id: 'overlay.639136f086e646067c176a8b.54cb50c76803fa8b248b4571.level.>=.2',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 22)
     ],
   },
 
@@ -235,7 +341,13 @@
   // 2026-08-10 - S1: now requires Prapor LL2 instead of player level
   '5eda19f0edce541157209cee': {
     traderRequirements: [
-      { trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 21)
+      {
+        id: 'overlay.5eda19f0edce541157209cee.54cb50c76803fa8b248b4571.level.>=.2',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 21)
     ],
   },
 
@@ -245,7 +357,13 @@
   // 2026-08-10 - S1: now requires Prapor LL2 instead of player level
   '59675ea386f77414b32bded2': {
     traderRequirements: [
-      { trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 10)
+      {
+        id: 'overlay.59675ea386f77414b32bded2.54cb50c76803fa8b248b4571.level.>=.2',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 10)
     ],
   },
 
@@ -255,7 +373,13 @@
   // 2026-08-10 - S1: now requires Prapor LL2 instead of player level
   '60e71b9bbd90872cb85440f3': {
     traderRequirements: [
-      { trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 42)
+      {
+        id: 'overlay.60e71b9bbd90872cb85440f3.54cb50c76803fa8b248b4571.level.>=.2',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 42)
     ],
   },
 
@@ -265,7 +389,13 @@
   // 2026-08-10 - S1: now requires Prapor LL2 instead of player level
   '59675d6c86f7740a842fc482': {
     traderRequirements: [
-      { trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 9)
+      {
+        id: '6a2692eb3290f881e29e6f72',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 9)
     ],
   },
 
@@ -279,7 +409,13 @@
   '639135b04ed9512be67647d7': {
     name: 'Glory to CPSU', // Was: Glory to CPSU - Part 1
     traderRequirements: [
-      { trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 17)
+      {
+        id: 'overlay.639135b04ed9512be67647d7.54cb50c76803fa8b248b4571.level.>=.2',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 17)
     ],
   },
 
@@ -289,7 +425,13 @@
   // 2026-08-10 - S1: now requires Prapor LL2 instead of player level
   '59674eb386f774539f14813a': {
     traderRequirements: [
-      { trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 5)
+      {
+        id: 'overlay.59674eb386f774539f14813a.54cb50c76803fa8b248b4571.level.>=.2',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 5)
     ],
   },
 
@@ -299,7 +441,13 @@
   // 2026-08-10 - S1: now requires Prapor LL2 instead of player level
   '669fa399033a3ce9870338a8': {
     traderRequirements: [
-      { trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 10)
+      {
+        id: 'overlay.669fa399033a3ce9870338a8.54cb50c76803fa8b248b4571.level.>=.2',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 10)
     ],
   },
 
@@ -311,7 +459,13 @@
   '64f5deac39e45b527a7c4232': {
     name: 'Job for a Patriot',
     traderRequirements: [
-      { trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 25)
+      {
+        id: 'overlay.64f5deac39e45b527a7c4232.54cb50c76803fa8b248b4571.level.>=.2',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 25)
     ],
   },
 
@@ -327,7 +481,13 @@
   '5c0bd94186f7747a727f09b2': {
     name: 'The Tarkov Import',
     traderRequirements: [
-      { trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 18)
+      {
+        id: 'overlay.5c0bd94186f7747a727f09b2.54cb50c76803fa8b248b4571.level.>=.3',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 18)
     ],
   },
 
@@ -345,7 +505,13 @@
       },
     },
     traderRequirements: [
-      { trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 32)
+      {
+        id: 'overlay.669fa3a40c828825de06d6a1.54cb50c76803fa8b248b4571.level.>=.3',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 32)
     ],
   },
 
@@ -355,7 +521,13 @@
   // 2026-08-10 - S1: now requires Prapor LL3 instead of player level
   '60896bca6ee58f38c417d4f2': {
     traderRequirements: [
-      { trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 17)
+      {
+        id: '6a32a71f7b1e24899a2ff53c',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 17)
     ],
   },
 
@@ -367,7 +539,13 @@
   '6179ac7511973d018217d0b9': {
     name: 'Easy Job', // Was: Easy Job - Part 1
     traderRequirements: [
-      { trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 18)
+      {
+        id: '6a32a4304fa148829f895710',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 18)
     ],
   },
 
@@ -377,7 +555,13 @@
   // 2026-08-10 - S1: now requires Prapor LL3 instead of player level
   '66ab970848ddbe9d4a0c49a8': {
     traderRequirements: [
-      { trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 19)
+      {
+        id: 'overlay.66ab970848ddbe9d4a0c49a8.54cb50c76803fa8b248b4571.level.>=.3',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 19)
     ],
   },
 
@@ -387,7 +571,13 @@
   // 2026-08-10 - S1: now requires Prapor LL3 instead of player level
   '626bd75c71bd851e971b82a5': {
     traderRequirements: [
-      { trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 18)
+      {
+        id: 'overlay.626bd75c71bd851e971b82a5.54cb50c76803fa8b248b4571.level.>=.3',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 18)
     ],
   },
 
@@ -397,7 +587,13 @@
   // 2026-08-10 - S1: now requires Prapor LL3 instead of player level
   '60896b7bfa70fc097863b8f5': {
     traderRequirements: [
-      { trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 19)
+      {
+        id: 'overlay.60896b7bfa70fc097863b8f5.54cb50c76803fa8b248b4571.level.>=.3',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 19)
     ],
   },
 
@@ -409,7 +605,13 @@
   '5ede55112c95834b583f052a': {
     name: 'The Bunker', // Was: The Bunker - Part 1
     traderRequirements: [
-      { trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 10)
+      {
+        id: '6a32a697feea519d9e9a827a',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 10)
     ],
   },
 
@@ -423,7 +625,13 @@
   // 2026-08-10 - S1: now requires Prapor LL4 instead of player level
   '63a9ae24009ffc6a551631a5': {
     traderRequirements: [
-      { trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }, value: 4 }, // Was: [] (player level requirement, minPlayerLevel 25)
+      {
+        id: 'overlay.63a9ae24009ffc6a551631a5.54cb50c76803fa8b248b4571.level.>=.4',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+        value: 4,
+      }, // Was: [] (player level requirement, minPlayerLevel 25)
     ],
   },
 
@@ -433,7 +641,13 @@
   // 2026-08-10 - S1: now requires Prapor LL4 instead of player level
   '60e71bb4e456d449cd47ca75': {
     traderRequirements: [
-      { trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }, value: 4 }, // Was: [] (player level requirement, minPlayerLevel 45)
+      {
+        id: 'overlay.60e71bb4e456d449cd47ca75.54cb50c76803fa8b248b4571.level.>=.4',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+        value: 4,
+      }, // Was: [] (player level requirement, minPlayerLevel 45)
     ],
   },
 
@@ -443,7 +657,13 @@
   // 2026-08-10 - S1: now requires Prapor LL4 instead of player level
   '67b45467814ab0ffa000c7e7': {
     traderRequirements: [
-      { trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }, value: 4 }, // Was: [] (player level requirement, minPlayerLevel 33)
+      {
+        id: '6a330d28962a6f96eba02bae',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+        value: 4,
+      }, // Was: [] (player level requirement, minPlayerLevel 33)
     ],
   },
 
@@ -455,7 +675,13 @@
   '675c1ff1a757ddd00404f0aa': {
     name: 'Unique Experience',
     traderRequirements: [
-      { trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }, value: 4 }, // Was: [] (player level requirement, minPlayerLevel 35)
+      {
+        id: 'overlay.675c1ff1a757ddd00404f0aa.54cb50c76803fa8b248b4571.level.>=.4',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+        value: 4,
+      }, // Was: [] (player level requirement, minPlayerLevel 35)
     ],
   },
 
@@ -465,7 +691,13 @@
   // 2026-08-10 - S1: now requires Prapor LL4 instead of player level
   '5d4bec3486f7743cac246665': {
     traderRequirements: [
-      { trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }, value: 4 }, // Was: [] (player level requirement, minPlayerLevel 25)
+      {
+        id: '6a331835f78e12821f3a5c3e',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+        value: 4,
+      }, // Was: [] (player level requirement, minPlayerLevel 25)
     ],
   },
 
@@ -477,7 +709,13 @@
   // Verified: in-game PvE capture 2026-08-12; wiki agrees.
   '60e71b62a0beca400d69efc4': {
     traderRequirements: [
-      { trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }, value: 4 }, // Was: [] (player level requirement, minPlayerLevel 46)
+      {
+        id: 'overlay.60e71b62a0beca400d69efc4.54cb50c76803fa8b248b4571.level.>=.4',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+        value: 4,
+      }, // Was: [] (player level requirement, minPlayerLevel 46)
     ],
     experience: 65000, // Was: 155000 (all modes, stale pre-1.1 value)
   },
@@ -490,7 +728,13 @@
   '6574e0dedc0d635f633a5805': {
     name: 'Getting Some Air',
     traderRequirements: [
-      { trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }, value: 4 }, // Was: [] (player level requirement, minPlayerLevel 28)
+      {
+        id: '6a557a780d81c4218f264a21',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+        value: 4,
+      }, // Was: [] (player level requirement, minPlayerLevel 28)
     ],
   },
 
@@ -500,7 +744,13 @@
   // 2026-08-10 - S1: now requires Prapor LL4 instead of player level
   '59c50a9e86f7745fef66f4ff': {
     traderRequirements: [
-      { trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }, value: 4 }, // Was: [] (player level requirement, minPlayerLevel 17)
+      {
+        id: 'overlay.59c50a9e86f7745fef66f4ff.54cb50c76803fa8b248b4571.level.>=.4',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+        value: 4,
+      }, // Was: [] (player level requirement, minPlayerLevel 17)
     ],
   },
 
@@ -510,7 +760,13 @@
   // 2026-08-10 - S1: now requires Prapor LL4 instead of player level
   '59c50c8886f7745fed3193bf': {
     traderRequirements: [
-      { trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }, value: 4 }, // Was: [] (player level requirement, minPlayerLevel 18)
+      {
+        id: '6a70899e66497c811decb758',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+        value: 4,
+      }, // Was: [] (player level requirement, minPlayerLevel 18)
     ],
   },
 
@@ -520,7 +776,13 @@
   // 2026-08-10 - S1: now requires Prapor LL4 instead of player level
   '59c512ad86f7741f0d09de9b': {
     traderRequirements: [
-      { trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }, value: 4 }, // Was: [] (player level requirement, minPlayerLevel 19)
+      {
+        id: 'overlay.59c512ad86f7741f0d09de9b.54cb50c76803fa8b248b4571.level.>=.4',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+        value: 4,
+      }, // Was: [] (player level requirement, minPlayerLevel 19)
     ],
   },
 
@@ -530,7 +792,13 @@
   // 2026-08-10 - S1: now requires Prapor LL4 instead of player level
   '59ca264786f77445a80ed044': {
     traderRequirements: [
-      { trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }, value: 4 }, // Was: [] (player level requirement, minPlayerLevel 20)
+      {
+        id: '6a708cbfc256169e529e4f1c',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+        value: 4,
+      }, // Was: [] (player level requirement, minPlayerLevel 20)
     ],
   },
 
@@ -540,7 +808,13 @@
   // 2026-08-10 - S1: now requires Prapor LL4 instead of player level
   '59ca29fb86f77445ab465c87': {
     traderRequirements: [
-      { trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }, value: 4 }, // Was: [] (player level requirement, minPlayerLevel 20)
+      {
+        id: 'overlay.59ca29fb86f77445ab465c87.54cb50c76803fa8b248b4571.level.>=.4',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+        value: 4,
+      }, // Was: [] (player level requirement, minPlayerLevel 20)
     ],
   },
 
@@ -550,7 +824,13 @@
   // 2026-08-10 - S1: now requires Prapor LL4 instead of player level
   '59ca2eb686f77445a80ed049': {
     traderRequirements: [
-      { trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }, value: 4 }, // Was: [] (player level requirement, minPlayerLevel 20)
+      {
+        id: 'overlay.59ca2eb686f77445a80ed049.54cb50c76803fa8b248b4571.level.>=.4',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+        value: 4,
+      }, // Was: [] (player level requirement, minPlayerLevel 20)
     ],
   },
 
@@ -560,7 +840,13 @@
   // 2026-08-10 - S1: now requires Prapor LL4 instead of player level
   '597a171586f77405ba6887d3': {
     traderRequirements: [
-      { trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }, value: 4 }, // Was: [] (player level requirement, minPlayerLevel 11)
+      {
+        id: 'overlay.597a171586f77405ba6887d3.54cb50c76803fa8b248b4571.level.>=.4',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+        value: 4,
+      }, // Was: [] (player level requirement, minPlayerLevel 11)
     ],
   },
 
@@ -570,7 +856,13 @@
   // 2026-08-10 - S1: now requires Prapor LL4 instead of player level
   '69ce1de03e15cd80bd06f6c9': {
     traderRequirements: [
-      { trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }, value: 4 }, // Was: [] (player level requirement, minPlayerLevel 0)
+      {
+        id: 'overlay.69ce1de03e15cd80bd06f6c9.54cb50c76803fa8b248b4571.level.>=.4',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+        value: 4,
+      }, // Was: [] (player level requirement, minPlayerLevel 0)
     ],
   },
 
@@ -580,7 +872,13 @@
   // 2026-08-10 - S1: now requires Prapor LL4 instead of player level
   '6740a3f4eca8acb2d2055159': {
     traderRequirements: [
-      { trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }, value: 4 }, // Was: [] (player level requirement, minPlayerLevel 0)
+      {
+        id: 'overlay.6740a3f4eca8acb2d2055159.54cb50c76803fa8b248b4571.level.>=.4',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+        value: 4,
+      }, // Was: [] (player level requirement, minPlayerLevel 0)
     ],
   },
 
@@ -590,7 +888,13 @@
   // 2026-08-10 - S1: now requires Prapor LL4 instead of player level
   '6740a15566e6a521aa051b15': {
     traderRequirements: [
-      { trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }, value: 4 }, // Was: [] (player level requirement, minPlayerLevel 0)
+      {
+        id: 'overlay.6740a15566e6a521aa051b15.54cb50c76803fa8b248b4571.level.>=.4',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+        value: 4,
+      }, // Was: [] (player level requirement, minPlayerLevel 0)
     ],
   },
 
@@ -600,7 +904,13 @@
   // 2026-08-10 - S1: now requires Prapor LL4 instead of player level
   '6740a2c17e3818d5bb0648b6': {
     traderRequirements: [
-      { trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }, value: 4 }, // Was: [] (player level requirement, minPlayerLevel 0)
+      {
+        id: 'overlay.6740a2c17e3818d5bb0648b6.54cb50c76803fa8b248b4571.level.>=.4',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+        value: 4,
+      }, // Was: [] (player level requirement, minPlayerLevel 0)
     ],
   },
 
@@ -618,7 +928,13 @@
   // 2026-08-10 - S1: now requires Therapist LL1 instead of player level
   '5969f9e986f7741dde183a50': {
     traderRequirements: [
-      { trader: { id: '54cb57776803fa99248b456e', name: 'Therapist' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 10)
+      {
+        id: 'overlay.5969f9e986f7741dde183a50.54cb57776803fa99248b456e.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb57776803fa99248b456e', name: 'Therapist' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 10)
     ],
   },
 
@@ -630,7 +946,13 @@
   '59689fbd86f7740d137ebfc4': {
     name: 'Operation Aquarius', // Was: Operation Aquarius - Part 1
     traderRequirements: [
-      { trader: { id: '54cb57776803fa99248b456e', name: 'Therapist' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 6)
+      {
+        id: 'overlay.59689fbd86f7740d137ebfc4.54cb57776803fa99248b456e.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb57776803fa99248b456e', name: 'Therapist' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 6)
     ],
   },
 
@@ -642,7 +964,13 @@
   '5968eb3186f7741dde183a4d': {
     name: 'Blood in the Water', // Was: Operation Aquarius - Part 2
     traderRequirements: [
-      { trader: { id: '54cb57776803fa99248b456e', name: 'Therapist' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 6)
+      {
+        id: 'overlay.5968eb3186f7741dde183a4d.54cb57776803fa99248b456e.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb57776803fa99248b456e', name: 'Therapist' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 6)
     ],
   },
 
@@ -652,7 +980,13 @@
   // 2026-08-10 - S1: now requires Therapist LL1 instead of player level
   '657315ddab5a49b71f098853': {
     traderRequirements: [
-      { trader: { id: '54cb57776803fa99248b456e', name: 'Therapist' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 1)
+      {
+        id: 'overlay.657315ddab5a49b71f098853.54cb57776803fa99248b456e.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb57776803fa99248b456e', name: 'Therapist' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 1)
     ],
   },
 
@@ -662,7 +996,13 @@
   // 2026-08-10 - S1: now requires Therapist LL1 instead of player level
   '675c047fa46173572a0bd878': {
     traderRequirements: [
-      { trader: { id: '54cb57776803fa99248b456e', name: 'Therapist' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 17)
+      {
+        id: 'overlay.675c047fa46173572a0bd878.54cb57776803fa99248b456e.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb57776803fa99248b456e', name: 'Therapist' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 17)
     ],
   },
 
@@ -672,7 +1012,13 @@
   // 2026-08-10 - S1: now requires Therapist LL1 instead of player level
   '5967733e86f774602332fc84': {
     traderRequirements: [
-      { trader: { id: '54cb57776803fa99248b456e', name: 'Therapist' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 1)
+      {
+        id: 'overlay.5967733e86f774602332fc84.54cb57776803fa99248b456e.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb57776803fa99248b456e', name: 'Therapist' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 1)
     ],
   },
 
@@ -682,7 +1028,13 @@
   // 2026-08-10 - S1: now requires Therapist LL1 instead of player level
   '596a0e1686f7741ddf17dbee': {
     traderRequirements: [
-      { trader: { id: '54cb57776803fa99248b456e', name: 'Therapist' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 13)
+      {
+        id: 'overlay.596a0e1686f7741ddf17dbee.54cb57776803fa99248b456e.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb57776803fa99248b456e', name: 'Therapist' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 13)
     ],
   },
 
@@ -692,7 +1044,13 @@
   // 2026-08-10 - S1: now requires Therapist LL1 instead of player level
   '675c03d1f7da9792a405549a': {
     traderRequirements: [
-      { trader: { id: '54cb57776803fa99248b456e', name: 'Therapist' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 17)
+      {
+        id: 'overlay.675c03d1f7da9792a405549a.54cb57776803fa99248b456e.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb57776803fa99248b456e', name: 'Therapist' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 17)
     ],
   },
 
@@ -706,7 +1064,13 @@
   // 2026-08-10 - S1: now requires Therapist LL2 instead of player level
   '669fa39ee749756c920d02c8': {
     traderRequirements: [
-      { trader: { id: '54cb57776803fa99248b456e', name: 'Therapist' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 12)
+      {
+        id: '6a5671eb45279d26d08058eb',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb57776803fa99248b456e', name: 'Therapist' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 12)
     ],
   },
 
@@ -716,7 +1080,13 @@
   // 2026-08-10 - S1: now requires Therapist LL2 instead of player level
   '596a1e6c86f7741ddc2d3206': {
     traderRequirements: [
-      { trader: { id: '54cb57776803fa99248b456e', name: 'Therapist' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 10)
+      {
+        id: 'overlay.596a1e6c86f7741ddc2d3206.54cb57776803fa99248b456e.level.>=.2',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb57776803fa99248b456e', name: 'Therapist' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 10)
     ],
   },
 
@@ -728,7 +1098,13 @@
   '59689ee586f7740d1570bbd5': {
     name: 'Sanitary Standards', // Was: Sanitary Standards - Part 1
     traderRequirements: [
-      { trader: { id: '54cb57776803fa99248b456e', name: 'Therapist' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 4)
+      {
+        id: 'overlay.59689ee586f7740d1570bbd5.54cb57776803fa99248b456e.level.>=.2',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb57776803fa99248b456e', name: 'Therapist' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 4)
     ],
   },
 
@@ -738,7 +1114,13 @@
   // 2026-08-10 - S1: now requires Therapist LL2 instead of player level
   '639135d89444fb141f4e6eea': {
     traderRequirements: [
-      { trader: { id: '54cb57776803fa99248b456e', name: 'Therapist' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 12)
+      {
+        id: '6a56728bf66db0e9f214d01f',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb57776803fa99248b456e', name: 'Therapist' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 12)
     ],
   },
 
@@ -748,7 +1130,13 @@
   // 2026-08-10 - S1: now requires Therapist LL2 instead of player level
   '639135e0fa894f0a866afde6': {
     traderRequirements: [
-      { trader: { id: '54cb57776803fa99248b456e', name: 'Therapist' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 17)
+      {
+        id: 'overlay.639135e0fa894f0a866afde6.54cb57776803fa99248b456e.level.>=.2',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb57776803fa99248b456e', name: 'Therapist' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 17)
     ],
   },
 
@@ -762,7 +1150,13 @@
   // 2026-08-10 - S1: now requires Therapist LL3 instead of player level
   '60896e28e4a85c72ef3fa301': {
     traderRequirements: [
-      { trader: { id: '54cb57776803fa99248b456e', name: 'Therapist' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 15)
+      {
+        id: 'overlay.60896e28e4a85c72ef3fa301.54cb57776803fa99248b456e.level.>=.3',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb57776803fa99248b456e', name: 'Therapist' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 15)
     ],
   },
 
@@ -772,7 +1166,13 @@
   // 2026-08-10 - S1: now requires Therapist LL3 instead of player level
   '596a218586f77420d232807c': {
     traderRequirements: [
-      { trader: { id: '54cb57776803fa99248b456e', name: 'Therapist' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 10)
+      {
+        id: 'overlay.596a218586f77420d232807c.54cb57776803fa99248b456e.level.>=.3',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb57776803fa99248b456e', name: 'Therapist' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 10)
     ],
   },
 
@@ -782,7 +1182,13 @@
   // 2026-08-10 - S1: now requires Therapist LL3 instead of player level
   '626bd75b05f287031503c7f6': {
     traderRequirements: [
-      { trader: { id: '54cb57776803fa99248b456e', name: 'Therapist' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 26)
+      {
+        id: 'overlay.626bd75b05f287031503c7f6.54cb57776803fa99248b456e.level.>=.3',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb57776803fa99248b456e', name: 'Therapist' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 26)
     ],
   },
 
@@ -794,7 +1200,13 @@
   '5edab736cc183c769d778bc2': {
     name: 'Colleagues', // Was: Colleagues - Part 1
     traderRequirements: [
-      { trader: { id: '54cb57776803fa99248b456e', name: 'Therapist' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 21)
+      {
+        id: '6a5685563580cb5f5777824a',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb57776803fa99248b456e', name: 'Therapist' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 21)
     ],
   },
 
@@ -806,7 +1218,13 @@
   '5edaba7c0c502106f869bc02': {
     name: 'Tarkov-Style Diplomacy', // Was: Colleagues - Part 2
     traderRequirements: [
-      { trader: { id: '54cb57776803fa99248b456e', name: 'Therapist' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 21)
+      {
+        id: 'overlay.5edaba7c0c502106f869bc02.54cb57776803fa99248b456e.level.>=.3',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb57776803fa99248b456e', name: 'Therapist' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 21)
     ],
   },
 
@@ -824,7 +1242,13 @@
   // 2026-08-10 - S1: now requires Therapist LL3 instead of player level
   '6179afd0bca27a099552e040': {
     traderRequirements: [
-      { trader: { id: '54cb57776803fa99248b456e', name: 'Therapist' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 26)
+      {
+        id: '6a568cd5051e9fd6be55db27',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb57776803fa99248b456e', name: 'Therapist' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 26)
     ],
   },
 
@@ -834,7 +1258,13 @@
   // 2026-08-10 - S1: now requires Therapist LL3 instead of player level
   '6179ad56c760af5ad2053587': {
     traderRequirements: [
-      { trader: { id: '54cb57776803fa99248b456e', name: 'Therapist' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 17)
+      {
+        id: 'overlay.6179ad56c760af5ad2053587.54cb57776803fa99248b456e.level.>=.3',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb57776803fa99248b456e', name: 'Therapist' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 17)
     ],
   },
 
@@ -848,7 +1278,13 @@
   // 2026-08-10 - S1: now requires Therapist LL4 instead of player level
   '66aba85403e0ee3101042877': {
     traderRequirements: [
-      { trader: { id: '54cb57776803fa99248b456e', name: 'Therapist' }, value: 4 }, // Was: [] (player level requirement, minPlayerLevel 12)
+      {
+        id: '6a5691e3b9e428b94e3559f9',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb57776803fa99248b456e', name: 'Therapist' },
+        value: 4,
+      }, // Was: [] (player level requirement, minPlayerLevel 12)
     ],
   },
 
@@ -858,7 +1294,13 @@
   // 2026-08-10 - S1: now requires Therapist LL4 instead of player level
   '60e71c48c1bfa3050473b8e5': {
     traderRequirements: [
-      { trader: { id: '54cb57776803fa99248b456e', name: 'Therapist' }, value: 4 }, // Was: [] (player level requirement, minPlayerLevel 38)
+      {
+        id: 'overlay.60e71c48c1bfa3050473b8e5.54cb57776803fa99248b456e.level.>=.4',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb57776803fa99248b456e', name: 'Therapist' },
+        value: 4,
+      }, // Was: [] (player level requirement, minPlayerLevel 38)
     ],
   },
 
@@ -870,7 +1312,13 @@
   // Verified: in-game PvE capture 2026-08-12; wiki agrees.
   '5c0d1c4cd0928202a02a6f5c': {
     traderRequirements: [
-      { trader: { id: '54cb57776803fa99248b456e', name: 'Therapist' }, value: 4 }, // Was: [] (player level requirement, minPlayerLevel 35)
+      {
+        id: '6a56918725d5f33f34942282',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '54cb57776803fa99248b456e', name: 'Therapist' },
+        value: 4,
+      }, // Was: [] (player level requirement, minPlayerLevel 35)
     ],
     experience: 65000, // Was: 12500 (all modes, stale pre-1.1 value)
   },
@@ -885,7 +1333,13 @@
   // 2026-08-10 - S1: now requires Fence LL1 instead of player level
   '6663148ed7f171c4c20226c1': {
     traderRequirements: [
-      { trader: { id: '579dc571d53a0658a154fbec', name: 'Fence' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 0)
+      {
+        id: 'overlay.6663148ed7f171c4c20226c1.579dc571d53a0658a154fbec.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '579dc571d53a0658a154fbec', name: 'Fence' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 0)
     ],
   },
 
@@ -895,7 +1349,13 @@
   // 2026-08-10 - S1: now requires Fence LL1 instead of player level
   '6663149196a9349baa021baa': {
     traderRequirements: [
-      { trader: { id: '579dc571d53a0658a154fbec', name: 'Fence' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 0)
+      {
+        id: 'overlay.6663149196a9349baa021baa.579dc571d53a0658a154fbec.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '579dc571d53a0658a154fbec', name: 'Fence' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 0)
     ],
   },
 
@@ -915,7 +1375,13 @@
   // 2026-08-10 - S1: now requires Fence LL1 instead of player level
   '66631493312343839d032d22': {
     traderRequirements: [
-      { trader: { id: '579dc571d53a0658a154fbec', name: 'Fence' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 0)
+      {
+        id: 'overlay.66631493312343839d032d22.579dc571d53a0658a154fbec.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '579dc571d53a0658a154fbec', name: 'Fence' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 0)
     ],
     objectives: {
       '666733e565831d5bafa18bbb': {
@@ -927,23 +1393,19 @@
     },
   },
 
-  // Establish Contact - Change requirements
-  // Proof: https://escapefromtarkov.fandom.com/wiki/Establish_Contact
-  //
-  // 2026-08-10: replaced the scav karma reputation gate with Fence LL1
-  '6672d9def1c88688a707d042': {
-    traderRequirements: [
-      { trader: { id: '579dc571d53a0658a154fbec', name: 'Fence' }, value: 1 }, // Was: [] (scav karma +4 reputation requirement)
-    ],
-  },
-
   // Friend Among Strangers - Change requirements
   // Proof: https://escapefromtarkov.fandom.com/wiki/Friend_Among_Strangers
   //
   // 2026-08-10 - S1: now requires Fence LL1 instead of player level
   '66631489acf8442f8b05319f': {
     traderRequirements: [
-      { trader: { id: '579dc571d53a0658a154fbec', name: 'Fence' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 0)
+      {
+        id: 'overlay.66631489acf8442f8b05319f.579dc571d53a0658a154fbec.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '579dc571d53a0658a154fbec', name: 'Fence' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 0)
     ],
   },
 
@@ -954,7 +1416,13 @@
   // tarkov.dev currently returns the Immunity skill page instead of the quest page.
   '6663148ca9290f9e0806cca1': {
     traderRequirements: [
-      { trader: { id: '579dc571d53a0658a154fbec', name: 'Fence' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 0)
+      {
+        id: 'overlay.6663148ca9290f9e0806cca1.579dc571d53a0658a154fbec.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '579dc571d53a0658a154fbec', name: 'Fence' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 0)
     ],
     wikiLink: 'https://escapefromtarkov.fandom.com/wiki/Immunity_(quest)', // Was: https://escapefromtarkov.fandom.com/wiki/Immunity
   },
@@ -965,27 +1433,13 @@
   // 2026-08-10 - S1: now requires Fence LL1 instead of player level
   '60effd818b669d08a35bfad5': {
     traderRequirements: [
-      { trader: { id: '579dc571d53a0658a154fbec', name: 'Fence' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 50)
-    ],
-  },
-
-  // Collector - Change requirements
-  // Proof: https://escapefromtarkov.fandom.com/wiki/Collector
-  //
-  // 2026-08-10 - S1: now requires Fence LL1 instead of player level
-  '5c51aac186f77432ea65c552': {
-    traderRequirements: [
-      { trader: { id: '579dc571d53a0658a154fbec', name: 'Fence' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 45)
-    ],
-  },
-
-  // Is This a Reference? - Change requirements
-  // Proof: https://escapefromtarkov.fandom.com/wiki/Is_This_a_Reference
-  //
-  // 2026-08-10 - S1: now requires Fence LL1 instead of player level
-  '66d9cbb67b491f9d5304f6e6': {
-    traderRequirements: [
-      { trader: { id: '579dc571d53a0658a154fbec', name: 'Fence' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 25)
+      {
+        id: 'overlay.60effd818b669d08a35bfad5.579dc571d53a0658a154fbec.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '579dc571d53a0658a154fbec', name: 'Fence' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 50)
     ],
   },
 
@@ -999,7 +1453,13 @@
   // 2026-08-10 - S1: now requires Skier LL1 instead of player level
   '596b36c586f77450d6045ad2': {
     traderRequirements: [
-      { trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 5)
+      {
+        id: 'overlay.596b36c586f77450d6045ad2.58330581ace78e27b8b10cee.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 5)
     ],
   },
 
@@ -1009,7 +1469,13 @@
   // 2026-08-10 - S1: now requires Skier LL1 instead of player level
   '657315e270bb0b8dba00cc48': {
     traderRequirements: [
-      { trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 1)
+      {
+        id: 'overlay.657315e270bb0b8dba00cc48.58330581ace78e27b8b10cee.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 1)
     ],
   },
 
@@ -1019,7 +1485,13 @@
   // 2026-08-10 - S1: now requires Skier LL1 instead of player level
   '5979eee086f774311955e614': {
     traderRequirements: [
-      { trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 8)
+      {
+        id: 'overlay.5979eee086f774311955e614.58330581ace78e27b8b10cee.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 8)
     ],
   },
 
@@ -1029,7 +1501,13 @@
   // 2026-08-10 - S1: now requires Skier LL1 instead of player level
   '5b47926a86f7747ccc057c15': {
     traderRequirements: [
-      { trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 24)
+      {
+        id: 'overlay.5b47926a86f7747ccc057c15.58330581ace78e27b8b10cee.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 24)
     ],
   },
 
@@ -1039,7 +1517,13 @@
   // 2026-08-10 - S1: now requires Skier LL1 instead of player level
   '596b43fb86f77457ca186186': {
     traderRequirements: [
-      { trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 7)
+      {
+        id: 'overlay.596b43fb86f77457ca186186.58330581ace78e27b8b10cee.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 7)
     ],
   },
 
@@ -1049,7 +1533,13 @@
   // 2026-08-10 - S1: now requires Skier LL1 instead of player level
   '675c3582f6ddc329a90f9c6d': {
     traderRequirements: [
-      { trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 24)
+      {
+        id: 'overlay.675c3582f6ddc329a90f9c6d.58330581ace78e27b8b10cee.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 24)
     ],
   },
 
@@ -1061,7 +1551,13 @@
   // Verified: in-game PvE capture 2026-08-12; wiki agrees.
   '658027799634223183395339': {
     traderRequirements: [
-      { trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 24)
+      {
+        id: 'overlay.658027799634223183395339.58330581ace78e27b8b10cee.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 24)
     ],
     experience: 3000, // Was: 12000 (all modes, stale pre-1.1 value)
   },
@@ -1072,7 +1568,13 @@
   // 2026-08-10 - S1: now requires Skier LL1 instead of player level
   '5979ed3886f77431307dc512': {
     traderRequirements: [
-      { trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 8)
+      {
+        id: 'overlay.5979ed3886f77431307dc512.58330581ace78e27b8b10cee.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 8)
     ],
   },
 
@@ -1082,7 +1584,13 @@
   // 2026-08-10 - S1: moved to Skier LL1 (was given by Prapor, player level requirement)
   '5979f8bb86f7743ec214c7a6': {
     traderRequirements: [
-      { trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' }, value: 1 }, // Was: [] (Prapor trader, minPlayerLevel 10)
+      {
+        id: 'overlay.5979f8bb86f7743ec214c7a6.58330581ace78e27b8b10cee.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' },
+        value: 1,
+      }, // Was: [] (Prapor trader, minPlayerLevel 10)
     ],
   },
 
@@ -1098,7 +1606,13 @@
   '64f5e20652fc01298e2c61e3': {
     name: 'Beyond the Red Meat', // Was: Beyond the Red Meat - Part 1
     traderRequirements: [
-      { trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 22)
+      {
+        id: '6a5a9410c2522cbbe5bcc808',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 22)
     ],
   },
 
@@ -1110,7 +1624,13 @@
   '64f6aafd67e11a7c6206e0d0': {
     name: 'The Secret Recipe', // Was: Beyond the Red Meat - Part 2
     traderRequirements: [
-      { trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 22)
+      {
+        id: 'overlay.64f6aafd67e11a7c6206e0d0.58330581ace78e27b8b10cee.level.>=.2',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 22)
     ],
   },
 
@@ -1120,7 +1640,13 @@
   // 2026-08-10 - S1: now requires Skier LL2 instead of player level
   '5b4795fb86f7745876267770': {
     traderRequirements: [
-      { trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 24)
+      {
+        id: '6a5a944e5e12536882583b02',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 24)
     ],
   },
 
@@ -1131,7 +1657,13 @@
   // Wiki Guide section lists additional valid hats and chest rigs for objective progress.
   '5c1234c286f77406fa13baeb': {
     traderRequirements: [
-      { trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 18)
+      {
+        id: 'overlay.5c1234c286f77406fa13baeb.58330581ace78e27b8b10cee.level.>=.2',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 18)
     ],
     objectives: {
       '5c1fa9c986f7740de474cb3d': {
@@ -1221,7 +1753,13 @@
   // Verified: in-game PvE capture 2026-08-12; wiki agrees.
   '639dbaf17c898a131e1cffff': {
     traderRequirements: [
-      { trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 31)
+      {
+        id: 'overlay.639dbaf17c898a131e1cffff.58330581ace78e27b8b10cee.level.>=.2',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 31)
     ],
     experience: 10000, // Was: 13200 (all modes, stale pre-1.1 value)
   },
@@ -1234,7 +1772,13 @@
   '5b478ff486f7744d184ecbbf': {
     name: 'Supplements', // Was: Vitamins - Part 2
     traderRequirements: [
-      { trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 22)
+      {
+        id: 'overlay.5b478ff486f7744d184ecbbf.58330581ace78e27b8b10cee.level.>=.2',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 22)
     ],
   },
 
@@ -1246,7 +1790,13 @@
   '5b478eca86f7744642012254': {
     name: 'Vitamins', // Was: Vitamins - Part 1
     traderRequirements: [
-      { trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 22)
+      {
+        id: 'overlay.5b478eca86f7744642012254.58330581ace78e27b8b10cee.level.>=.2',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 22)
     ],
   },
 
@@ -1256,7 +1806,13 @@
   // 2026-08-10 - S1: now requires Skier LL2 instead of player level
   '669fa39c64ea11e84c0642a6': {
     traderRequirements: [
-      { trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 12)
+      {
+        id: 'overlay.669fa39c64ea11e84c0642a6.58330581ace78e27b8b10cee.level.>=.2',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 12)
     ],
   },
 
@@ -1266,7 +1822,13 @@
   // 2026-08-10 - S1: now requires Skier LL2 instead of player level
   '669fa395c4c5c04798002497': {
     traderRequirements: [
-      { trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 12)
+      {
+        id: '6a5a93c8db2687962b275371',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 12)
     ],
   },
 
@@ -1278,7 +1840,13 @@
   '5a27c99a86f7747d2c6bdd8e': {
     name: 'Friend From the West', // Was: Friend From the West - Part 1
     traderRequirements: [
-      { trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 9)
+      {
+        id: 'overlay.5a27c99a86f7747d2c6bdd8e.58330581ace78e27b8b10cee.level.>=.2',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 9)
     ],
   },
 
@@ -1288,7 +1856,13 @@
   // 2026-08-10 - S1: now requires Skier LL2 instead of player level
   '596b455186f77457cb50eccb': {
     traderRequirements: [
-      { trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 8)
+      {
+        id: 'overlay.596b455186f77457cb50eccb.58330581ace78e27b8b10cee.level.>=.2',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 8)
     ],
   },
 
@@ -1300,7 +1874,13 @@
   '639135c3744e452011470807': {
     name: 'House Arrest', // Was: House Arrest - Part 1
     traderRequirements: [
-      { trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 33)
+      {
+        id: 'overlay.639135c3744e452011470807.58330581ace78e27b8b10cee.level.>=.2',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 33)
     ],
   },
 
@@ -1314,7 +1894,13 @@
   // 2026-08-10 - S1: now requires Skier LL3 instead of player level
   '6089743983426423753cd58a': {
     traderRequirements: [
-      { trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 15)
+      {
+        id: 'overlay.6089743983426423753cd58a.58330581ace78e27b8b10cee.level.>=.3',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 15)
     ],
   },
 
@@ -1324,7 +1910,13 @@
   // 2026-08-10 - S1: now requires Skier LL3 instead of player level
   '6179b4f16e9dd54ac275e407': {
     traderRequirements: [
-      { trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 30)
+      {
+        id: '6a5ab667f680e09c8c1bf5a3',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 30)
     ],
   },
 
@@ -1334,7 +1926,13 @@
   // 2026-08-10 - S1: now requires Skier LL3 instead of player level
   '5edabd13218d181e29451442': {
     traderRequirements: [
-      { trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 21)
+      {
+        id: 'overlay.5edabd13218d181e29451442.58330581ace78e27b8b10cee.level.>=.3',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 21)
     ],
   },
 
@@ -1346,7 +1944,13 @@
   // Verified: in-game PvE capture 2026-08-12; wiki agrees.
   '6572e876dc0d635f633a5714': {
     traderRequirements: [
-      { trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 28)
+      {
+        id: 'overlay.6572e876dc0d635f633a5714.58330581ace78e27b8b10cee.level.>=.3',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 28)
     ],
     experience: 28000, // Was: 12400 (all modes, stale pre-1.1 value)
   },
@@ -1357,7 +1961,13 @@
   // 2026-08-10 - S1: now requires Skier LL3 instead of player level
   '626bd75d5bef5d7d590bd415': {
     traderRequirements: [
-      { trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 30)
+      {
+        id: 'overlay.626bd75d5bef5d7d590bd415.58330581ace78e27b8b10cee.level.>=.3',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 30)
     ],
   },
 
@@ -1367,7 +1977,13 @@
   // 2026-08-10 - S1: moved to Skier LL3 (was given by Peacekeeper, player level requirement)
   '60896888e4a85c72ef3fa300': {
     traderRequirements: [
-      { trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' }, value: 3 }, // Was: [] (Peacekeeper trader, minPlayerLevel 14)
+      {
+        id: '6a5ab6bf5d4ba3e1966dcd75',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' },
+        value: 3,
+      }, // Was: [] (Peacekeeper trader, minPlayerLevel 14)
     ],
   },
 
@@ -1377,7 +1993,13 @@
   // 2026-08-10 - S1: now requires Skier LL3 instead of player level
   '6193850f60b34236ee0483de': {
     traderRequirements: [
-      { trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 20)
+      {
+        id: 'overlay.6193850f60b34236ee0483de.58330581ace78e27b8b10cee.level.>=.3',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 20)
     ],
   },
 
@@ -1391,7 +2013,13 @@
   // 2026-08-10 - S1: now requires Skier LL4 instead of player level
   '5c0bc91486f7746ab41857a2': {
     traderRequirements: [
-      { trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' }, value: 4 }, // Was: [] (player level requirement, minPlayerLevel 30)
+      {
+        id: '6a5abc99e0f019d42e708621',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' },
+        value: 4,
+      }, // Was: [] (player level requirement, minPlayerLevel 30)
     ],
   },
 
@@ -1401,7 +2029,13 @@
   // 2026-08-10 - S1: now requires Skier LL4 instead of player level
   '5c0bbaa886f7746941031d82': {
     traderRequirements: [
-      { trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' }, value: 4 }, // Was: [] (player level requirement, minPlayerLevel 24)
+      {
+        id: '6a5abbce80de21369de9a336',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' },
+        value: 4,
+      }, // Was: [] (player level requirement, minPlayerLevel 24)
     ],
   },
 
@@ -1411,7 +2045,13 @@
   // 2026-08-10 - S1: now requires Skier LL4 instead of player level
   '6764174c86addd02bc033d68': {
     traderRequirements: [
-      { trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' }, value: 4 }, // Was: [] (player level requirement, minPlayerLevel 33)
+      {
+        id: 'overlay.6764174c86addd02bc033d68.58330581ace78e27b8b10cee.level.>=.4',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' },
+        value: 4,
+      }, // Was: [] (player level requirement, minPlayerLevel 33)
     ],
   },
 
@@ -1421,7 +2061,13 @@
   // 2026-08-10 - S1: now requires Skier LL4 instead of player level
   '60e71c11d54b755a3b53eb65': {
     traderRequirements: [
-      { trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' }, value: 4 }, // Was: [] (player level requirement, minPlayerLevel 50)
+      {
+        id: 'overlay.60e71c11d54b755a3b53eb65.58330581ace78e27b8b10cee.level.>=.4',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '58330581ace78e27b8b10cee', name: 'Skier' },
+        value: 4,
+      }, // Was: [] (player level requirement, minPlayerLevel 50)
     ],
   },
 
@@ -1435,7 +2081,13 @@
   // 2026-08-10 - S1: now requires Peacekeeper LL1 instead of player level
   '675c1d6d59b0575973008fc7': {
     traderRequirements: [
-      { trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 11)
+      {
+        id: 'overlay.675c1d6d59b0575973008fc7.5935c25fb3acc3127c3d8cd9.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 11)
     ],
   },
 
@@ -1447,7 +2099,13 @@
   '66aa58245ab22944110db6e9': {
     name: 'New Paths', // Was: New Day, New Paths
     traderRequirements: [
-      { trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 17)
+      {
+        id: 'overlay.66aa58245ab22944110db6e9.5935c25fb3acc3127c3d8cd9.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 17)
     ],
   },
 
@@ -1457,7 +2115,13 @@
   // 2026-08-10 - S1: now requires Peacekeeper LL1 instead of player level
   '5a27b7a786f774579c3eb376': {
     traderRequirements: [
-      { trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 10)
+      {
+        id: 'overlay.5a27b7a786f774579c3eb376.5935c25fb3acc3127c3d8cd9.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 10)
     ],
   },
 
@@ -1467,7 +2131,13 @@
   // 2026-08-10 - S1: now requires Peacekeeper LL1 instead of player level
   '669fa38fad7f1eac2607ed46': {
     traderRequirements: [
-      { trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 15)
+      {
+        id: 'overlay.669fa38fad7f1eac2607ed46.5935c25fb3acc3127c3d8cd9.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 15)
     ],
   },
 
@@ -1481,7 +2151,13 @@
   // 2026-08-10 - S1: now requires Peacekeeper LL2 instead of player level
   '5a27b80086f774429a5d7e20': {
     traderRequirements: [
-      { trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 11)
+      {
+        id: 'overlay.5a27b80086f774429a5d7e20.5935c25fb3acc3127c3d8cd9.level.>=.2',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 11)
     ],
   },
 
@@ -1491,7 +2167,13 @@
   // 2026-08-10 - S1: now requires Peacekeeper LL2 instead of player level
   '5a27b75b86f7742e97191958': {
     traderRequirements: [
-      { trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 10)
+      {
+        id: '6a5ccb9c38a1dc09841e0002',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 10)
     ],
   },
 
@@ -1503,7 +2185,13 @@
   '5a27ba1c86f77461ea5a3c56': {
     name: 'Weapons Circulation', // Was: The Cult - Part 2
     traderRequirements: [
-      { trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 18)
+      {
+        id: 'overlay.5a27ba1c86f77461ea5a3c56.5935c25fb3acc3127c3d8cd9.level.>=.2',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 18)
     ],
   },
 
@@ -1513,7 +2201,13 @@
   // 2026-08-10 - S1: now requires Peacekeeper LL2 instead of player level
   '639282134ed9512be67647ed': {
     traderRequirements: [
-      { trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 20)
+      {
+        id: 'overlay.639282134ed9512be67647ed.5935c25fb3acc3127c3d8cd9.level.>=.2',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 20)
     ],
   },
 
@@ -1523,7 +2217,13 @@
   // 2026-08-10 - S1: now requires Peacekeeper LL2 instead of player level
   '5a27b87686f77460de0252a8': {
     traderRequirements: [
-      { trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 11)
+      {
+        id: 'overlay.5a27b87686f77460de0252a8.5935c25fb3acc3127c3d8cd9.level.>=.2',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 11)
     ],
   },
 
@@ -1535,7 +2235,13 @@
   '5a27b9de86f77464e5044585': {
     name: 'The Cult', // Was: The Cult - Part 1
     traderRequirements: [
-      { trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 12)
+      {
+        id: '6a5ccc86a7c316d35f7b7c72',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 12)
     ],
   },
 
@@ -1545,7 +2251,13 @@
   // 2026-08-10 - S1: now requires Peacekeeper LL2 instead of player level
   '639135f286e646067c176a87': {
     traderRequirements: [
-      { trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 17)
+      {
+        id: 'overlay.639135f286e646067c176a87.5935c25fb3acc3127c3d8cd9.level.>=.2',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 17)
     ],
   },
 
@@ -1555,7 +2267,13 @@
   // 2026-08-10 - S1: now requires Peacekeeper LL2 instead of player level
   '639135534b15ca31f76bc317': {
     traderRequirements: [
-      { trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 35)
+      {
+        id: 'overlay.639135534b15ca31f76bc317.5935c25fb3acc3127c3d8cd9.level.>=.2',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 35)
     ],
   },
 
@@ -1565,7 +2283,13 @@
   // 2026-08-10 - S1: now requires Peacekeeper LL2 instead of player level
   '5a27b7d686f77460d847e6a6': {
     traderRequirements: [
-      { trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 10)
+      {
+        id: 'overlay.5a27b7d686f77460d847e6a6.5935c25fb3acc3127c3d8cd9.level.>=.2',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 10)
     ],
   },
 
@@ -1581,7 +2305,13 @@
   '5a27bb3d86f77411ea361a21': {
     name: 'Tracker', // Was: Cargo X - Part 2
     traderRequirements: [
-      { trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 12)
+      {
+        id: '6a5cd187f437270d2aaf9a78',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 12)
     ],
   },
 
@@ -1593,7 +2323,13 @@
   '5a27bb1e86f7741f27621b7e': {
     name: 'Cargo X', // Was: Cargo X - Part 1
     traderRequirements: [
-      { trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 12)
+      {
+        id: 'overlay.5a27bb1e86f7741f27621b7e.5935c25fb3acc3127c3d8cd9.level.>=.3',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 12)
     ],
   },
 
@@ -1603,7 +2339,13 @@
   // 2026-08-10 - S1: now requires Peacekeeper LL3 instead of player level
   '6179b4d1bca27a099552e04e': {
     traderRequirements: [
-      { trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 14)
+      {
+        id: '6a5cd322e269e5d058004aec',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 14)
     ],
   },
 
@@ -1613,7 +2355,13 @@
   // 2026-08-10 - S1: now requires Peacekeeper LL3 instead of player level
   '60e71c9ad54b755a3b53eb66': {
     traderRequirements: [
-      { trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 45)
+      {
+        id: 'overlay.60e71c9ad54b755a3b53eb66.5935c25fb3acc3127c3d8cd9.level.>=.3',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 45)
     ],
   },
 
@@ -1625,7 +2373,13 @@
   '61958c366726521dd96828ec': {
     name: 'Gifts from Tarkov', // Was: Cargo X - Part 4
     traderRequirements: [
-      { trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 12)
+      {
+        id: 'overlay.61958c366726521dd96828ec.5935c25fb3acc3127c3d8cd9.level.>=.3',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 12)
     ],
   },
 
@@ -1635,7 +2389,13 @@
   // 2026-08-10 - S1: now requires Peacekeeper LL3 instead of player level
   '6086c852c945025d41566124': {
     traderRequirements: [
-      { trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 14)
+      {
+        id: '6a5cd3c28199bce8ef295232',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 14)
     ],
   },
 
@@ -1645,7 +2405,13 @@
   // 2026-08-10 - S1: now requires Peacekeeper LL3 instead of player level
   '6179aff8f57fb279792c60a1': {
     traderRequirements: [
-      { trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 15)
+      {
+        id: 'overlay.6179aff8f57fb279792c60a1.5935c25fb3acc3127c3d8cd9.level.>=.3',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 15)
     ],
   },
 
@@ -1659,7 +2425,13 @@
   // 2026-08-10 - S1: now requires Peacekeeper LL4 instead of player level
   '5c0d4e61d09282029f53920e': {
     traderRequirements: [
-      { trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' }, value: 4 }, // Was: [] (player level requirement, minPlayerLevel 32)
+      {
+        id: 'overlay.5c0d4e61d09282029f53920e.5935c25fb3acc3127c3d8cd9.level.>=.4',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' },
+        value: 4,
+      }, // Was: [] (player level requirement, minPlayerLevel 32)
     ],
   },
 
@@ -1669,7 +2441,13 @@
   // 2026-08-10 - S1: now requires Peacekeeper LL4 instead of player level
   '6179b5eabca27a099552e052': {
     traderRequirements: [
-      { trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' }, value: 4 }, // Was: [] (player level requirement, minPlayerLevel 30)
+      {
+        id: 'overlay.6179b5eabca27a099552e052.5935c25fb3acc3127c3d8cd9.level.>=.4',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' },
+        value: 4,
+      }, // Was: [] (player level requirement, minPlayerLevel 30)
     ],
   },
 
@@ -1679,7 +2457,13 @@
   // 2026-08-10 - S1: now requires Peacekeeper LL4 instead of player level
   '5c0d4c12d09282029f539173': {
     traderRequirements: [
-      { trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' }, value: 4 }, // Was: [] (player level requirement, minPlayerLevel 30)
+      {
+        id: 'overlay.5c0d4c12d09282029f539173.5935c25fb3acc3127c3d8cd9.level.>=.4',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' },
+        value: 4,
+      }, // Was: [] (player level requirement, minPlayerLevel 30)
     ],
   },
 
@@ -1689,7 +2473,13 @@
   // 2026-08-10 - S1: now requires Peacekeeper LL4 instead of player level
   '60e71ccb5688f6424c7bfec4': {
     traderRequirements: [
-      { trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' }, value: 4 }, // Was: [] (player level requirement, minPlayerLevel 55)
+      {
+        id: 'overlay.60e71ccb5688f6424c7bfec4.5935c25fb3acc3127c3d8cd9.level.>=.4',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' },
+        value: 4,
+      }, // Was: [] (player level requirement, minPlayerLevel 55)
     ],
   },
 
@@ -1699,7 +2489,13 @@
   // 2026-08-10 - S1: now requires Peacekeeper LL4 instead of player level
   '60e71ce009d7c801eb0c0ec6': {
     traderRequirements: [
-      { trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' }, value: 4 }, // Was: [] (player level requirement, minPlayerLevel 60)
+      {
+        id: 'overlay.60e71ce009d7c801eb0c0ec6.5935c25fb3acc3127c3d8cd9.level.>=.4',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' },
+        value: 4,
+      }, // Was: [] (player level requirement, minPlayerLevel 60)
     ],
   },
 
@@ -1709,7 +2505,13 @@
   // 2026-08-10 - S1: now requires Peacekeeper LL4 instead of player level
   '5edac020218d181e29451446': {
     traderRequirements: [
-      { trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' }, value: 4 }, // Was: [] (player level requirement, minPlayerLevel 21)
+      {
+        id: '6a5cd66316983d568b203db2',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' },
+        value: 4,
+      }, // Was: [] (player level requirement, minPlayerLevel 21)
     ],
   },
 
@@ -1719,7 +2521,13 @@
   // 2026-08-10 - S1: now requires Peacekeeper LL4 instead of player level
   '5edac63b930f5454f51e128b': {
     traderRequirements: [
-      { trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' }, value: 4 }, // Was: [] (player level requirement, minPlayerLevel 23)
+      {
+        id: 'overlay.5edac63b930f5454f51e128b.5935c25fb3acc3127c3d8cd9.level.>=.4',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' },
+        value: 4,
+      }, // Was: [] (player level requirement, minPlayerLevel 23)
     ],
   },
 
@@ -1729,7 +2537,13 @@
   // 2026-08-10 - S1: now requires Peacekeeper LL4 instead of player level
   '5c0bd01e86f7747cdd799e56': {
     traderRequirements: [
-      { trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' }, value: 4 }, // Was: [] (player level requirement, minPlayerLevel 25)
+      {
+        id: 'overlay.5c0bd01e86f7747cdd799e56.5935c25fb3acc3127c3d8cd9.level.>=.4',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' },
+        value: 4,
+      }, // Was: [] (player level requirement, minPlayerLevel 25)
     ],
   },
 
@@ -1739,7 +2553,13 @@
   // 2026-08-10 - S1: now requires Peacekeeper LL4 instead of player level
   '63a9b229813bba58a50c9ee5': {
     traderRequirements: [
-      { trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' }, value: 4 }, // Was: [] (player level requirement, minPlayerLevel 25)
+      {
+        id: '6a5cd69e8fdc18585e3a8bc0',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5935c25fb3acc3127c3d8cd9', name: 'Peacekeeper' },
+        value: 4,
+      }, // Was: [] (player level requirement, minPlayerLevel 25)
     ],
   },
 
@@ -1753,7 +2573,13 @@
   // 2026-08-10 - S1: now requires Mechanic LL1 instead of player level
   '5ac3475486f7741d6224abd3': {
     traderRequirements: [
-      { trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 12)
+      {
+        id: 'overlay.5ac3475486f7741d6224abd3.5a7c2eca46aef81a7ca2145d.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 12)
     ],
   },
 
@@ -1763,7 +2589,13 @@
   // 2026-08-10 - S1: now requires Mechanic LL1 instead of player level
   '6578ec473dbd035d04531a8d': {
     traderRequirements: [
-      { trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 15)
+      {
+        id: 'overlay.6578ec473dbd035d04531a8d.5a7c2eca46aef81a7ca2145d.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 15)
     ],
   },
 
@@ -1773,7 +2605,13 @@
   // 2026-08-10 - S1: now requires Mechanic LL1 instead of player level
   '657315e4a6af4ab4b50f3459': {
     traderRequirements: [
-      { trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 1)
+      {
+        id: 'overlay.657315e4a6af4ab4b50f3459.5a7c2eca46aef81a7ca2145d.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 1)
     ],
   },
 
@@ -1785,7 +2623,13 @@
   '5ac23c6186f7741247042bad': {
     name: 'Gunsmith - MP-133', // Was: Gunsmith - Part 1
     traderRequirements: [
-      { trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 2)
+      {
+        id: 'overlay.5ac23c6186f7741247042bad.5a7c2eca46aef81a7ca2145d.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 2)
     ],
   },
 
@@ -1795,7 +2639,13 @@
   // 2026-08-10 - S1: now requires Mechanic LL1 instead of player level
   '60e71d6d7fcf9c556f325055': {
     traderRequirements: [
-      { trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 52)
+      {
+        id: 'overlay.60e71d6d7fcf9c556f325055.5a7c2eca46aef81a7ca2145d.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 52)
     ],
   },
 
@@ -1807,7 +2657,13 @@
   '5ac3462b86f7741d6118b983': {
     name: 'Farming', // Was: Farming - Part 3
     traderRequirements: [
-      { trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 14)
+      {
+        id: 'overlay.5ac3462b86f7741d6118b983.5a7c2eca46aef81a7ca2145d.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 14)
     ],
   },
 
@@ -1819,7 +2675,13 @@
   '5ac2428686f77412450b42bf': {
     name: 'Gunsmith - HK MP5', // Was: Gunsmith - Part 3
     traderRequirements: [
-      { trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 7)
+      {
+        id: 'overlay.5ac2428686f77412450b42bf.5a7c2eca46aef81a7ca2145d.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 7)
     ],
   },
 
@@ -1829,7 +2691,13 @@
   // 2026-08-10 - S1: now requires Mechanic LL1 instead of player level
   '675c1570526ff496850895d9': {
     traderRequirements: [
-      { trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 12)
+      {
+        id: 'overlay.675c1570526ff496850895d9.5a7c2eca46aef81a7ca2145d.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 12)
     ],
   },
 
@@ -1841,7 +2709,13 @@
   '5ac2426c86f774138762edfe': {
     name: 'Gunsmith - AKS-74U', // Was: Gunsmith - Part 2
     traderRequirements: [
-      { trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 5)
+      {
+        id: 'overlay.5ac2426c86f774138762edfe.5a7c2eca46aef81a7ca2145d.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 5)
     ],
   },
 
@@ -1857,7 +2731,13 @@
   '5ac345dc86f774288030817f': {
     name: 'Playing the Market', // Was: Farming - Part 1
     traderRequirements: [
-      { trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 12)
+      {
+        id: 'overlay.5ac345dc86f774288030817f.5a7c2eca46aef81a7ca2145d.level.>=.2',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 12)
     ],
   },
 
@@ -1869,7 +2749,13 @@
   '639872f9decada40426d3447': {
     name: 'Gunsmith - OP-SKS', // Was: Gunsmith - Part 4
     traderRequirements: [
-      { trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 9)
+      {
+        id: 'overlay.639872f9decada40426d3447.5a7c2eca46aef81a7ca2145d.level.>=.2',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 9)
     ],
   },
 
@@ -1879,7 +2765,13 @@
   // 2026-08-10 - S1: now requires Mechanic LL2 instead of player level
   '639136fa9444fb141f4e6eee': {
     traderRequirements: [
-      { trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 20)
+      {
+        id: '6a3cecc813ad897eca91b196',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 20)
     ],
   },
 
@@ -1891,7 +2783,13 @@
   '6573382e557ff128bf3da536': {
     name: 'The Secret to Productivity', // Was: Developer's Secrets - Part 2
     traderRequirements: [
-      { trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 25)
+      {
+        id: 'overlay.6573382e557ff128bf3da536.5a7c2eca46aef81a7ca2145d.level.>=.2',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 25)
     ],
   },
 
@@ -1903,7 +2801,13 @@
   '5ae3267986f7742a413592fe': {
     name: 'Gunsmith - Model 870', // Was: Gunsmith - Part 5
     traderRequirements: [
-      { trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 10)
+      {
+        id: 'overlay.5ae3267986f7742a413592fe.5a7c2eca46aef81a7ca2145d.level.>=.2',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 10)
     ],
   },
 
@@ -1913,7 +2817,13 @@
   // 2026-08-10 - S1: now requires Mechanic LL2 instead of player level
   '639135e8c115f907b14700aa': {
     traderRequirements: [
-      { trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 25)
+      {
+        id: 'overlay.639135e8c115f907b14700aa.5a7c2eca46aef81a7ca2145d.level.>=.2',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 25)
     ],
   },
 
@@ -1925,7 +2835,13 @@
   '65733403eefc2c312a759ddb': {
     name: 'Corporate Perks', // Was: Developer's Secrets - Part 1
     traderRequirements: [
-      { trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 25)
+      {
+        id: 'overlay.65733403eefc2c312a759ddb.5a7c2eca46aef81a7ca2145d.level.>=.2',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 25)
     ],
   },
 
@@ -1935,7 +2851,13 @@
   // 2026-08-10 - S1: now requires Mechanic LL2 instead of player level
   '5ac3477486f7741d651d6885': {
     traderRequirements: [
-      { trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 12)
+      {
+        id: 'overlay.5ac3477486f7741d651d6885.5a7c2eca46aef81a7ca2145d.level.>=.2',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 12)
     ],
   },
 
@@ -1945,7 +2867,13 @@
   // 2026-08-10 - S1: now requires Mechanic LL2 instead of player level
   '669fa39b91b0a8c9680fc467': {
     traderRequirements: [
-      { trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 12)
+      {
+        id: '6a3cedd1bcb002ca9700efbd',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 12)
     ],
   },
 
@@ -1957,7 +2885,13 @@
   '5ac3467986f7741d6224abc2': {
     name: 'Ill-Wisher', // Was: Signal - Part 1
     traderRequirements: [
-      { trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 12)
+      {
+        id: 'overlay.5ac3467986f7741d6224abc2.5a7c2eca46aef81a7ca2145d.level.>=.2',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 12)
     ],
   },
 
@@ -1967,7 +2901,13 @@
   // 2026-08-10 - S1: now requires Mechanic LL2 instead of player level
   '5f04886a3937dc337a6b8238': {
     traderRequirements: [
-      { trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 22)
+      {
+        id: 'overlay.5f04886a3937dc337a6b8238.5a7c2eca46aef81a7ca2145d.level.>=.2',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 22)
     ],
   },
 
@@ -1979,7 +2919,13 @@
   '5ac346a886f7744e1b083d67': {
     name: 'Rat Hunting', // Was: Signal - Part 2
     traderRequirements: [
-      { trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 12)
+      {
+        id: '6a3cedb67e670e5506046b67',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 12)
     ],
   },
 
@@ -1989,7 +2935,13 @@
   // 2026-08-10 - S1: now requires Mechanic LL2 instead of player level
   '66aa74571e5e199ecd094f18': {
     traderRequirements: [
-      { trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 12)
+      {
+        id: 'overlay.66aa74571e5e199ecd094f18.5a7c2eca46aef81a7ca2145d.level.>=.2',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 12)
     ],
   },
 
@@ -2005,7 +2957,13 @@
   '5ac244eb86f7741356335af1': {
     name: 'Gunsmith - M4A1', // Was: Gunsmith - Part 7
     traderRequirements: [
-      { trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 15)
+      {
+        id: '6a3cfb71dac73a85f11bab2c',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 15)
     ],
   },
 
@@ -2017,7 +2975,13 @@
   '639872fa9b4fb827b200d8e5': {
     name: 'Gunsmith - P226R', // Was: Gunsmith - Part 9
     traderRequirements: [
-      { trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 19)
+      {
+        id: 'overlay.639872fa9b4fb827b200d8e5.5a7c2eca46aef81a7ca2145d.level.>=.3',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 19)
     ],
   },
 
@@ -2029,7 +2993,13 @@
   '5ac3464c86f7741d651d6877': {
     name: 'Semiconductor Crisis', // Was: Farming - Part 4
     traderRequirements: [
-      { trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 14)
+      {
+        id: 'overlay.5ac3464c86f7741d651d6877.5a7c2eca46aef81a7ca2145d.level.>=.3',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 14)
     ],
   },
 
@@ -2039,7 +3009,13 @@
   // 2026-08-10 - S1: now requires Mechanic LL3 instead of player level
   '6179b3bdc7560e13d23eeb8d': {
     traderRequirements: [
-      { trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 17)
+      {
+        id: 'overlay.6179b3bdc7560e13d23eeb8d.5a7c2eca46aef81a7ca2145d.level.>=.3',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 17)
     ],
   },
 
@@ -2051,7 +3027,13 @@
   '5ae327c886f7745c7b3f2f3f': {
     name: 'Gunsmith - AK-105', // Was: Gunsmith - Part 10
     traderRequirements: [
-      { trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 20)
+      {
+        id: 'overlay.5ae327c886f7745c7b3f2f3f.5a7c2eca46aef81a7ca2145d.level.>=.3',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 20)
     ],
   },
 
@@ -2061,7 +3043,13 @@
   // 2026-08-10 - S1: now requires Mechanic LL3 instead of player level
   '6089732b59b92115597ad789': {
     traderRequirements: [
-      { trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 14)
+      {
+        id: '6a3cfc0e2c779659e15e5796',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 14)
     ],
   },
 
@@ -2071,7 +3059,13 @@
   // 2026-08-10 - S1: now requires Mechanic LL3 instead of player level
   '64ee9df4496db64f9b7a4432': {
     traderRequirements: [
-      { trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 15)
+      {
+        id: 'overlay.64ee9df4496db64f9b7a4432.5a7c2eca46aef81a7ca2145d.level.>=.3',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 15)
     ],
   },
 
@@ -2083,7 +3077,13 @@
   '5b47799d86f7746c5d6a5fd8': {
     name: 'Gunsmith - MPX', // Was: Gunsmith - Part 12
     traderRequirements: [
-      { trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 23)
+      {
+        id: 'overlay.5b47799d86f7746c5d6a5fd8.5a7c2eca46aef81a7ca2145d.level.>=.3',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 23)
     ],
   },
 
@@ -2093,7 +3093,13 @@
   // 2026-08-10 - S1: now requires Mechanic LL3 instead of player level
   '6179b3a12153c15e937d52bc': {
     traderRequirements: [
-      { trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 25)
+      {
+        id: 'overlay.6179b3a12153c15e937d52bc.5a7c2eca46aef81a7ca2145d.level.>=.3',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 25)
     ],
   },
 
@@ -2103,7 +3109,13 @@
   // 2026-08-10 - S1: now requires Mechanic LL3 instead of player level
   '5c139eb686f7747878361a6f': {
     traderRequirements: [
-      { trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 35)
+      {
+        id: 'overlay.5c139eb686f7747878361a6f.5a7c2eca46aef81a7ca2145d.level.>=.3',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 35)
     ],
   },
 
@@ -2115,7 +3127,13 @@
   '5ae3277186f7745973054106': {
     name: 'Gunsmith - AKS-74N', // Was: Gunsmith - Part 8
     traderRequirements: [
-      { trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 17)
+      {
+        id: 'overlay.5ae3277186f7745973054106.5a7c2eca46aef81a7ca2145d.level.>=.3',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 17)
     ],
   },
 
@@ -2127,7 +3145,13 @@
   '5ae3270f86f77445ba41d4dd': {
     name: 'Gunsmith - AKM', // Was: Gunsmith - Part 6
     traderRequirements: [
-      { trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 14)
+      {
+        id: '6a3cfb55342c8e533a22b71d',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 14)
     ],
   },
 
@@ -2139,7 +3163,13 @@
   '639872fc93ae507d5858c3a6': {
     name: 'Gunsmith - Vector 9x19', // Was: Gunsmith - Part 11
     traderRequirements: [
-      { trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 22)
+      {
+        id: 'overlay.639872fc93ae507d5858c3a6.5a7c2eca46aef81a7ca2145d.level.>=.3',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 22)
     ],
   },
 
@@ -2149,7 +3179,13 @@
   // 2026-08-10 - S1: now requires Mechanic LL3 instead of player level
   '6089736efa70fc097863b8f6': {
     traderRequirements: [
-      { trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 14)
+      {
+        id: '6a3cfbc3a685e57869a07a84',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 14)
     ],
   },
 
@@ -2161,7 +3197,13 @@
   '5ae3280386f7742a41359364': {
     name: 'Gunsmith - AS VAL', // Was: Gunsmith - Part 15
     traderRequirements: [
-      { trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 29)
+      {
+        id: 'overlay.5ae3280386f7742a41359364.5a7c2eca46aef81a7ca2145d.level.>=.3',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 29)
     ],
   },
 
@@ -2171,7 +3213,13 @@
   // 2026-08-10 - S1: now requires Mechanic LL3 instead of player level
   '5c1128e386f7746565181106': {
     traderRequirements: [
-      { trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 30)
+      {
+        id: 'overlay.5c1128e386f7746565181106.5a7c2eca46aef81a7ca2145d.level.>=.3',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 30)
     ],
   },
 
@@ -2185,7 +3233,13 @@
   // 2026-08-10 - S1: now requires Mechanic LL4 instead of player level
   '5c0be13186f7746f016734aa': {
     traderRequirements: [
-      { trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' }, value: 4 }, // Was: [] (player level requirement, minPlayerLevel 27)
+      {
+        id: '6a3d2a5d0eb870511f3cb8d7',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' },
+        value: 4,
+      }, // Was: [] (player level requirement, minPlayerLevel 27)
     ],
   },
 
@@ -2195,7 +3249,13 @@
   // 2026-08-10 - S1: now requires Mechanic LL4 instead of player level
   '60e71d23c1bfa3050473b8e6': {
     traderRequirements: [
-      { trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' }, value: 4 }, // Was: [] (player level requirement, minPlayerLevel 47)
+      {
+        id: '6a3d29bc12904a2b7bd0d847',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' },
+        value: 4,
+      }, // Was: [] (player level requirement, minPlayerLevel 47)
     ],
   },
 
@@ -2205,7 +3265,13 @@
   // 2026-08-10 - S1: now requires Mechanic LL4 instead of player level
   '6942b44f891369fc790e385a': {
     traderRequirements: [
-      { trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' }, value: 4 }, // Was: [] (player level requirement, minPlayerLevel 37)
+      {
+        id: '6a58fd4c816f85805123ec55',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' },
+        value: 4,
+      }, // Was: [] (player level requirement, minPlayerLevel 37)
     ],
   },
 
@@ -2219,7 +3285,13 @@
   '5c0bde0986f77479cf22c2f8': {
     name: 'Shooter Born in Heaven', // Was: A Shooter Born in Heaven
     traderRequirements: [
-      { trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' }, value: 4 }, // Was: [] (player level requirement, minPlayerLevel 14)
+      {
+        id: 'overlay.5c0bde0986f77479cf22c2f8.5a7c2eca46aef81a7ca2145d.level.>=.4',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' },
+        value: 4,
+      }, // Was: [] (player level requirement, minPlayerLevel 14)
     ],
     experience: 65000, // Was: 55000 (all modes, stale pre-1.1 value)
   },
@@ -2230,7 +3302,13 @@
   // 2026-08-10 - S1: now requires Mechanic LL4 instead of player level
   '68db9c7557bc51a8c804c14b': {
     traderRequirements: [
-      { trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' }, value: 4 }, // Was: [] (player level requirement, minPlayerLevel 29)
+      {
+        id: 'overlay.68db9c7557bc51a8c804c14b.5a7c2eca46aef81a7ca2145d.level.>=.4',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5a7c2eca46aef81a7ca2145d', name: 'Mechanic' },
+        value: 4,
+      }, // Was: [] (player level requirement, minPlayerLevel 29)
     ],
   },
 
@@ -2343,7 +3421,13 @@
   // 2026-08-10 - S1: now requires Ragman LL1 instead of player level
   '60e71dc0a94be721b065bbfc': {
     traderRequirements: [
-      { trader: { id: '5ac3b934156ae10c4430e83c', name: 'Ragman' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 45)
+      {
+        id: 'overlay.60e71dc0a94be721b065bbfc.5ac3b934156ae10c4430e83c.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5ac3b934156ae10c4430e83c', name: 'Ragman' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 45)
     ],
   },
 
@@ -2353,7 +3437,13 @@
   // 2026-08-10 - S1: now requires Ragman LL1 instead of player level
   '5ae448bf86f7744d733e55ee': {
     traderRequirements: [
-      { trader: { id: '5ac3b934156ae10c4430e83c', name: 'Ragman' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 15)
+      {
+        id: 'overlay.5ae448bf86f7744d733e55ee.5ac3b934156ae10c4430e83c.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5ac3b934156ae10c4430e83c', name: 'Ragman' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 15)
     ],
   },
 
@@ -2372,7 +3462,13 @@
   '5ae448f286f77448d73c0131': {
     name: 'Fuel Crisis', // Was: The Blood of War - Part 1
     traderRequirements: [
-      { trader: { id: '5ac3b934156ae10c4430e83c', name: 'Ragman' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 15)
+      {
+        id: 'overlay.5ae448f286f77448d73c0131.5ac3b934156ae10c4430e83c.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5ac3b934156ae10c4430e83c', name: 'Ragman' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 15)
     ],
     objectives: {
       '5ae452de86f77450595c4333': {
@@ -2423,7 +3519,13 @@
   '5ae4493486f7744efa289417': {
     name: 'Inventory Files', // Was: Database - Part 1
     traderRequirements: [
-      { trader: { id: '5ac3b934156ae10c4430e83c', name: 'Ragman' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 15)
+      {
+        id: 'overlay.5ae4493486f7744efa289417.5ac3b934156ae10c4430e83c.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5ac3b934156ae10c4430e83c', name: 'Ragman' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 15)
     ],
   },
 
@@ -2433,7 +3535,13 @@
   // 2026-08-10 - S1: now requires Ragman LL1 instead of player level
   '5ae449b386f77446d8741719': {
     traderRequirements: [
-      { trader: { id: '5ac3b934156ae10c4430e83c', name: 'Ragman' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 15)
+      {
+        id: 'overlay.5ae449b386f77446d8741719.5ac3b934156ae10c4430e83c.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5ac3b934156ae10c4430e83c', name: 'Ragman' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 15)
     ],
   },
 
@@ -2445,7 +3553,13 @@
   '5c10f94386f774227172c572': {
     name: 'Small Things, Big Help', // Was: The Blood of War - Part 3
     traderRequirements: [
-      { trader: { id: '5ac3b934156ae10c4430e83c', name: 'Ragman' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 30)
+      {
+        id: 'overlay.5c10f94386f774227172c572.5ac3b934156ae10c4430e83c.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5ac3b934156ae10c4430e83c', name: 'Ragman' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 30)
     ],
   },
 
@@ -2457,7 +3571,13 @@
   '5ae4493d86f7744b8e15aa8f': {
     name: 'A Big Loss', // Was: Database - Part 2
     traderRequirements: [
-      { trader: { id: '5ac3b934156ae10c4430e83c', name: 'Ragman' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 15)
+      {
+        id: 'overlay.5ae4493d86f7744b8e15aa8f.5ac3b934156ae10c4430e83c.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5ac3b934156ae10c4430e83c', name: 'Ragman' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 15)
     ],
   },
 
@@ -2467,7 +3587,13 @@
   // 2026-08-10 - S1: now requires Ragman LL1 instead of player level
   '5ae4490786f7744ca822adcc': {
     traderRequirements: [
-      { trader: { id: '5ac3b934156ae10c4430e83c', name: 'Ragman' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 15)
+      {
+        id: 'overlay.5ae4490786f7744ca822adcc.5ac3b934156ae10c4430e83c.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5ac3b934156ae10c4430e83c', name: 'Ragman' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 15)
     ],
   },
 
@@ -2481,7 +3607,13 @@
   // 2026-08-10 - S1: now requires Ragman LL2 instead of player level
   '5ae4498786f7744bde357695': {
     traderRequirements: [
-      { trader: { id: '5ac3b934156ae10c4430e83c', name: 'Ragman' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 26)
+      {
+        id: 'overlay.5ae4498786f7744bde357695.5ac3b934156ae10c4430e83c.level.>=.2',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5ac3b934156ae10c4430e83c', name: 'Ragman' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 26)
     ],
   },
 
@@ -2491,7 +3623,13 @@
   // 2026-08-10 - S1: now requires Ragman LL2 instead of player level
   '675c085d59b0575973005f52': {
     traderRequirements: [
-      { trader: { id: '5ac3b934156ae10c4430e83c', name: 'Ragman' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 15)
+      {
+        id: '6a4b5f7495d81e2fd8289af6',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5ac3b934156ae10c4430e83c', name: 'Ragman' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 15)
     ],
   },
 
@@ -2501,7 +3639,13 @@
   // 2026-08-10 - S1: now requires Ragman LL2 instead of player level
   '639135a7e705511c8a4a1b78': {
     traderRequirements: [
-      { trader: { id: '5ac3b934156ae10c4430e83c', name: 'Ragman' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 20)
+      {
+        id: 'overlay.639135a7e705511c8a4a1b78.5ac3b934156ae10c4430e83c.level.>=.2',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5ac3b934156ae10c4430e83c', name: 'Ragman' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 20)
     ],
   },
 
@@ -2511,7 +3655,13 @@
   // 2026-08-10 - S1: now requires Ragman LL2 instead of player level
   '638fcd23dc65553116701d33': {
     traderRequirements: [
-      { trader: { id: '5ac3b934156ae10c4430e83c', name: 'Ragman' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 17)
+      {
+        id: '6a4b5ee080698c997be313bf',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5ac3b934156ae10c4430e83c', name: 'Ragman' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 17)
     ],
   },
 
@@ -2521,7 +3671,13 @@
   // 2026-08-10 - S1: now requires Ragman LL2 instead of player level
   '5ae448e586f7744dcf0c2a67': {
     traderRequirements: [
-      { trader: { id: '5ac3b934156ae10c4430e83c', name: 'Ragman' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 15)
+      {
+        id: 'overlay.5ae448e586f7744dcf0c2a67.5ac3b934156ae10c4430e83c.level.>=.2',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5ac3b934156ae10c4430e83c', name: 'Ragman' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 15)
     ],
   },
 
@@ -2531,7 +3687,13 @@
   // 2026-08-10 - S1: now requires Ragman LL2 instead of player level
   '5b478d0f86f7744d190d91b5': {
     traderRequirements: [
-      { trader: { id: '5ac3b934156ae10c4430e83c', name: 'Ragman' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 24)
+      {
+        id: 'overlay.5b478d0f86f7744d190d91b5.5ac3b934156ae10c4430e83c.level.>=.2',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5ac3b934156ae10c4430e83c', name: 'Ragman' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 24)
     ],
   },
 
@@ -2541,7 +3703,13 @@
   // 2026-08-10 - S1: now requires Ragman LL2 instead of player level
   '65802b627b44fa5e14638899': {
     traderRequirements: [
-      { trader: { id: '5ac3b934156ae10c4430e83c', name: 'Ragman' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 15)
+      {
+        id: '6a4b5dd063041a7e3e50cfdc',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5ac3b934156ae10c4430e83c', name: 'Ragman' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 15)
     ],
   },
 
@@ -2566,7 +3734,13 @@
   // Verified: in-game PvE capture 2026-08-12; wiki agrees.
   '65734c186dc1e402c80dc19e': {
     traderRequirements: [
-      { trader: { id: '5ac3b934156ae10c4430e83c', name: 'Ragman' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 33)
+      {
+        id: '6a4b5e2b5c6c767b9b01063f',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5ac3b934156ae10c4430e83c', name: 'Ragman' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 33)
     ],
     experience: 10000, // Was: 11000 (all modes, stale pre-1.1 value)
   },
@@ -2577,7 +3751,13 @@
   // 2026-08-10 - S1: now requires Ragman LL2 instead of player level
   '5ae449d986f774453a54a7e1': {
     traderRequirements: [
-      { trader: { id: '5ac3b934156ae10c4430e83c', name: 'Ragman' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 40)
+      {
+        id: 'overlay.5ae449d986f774453a54a7e1.5ac3b934156ae10c4430e83c.level.>=.2',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5ac3b934156ae10c4430e83c', name: 'Ragman' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 40)
     ],
   },
 
@@ -2587,7 +3767,13 @@
   // 2026-08-10 - S1: now requires Ragman LL2 instead of player level
   '5b478b1886f7744d1b23c57d': {
     traderRequirements: [
-      { trader: { id: '5ac3b934156ae10c4430e83c', name: 'Ragman' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 29)
+      {
+        id: 'overlay.5b478b1886f7744d1b23c57d.5ac3b934156ae10c4430e83c.level.>=.2',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5ac3b934156ae10c4430e83c', name: 'Ragman' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 29)
     ],
   },
 
@@ -2603,7 +3789,13 @@
   '608974af4b05530f55550c21': {
     name: 'Reserve Expert', // Was: Inventory Check
     traderRequirements: [
-      { trader: { id: '5ac3b934156ae10c4430e83c', name: 'Ragman' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 15)
+      {
+        id: 'overlay.608974af4b05530f55550c21.5ac3b934156ae10c4430e83c.level.>=.3',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5ac3b934156ae10c4430e83c', name: 'Ragman' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 15)
     ],
   },
 
@@ -2615,7 +3807,13 @@
   '5b47891f86f7744d1b23c571': {
     name: 'Living High is Not a Crime', // Was: Living High is Not a Crime - Part 1
     traderRequirements: [
-      { trader: { id: '5ac3b934156ae10c4430e83c', name: 'Ragman' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 27)
+      {
+        id: 'overlay.5b47891f86f7744d1b23c571.5ac3b934156ae10c4430e83c.level.>=.3',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5ac3b934156ae10c4430e83c', name: 'Ragman' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 27)
     ],
   },
 
@@ -2625,7 +3823,13 @@
   // 2026-08-10 - S1: now requires Ragman LL3 instead of player level
   '639135bbc115f907b14700a6': {
     traderRequirements: [
-      { trader: { id: '5ac3b934156ae10c4430e83c', name: 'Ragman' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 25)
+      {
+        id: '6a574f0b5627edb1421f8fc6',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5ac3b934156ae10c4430e83c', name: 'Ragman' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 25)
     ],
   },
 
@@ -2635,7 +3839,13 @@
   // 2026-08-10 - S1: now requires Ragman LL3 instead of player level
   '608974d01a66564e74191fc0': {
     traderRequirements: [
-      { trader: { id: '5ac3b934156ae10c4430e83c', name: 'Ragman' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 15)
+      {
+        id: '6a57433f9ddb2c2e9c166039',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5ac3b934156ae10c4430e83c', name: 'Ragman' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 15)
     ],
   },
 
@@ -2645,7 +3855,13 @@
   // 2026-08-10 - S1: now requires Ragman LL3 instead of player level
   '60e71dc67fcf9c556f325056': {
     traderRequirements: [
-      { trader: { id: '5ac3b934156ae10c4430e83c', name: 'Ragman' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 50)
+      {
+        id: '6a5743d21a9c025cfafd7d3b',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5ac3b934156ae10c4430e83c', name: 'Ragman' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 50)
     ],
   },
 
@@ -2655,7 +3871,13 @@
   // 2026-08-10 - S1: now requires Ragman LL3 instead of player level
   '66aa61663aa37705c5024277': {
     traderRequirements: [
-      { trader: { id: '5ac3b934156ae10c4430e83c', name: 'Ragman' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 30)
+      {
+        id: '6a574f3e3bdeaece97631b3e',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5ac3b934156ae10c4430e83c', name: 'Ragman' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 30)
     ],
   },
 
@@ -2667,7 +3889,13 @@
   // Verified: in-game PvE capture 2026-08-12; wiki agrees.
   '5c112d7e86f7740d6f647486': {
     traderRequirements: [
-      { trader: { id: '5ac3b934156ae10c4430e83c', name: 'Ragman' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 29)
+      {
+        id: 'overlay.5c112d7e86f7740d6f647486.5ac3b934156ae10c4430e83c.level.>=.3',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5ac3b934156ae10c4430e83c', name: 'Ragman' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 29)
     ],
     experience: 28000, // Was: 10000 (all modes, stale pre-1.1 value)
   },
@@ -2684,7 +3912,13 @@
   '5c1141f386f77430ff393792': {
     name: 'Antique Enthusiast', // Was: Living High is Not a Crime - Part 2
     traderRequirements: [
-      { trader: { id: '5ac3b934156ae10c4430e83c', name: 'Ragman' }, value: 4 }, // Was: [] (player level requirement, minPlayerLevel 30)
+      {
+        id: '6a59e2f1fd94c70162c713c1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5ac3b934156ae10c4430e83c', name: 'Ragman' },
+        value: 4,
+      }, // Was: [] (player level requirement, minPlayerLevel 30)
     ],
   },
 
@@ -2698,7 +3932,13 @@
   // 2026-08-10 - S1: now requires Jaeger LL1 instead of player level
   '66b38c7bf85b8bf7250f9cb6': {
     traderRequirements: [
-      { trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 2)
+      {
+        id: 'overlay.66b38c7bf85b8bf7250f9cb6.5c0647fdd443bc2504c2d371.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 2)
     ],
   },
 
@@ -2708,7 +3948,13 @@
   // 2026-08-10 - S1: now requires Jaeger LL1 instead of player level
   '5d25e2c386f77443e7549029': {
     traderRequirements: [
-      { trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 2)
+      {
+        id: 'overlay.5d25e2c386f77443e7549029.5c0647fdd443bc2504c2d371.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 2)
     ],
   },
 
@@ -2718,7 +3964,13 @@
   // 2026-08-10 - S1: now requires Jaeger LL1 instead of player level
   '675c1cf4a757ddd00404f0a3': {
     traderRequirements: [
-      { trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 2)
+      {
+        id: 'overlay.675c1cf4a757ddd00404f0a3.5c0647fdd443bc2504c2d371.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 2)
     ],
   },
 
@@ -2728,7 +3980,13 @@
   // 2026-08-10 - S1: now requires Jaeger LL1 instead of player level
   '5d25e43786f7740a212217fa': {
     traderRequirements: [
-      { trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 2)
+      {
+        id: 'overlay.5d25e43786f7740a212217fa.5c0647fdd443bc2504c2d371.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 2)
     ],
   },
 
@@ -2740,7 +3998,13 @@
   '60e729cf5698ee7b05057439': {
     name: 'Swift', // Was: Swift One
     traderRequirements: [
-      { trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 50)
+      {
+        id: 'overlay.60e729cf5698ee7b05057439.5c0647fdd443bc2504c2d371.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 50)
     ],
   },
 
@@ -2750,7 +4014,13 @@
   // 2026-08-10 - S1: now requires Jaeger LL1 instead of player level
   '5d24b81486f77439c92d6ba8': {
     traderRequirements: [
-      { trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 2)
+      {
+        id: 'overlay.5d24b81486f77439c92d6ba8.5c0647fdd443bc2504c2d371.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 2)
     ],
   },
 
@@ -2762,7 +4032,13 @@
   '5d25e44386f77409453bce7b': {
     name: 'The Huntsman Path - Angry Watchman', // Was: The Huntsman Path - Evil Watchman
     traderRequirements: [
-      { trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 2)
+      {
+        id: 'overlay.5d25e44386f77409453bce7b.5c0647fdd443bc2504c2d371.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 2)
     ],
   },
 
@@ -2772,7 +4048,13 @@
   // 2026-08-10 - S1: now requires Jaeger LL1 instead of player level
   '5d25e2ee86f77443e35162ea': {
     traderRequirements: [
-      { trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' }, value: 1 }, // Was: [] (player level requirement, minPlayerLevel 13)
+      {
+        id: 'overlay.5d25e2ee86f77443e35162ea.5c0647fdd443bc2504c2d371.level.>=.1',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' },
+        value: 1,
+      }, // Was: [] (player level requirement, minPlayerLevel 13)
     ],
   },
 
@@ -2786,7 +4068,13 @@
   // 2026-08-10 - S1: now requires Jaeger LL2 instead of player level
   '64e7b971f9d6fa49d6769b44': {
     traderRequirements: [
-      { trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 17)
+      {
+        id: 'overlay.64e7b971f9d6fa49d6769b44.5c0647fdd443bc2504c2d371.level.>=.2',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 17)
     ],
   },
 
@@ -2796,7 +4084,13 @@
   // 2026-08-10 - S1: now requires Jaeger LL2 instead of player level
   '66b38e144f2ab7cc530c3fe7': {
     traderRequirements: [
-      { trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 2)
+      {
+        id: '6a43d8b1623131daaf9057a2',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 2)
     ],
   },
 
@@ -2806,7 +4100,13 @@
   // 2026-08-10 - S1: now requires Jaeger LL2 instead of player level
   '639136e84ed9512be67647db': {
     traderRequirements: [
-      { trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 10)
+      {
+        id: '6a43d7d4c16d83bc7d80c7de',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 10)
     ],
   },
 
@@ -2816,7 +4116,13 @@
   // 2026-08-10 - S1: now requires Jaeger LL2 instead of player level
   '5d25e4ad86f77443e625e387': {
     traderRequirements: [
-      { trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 28)
+      {
+        id: 'overlay.5d25e4ad86f77443e625e387.5c0647fdd443bc2504c2d371.level.>=.2',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 28)
     ],
   },
 
@@ -2826,7 +4132,13 @@
   // 2026-08-10 - S1: now requires Jaeger LL2 instead of player level
   '5d25e48186f77443e625e386': {
     traderRequirements: [
-      { trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 20)
+      {
+        id: 'overlay.5d25e48186f77443e625e386.5c0647fdd443bc2504c2d371.level.>=.2',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 20)
     ],
   },
 
@@ -2836,7 +4148,13 @@
   // 2026-08-10 - S1: now requires Jaeger LL2 instead of player level
   '6578eb36e5020875d64645cd': {
     traderRequirements: [
-      { trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 23)
+      {
+        id: 'overlay.6578eb36e5020875d64645cd.5c0647fdd443bc2504c2d371.level.>=.2',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 23)
     ],
   },
 
@@ -2846,7 +4164,13 @@
   // 2026-08-10 - S1: now requires Jaeger LL2 instead of player level
   '669fa3979b0ce3feae01a130': {
     traderRequirements: [
-      { trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 2)
+      {
+        id: 'overlay.669fa3979b0ce3feae01a130.5c0647fdd443bc2504c2d371.level.>=.2',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 2)
     ],
   },
 
@@ -2856,7 +4180,13 @@
   // 2026-08-10 - S1: now requires Jaeger LL2 instead of player level
   '63a88045abf76d719f42d715': {
     traderRequirements: [
-      { trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 5)
+      {
+        id: 'overlay.63a88045abf76d719f42d715.5c0647fdd443bc2504c2d371.level.>=.2',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 5)
     ],
   },
 
@@ -2866,7 +4196,13 @@
   // 2026-08-10 - S1: now requires Jaeger LL2 instead of player level
   '669fa3a08b4a64b332041ff7': {
     traderRequirements: [
-      { trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 15)
+      {
+        id: '6a43d84b37bd0f8cc668b0ee',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 15)
     ],
   },
 
@@ -2876,7 +4212,13 @@
   // 2026-08-10 - S1: now requires Jaeger LL2 instead of player level
   '5d25e2e286f77444001e2e48': {
     traderRequirements: [
-      { trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 30)
+      {
+        id: 'overlay.5d25e2e286f77444001e2e48.5c0647fdd443bc2504c2d371.level.>=.2',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 30)
     ],
   },
 
@@ -2886,7 +4228,13 @@
   // 2026-08-10 - S1: now requires Jaeger LL2 instead of player level
   '60c0c018f7afb4354815096a': {
     traderRequirements: [
-      { trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' }, value: 2 }, // Was: [] (player level requirement, minPlayerLevel 12)
+      {
+        id: 'overlay.60c0c018f7afb4354815096a.5c0647fdd443bc2504c2d371.level.>=.2',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' },
+        value: 2,
+      }, // Was: [] (player level requirement, minPlayerLevel 12)
     ],
   },
 
@@ -2900,7 +4248,13 @@
   // 2026-08-10 - S1: now requires Jaeger LL3 instead of player level
   '5d25e4d586f77443e625e388': {
     traderRequirements: [
-      { trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 20)
+      {
+        id: '6a451e72045194269adecd4a',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 20)
     ],
   },
 
@@ -2910,7 +4264,13 @@
   // 2026-08-10 - S1: now requires Jaeger LL3 instead of player level
   '639136df4b15ca31f76bc31f': {
     traderRequirements: [
-      { trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 23)
+      {
+        id: '6a45201bed09b5a55dcbdc4f',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 23)
     ],
   },
 
@@ -2920,7 +4280,13 @@
   // 2026-08-10 - S1: now requires Jaeger LL3 instead of player level
   '61904daa7d0d857927447b9c': {
     traderRequirements: [
-      { trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 20)
+      {
+        id: '6a451ee1e2c6f800f3df8312',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 20)
     ],
   },
 
@@ -2930,7 +4296,13 @@
   // 2026-08-10 - S1: now requires Jaeger LL3 instead of player level
   '5d25e4b786f77408251c4bfc': {
     traderRequirements: [
-      { trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 28)
+      {
+        id: '6a4520f8fcf629a7be63704c',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 28)
     ],
   },
 
@@ -2942,7 +4314,13 @@
   '5d25e45e86f77408251c4bfa': {
     name: 'The Huntsman Path - Liberation', // Was: The Huntsman Path - Eraser - Part 2
     traderRequirements: [
-      { trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 30)
+      {
+        id: 'overlay.5d25e45e86f77408251c4bfa.5c0647fdd443bc2504c2d371.level.>=.3',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 30)
     ],
   },
 
@@ -2952,7 +4330,13 @@
   // 2026-08-10 - S1: now requires Jaeger LL3 instead of player level
   '6179ad0a6e9dd54ac275e3f2': {
     traderRequirements: [
-      { trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 22)
+      {
+        id: 'overlay.6179ad0a6e9dd54ac275e3f2.5c0647fdd443bc2504c2d371.level.>=.3',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 22)
     ],
   },
 
@@ -2962,7 +4346,13 @@
   // 2026-08-10 - S1: now requires Jaeger LL3 instead of player level
   '5d25e2cc86f77443e47ae019': {
     traderRequirements: [
-      { trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 2)
+      {
+        id: 'overlay.5d25e2cc86f77443e47ae019.5c0647fdd443bc2504c2d371.level.>=.3',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 2)
     ],
   },
 
@@ -2973,7 +4363,13 @@
   // Recent wiki update (post-1.0)
   '66ab9da7eb102b9bcd08591c': {
     traderRequirements: [
-      { trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 28)
+      {
+        id: 'overlay.66ab9da7eb102b9bcd08591c.5c0647fdd443bc2504c2d371.level.>=.3',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 28)
     ],
     objectives: {
       '66ab9da7eb102b9bcd08591d': {
@@ -2993,7 +4389,13 @@
   // 2026-08-10 - S1: now requires Jaeger LL3 instead of player level
   '5d25e2b486f77409de05bba0': {
     traderRequirements: [
-      { trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 2)
+      {
+        id: 'overlay.5d25e2b486f77409de05bba0.5c0647fdd443bc2504c2d371.level.>=.3',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 2)
     ],
   },
 
@@ -3003,7 +4405,13 @@
   // 2026-08-10 - S1: now requires Jaeger LL3 instead of player level
   '608a768d82e40b3c727fd17d': {
     traderRequirements: [
-      { trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 20)
+      {
+        id: 'overlay.608a768d82e40b3c727fd17d.5c0647fdd443bc2504c2d371.level.>=.3',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 20)
     ],
   },
 
@@ -3015,7 +4423,13 @@
   '5d25e44f86f77443e625e385': {
     name: 'The Huntsman Path - Eraser', // Was: The Huntsman Path - Eraser - Part 1
     traderRequirements: [
-      { trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' }, value: 3 }, // Was: [] (player level requirement, minPlayerLevel 20)
+      {
+        id: 'overlay.5d25e44f86f77443e625e385.5c0647fdd443bc2504c2d371.level.>=.3',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' },
+        value: 3,
+      }, // Was: [] (player level requirement, minPlayerLevel 20)
     ],
   },
 
@@ -3029,7 +4443,13 @@
   // 2026-08-10 - S1: now requires Jaeger LL4 instead of player level
   '5edab4b1218d181e29451435': {
     traderRequirements: [
-      { trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' }, value: 4 }, // Was: [] (player level requirement, minPlayerLevel 22)
+      {
+        id: 'overlay.5edab4b1218d181e29451435.5c0647fdd443bc2504c2d371.level.>=.4',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' },
+        value: 4,
+      }, // Was: [] (player level requirement, minPlayerLevel 22)
     ],
   },
 
@@ -3039,7 +4459,13 @@
   // 2026-08-10 - S1: now requires Jaeger LL4 instead of player level
   '63a9b36cc31b00242d28a99f': {
     traderRequirements: [
-      { trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' }, value: 4 }, // Was: [] (player level requirement, minPlayerLevel 40)
+      {
+        id: '6a453365b45317316addf45c',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' },
+        value: 4,
+      }, // Was: [] (player level requirement, minPlayerLevel 40)
     ],
   },
 
@@ -3049,7 +4475,13 @@
   // 2026-08-10 - S1: now requires Jaeger LL4 instead of player level
   '60e71e8ed54b755a3b53eb67': {
     traderRequirements: [
-      { trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' }, value: 4 }, // Was: [] (player level requirement, minPlayerLevel 55)
+      {
+        id: 'overlay.60e71e8ed54b755a3b53eb67.5c0647fdd443bc2504c2d371.level.>=.4',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' },
+        value: 4,
+      }, // Was: [] (player level requirement, minPlayerLevel 55)
     ],
   },
 
@@ -3059,7 +4491,13 @@
   // 2026-08-10 - S1: now requires Jaeger LL4 instead of player level
   '626bdcc3a371ee3a7a3514c5': {
     traderRequirements: [
-      { trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' }, value: 4 }, // Was: [] (player level requirement, minPlayerLevel 35)
+      {
+        id: '6a45324e58fc74327b5d0867',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' },
+        value: 4,
+      }, // Was: [] (player level requirement, minPlayerLevel 35)
     ],
   },
 
@@ -3069,7 +4507,13 @@
   // 2026-08-10 - S1: now requires Jaeger LL4 instead of player level
   '5d25e2d886f77442734d335e': {
     traderRequirements: [
-      { trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' }, value: 4 }, // Was: [] (player level requirement, minPlayerLevel 2)
+      {
+        id: '6a71c5b3fdd890dfd2f2c34d',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' },
+        value: 4,
+      }, // Was: [] (player level requirement, minPlayerLevel 2)
     ],
   },
 
@@ -3079,7 +4523,13 @@
   // 2026-08-10 - S1: now requires Jaeger LL4 instead of player level
   '5d25e4ca86f77409dd5cdf2c': {
     traderRequirements: [
-      { trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' }, value: 4 }, // Was: [] (player level requirement, minPlayerLevel 33)
+      {
+        id: 'overlay.5d25e4ca86f77409dd5cdf2c.5c0647fdd443bc2504c2d371.level.>=.4',
+        requirementType: 'level',
+        compareMethod: '>=',
+        trader: { id: '5c0647fdd443bc2504c2d371', name: 'Jaeger' },
+        value: 4,
+      }, // Was: [] (player level requirement, minPlayerLevel 33)
     ],
   },
 

--- a/src/schemas/task-additions.schema.json
+++ b/src/schemas/task-additions.schema.json
@@ -852,64 +852,7 @@
       "traderRequirements": {
         "description": "Trader requirements to start the task (loyalty level or reputation)",
         "items": {
-          "allOf": [
-            {
-              "if": {
-                "properties": {
-                  "requirementType": {
-                    "const": "level"
-                  }
-                },
-                "required": ["requirementType"]
-              },
-              "then": {
-                "properties": {
-                  "value": {
-                    "description": "Loyalty Level (LL1-LL4)",
-                    "maximum": 4,
-                    "minimum": 0,
-                    "type": "integer"
-                  }
-                }
-              }
-            }
-          ],
-          "properties": {
-            "id": {
-              "description": "Merge identity: an upstream requirement id ('<24-hex>' or the composite '<24-hex taskId>-<24-hex traderId>'), or a stable synthetic id 'overlay.<taskId>.<traderId>.<type>.<method>.<value>' for overlay-authored requirements",
-              "pattern": "^(?:[0-9a-f]{24}(?:-[0-9a-f]{24})?|overlay\\.[0-9a-f]{24}\\.[0-9a-f]{24}\\.(?:level|reputation)\\.(?:>=|<=|>|<|=)\\.-?[0-9]+(?:\\.[0-9]+)?)$",
-              "type": "string"
-            },
-            "requirementType": {
-              "description": "Semantic of the requirement: 'level' (Loyalty Level) or 'reputation' (trader rep / scav karma)",
-              "enum": ["level", "reputation"],
-              "type": "string"
-            },
-            "compareMethod": {
-              "description": "Comparison method for the requirement",
-              "enum": [">=", "<=", ">", "<", "="],
-              "type": "string"
-            },
-            "value": {
-              "description": "Threshold value: integer 0-4 for 'level'; any number (including negative) for 'reputation'",
-              "type": "number"
-            },
-            "trader": {
-              "additionalProperties": false,
-              "properties": {
-                "id": {
-                  "type": "string"
-                },
-                "name": {
-                  "type": "string"
-                }
-              },
-              "required": ["id", "name"],
-              "type": "object"
-            }
-          },
-          "required": ["id", "requirementType", "compareMethod", "value", "trader"],
-          "type": "object"
+          "$ref": "trader-requirement.schema.json"
         },
         "type": "array"
       },

--- a/src/schemas/task-additions.schema.json
+++ b/src/schemas/task-additions.schema.json
@@ -876,7 +876,8 @@
           ],
           "properties": {
             "id": {
-              "description": "Upstream requirement id, or a stable 'overlay.'-prefixed synthetic id for overlay-authored requirements",
+              "description": "Merge identity: an upstream requirement id ('<24-hex>' or the composite '<24-hex taskId>-<24-hex traderId>'), or a stable synthetic id 'overlay.<taskId>.<traderId>.<type>.<method>.<value>' for overlay-authored requirements",
+              "pattern": "^(?:[0-9a-f]{24}(?:-[0-9a-f]{24})?|overlay\\.[0-9a-f]{24}\\.[0-9a-f]{24}\\.(?:level|reputation)\\.(?:>=|<=|>|<|=)\\.-?[0-9]+(?:\\.[0-9]+)?)$",
               "type": "string"
             },
             "requirementType": {

--- a/src/schemas/task-additions.schema.json
+++ b/src/schemas/task-additions.schema.json
@@ -850,10 +850,51 @@
         "type": "array"
       },
       "traderRequirements": {
-        "description": "Trader loyalty requirements to start the task",
+        "description": "Trader requirements to start the task (loyalty level or reputation)",
         "items": {
+          "allOf": [
+            {
+              "if": {
+                "properties": {
+                  "requirementType": {
+                    "const": "level"
+                  }
+                },
+                "required": ["requirementType"]
+              },
+              "then": {
+                "properties": {
+                  "value": {
+                    "description": "Loyalty Level (LL1-LL4)",
+                    "maximum": 4,
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          ],
           "properties": {
+            "id": {
+              "description": "Upstream requirement id, or a stable 'overlay.'-prefixed synthetic id for overlay-authored requirements",
+              "type": "string"
+            },
+            "requirementType": {
+              "description": "Semantic of the requirement: 'level' (Loyalty Level) or 'reputation' (trader rep / scav karma)",
+              "enum": ["level", "reputation"],
+              "type": "string"
+            },
+            "compareMethod": {
+              "description": "Comparison method for the requirement",
+              "enum": [">=", "<=", ">", "<", "="],
+              "type": "string"
+            },
+            "value": {
+              "description": "Threshold value: integer 0-4 for 'level'; any number (including negative) for 'reputation'",
+              "type": "number"
+            },
             "trader": {
+              "additionalProperties": false,
               "properties": {
                 "id": {
                   "type": "string"
@@ -864,19 +905,9 @@
               },
               "required": ["id", "name"],
               "type": "object"
-            },
-            "value": {
-              "description": "Required trader level/loyalty",
-              "maximum": 4,
-              "minimum": 0,
-              "type": "integer"
-            },
-            "compareMethod": {
-              "description": "Comparison method for the requirement (e.g., '>=')",
-              "type": "string"
             }
           },
-          "required": ["trader", "value"],
+          "required": ["id", "requirementType", "compareMethod", "value", "trader"],
           "type": "object"
         },
         "type": "array"

--- a/src/schemas/task-override.schema.json
+++ b/src/schemas/task-override.schema.json
@@ -1184,7 +1184,8 @@
           ],
           "properties": {
             "id": {
-              "description": "Upstream requirement id, or a stable 'overlay.'-prefixed synthetic id for overlay-authored requirements",
+              "description": "Merge identity: an upstream requirement id ('<24-hex>' or the composite '<24-hex taskId>-<24-hex traderId>'), or a stable synthetic id 'overlay.<taskId>.<traderId>.<type>.<method>.<value>' for overlay-authored requirements",
+              "pattern": "^(?:[0-9a-f]{24}(?:-[0-9a-f]{24})?|overlay\\.[0-9a-f]{24}\\.[0-9a-f]{24}\\.(?:level|reputation)\\.(?:>=|<=|>|<|=)\\.-?[0-9]+(?:\\.[0-9]+)?)$",
               "type": "string"
             },
             "requirementType": {

--- a/src/schemas/task-override.schema.json
+++ b/src/schemas/task-override.schema.json
@@ -1158,10 +1158,51 @@
         "type": "array"
       },
       "traderRequirements": {
-        "description": "Trader loyalty requirements to start the task",
+        "description": "Trader requirements to start the task (loyalty level or reputation)",
         "items": {
+          "allOf": [
+            {
+              "if": {
+                "properties": {
+                  "requirementType": {
+                    "const": "level"
+                  }
+                },
+                "required": ["requirementType"]
+              },
+              "then": {
+                "properties": {
+                  "value": {
+                    "description": "Loyalty Level (LL1-LL4)",
+                    "maximum": 4,
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          ],
           "properties": {
+            "id": {
+              "description": "Upstream requirement id, or a stable 'overlay.'-prefixed synthetic id for overlay-authored requirements",
+              "type": "string"
+            },
+            "requirementType": {
+              "description": "Semantic of the requirement: 'level' (Loyalty Level) or 'reputation' (trader rep / scav karma)",
+              "enum": ["level", "reputation"],
+              "type": "string"
+            },
+            "compareMethod": {
+              "description": "Comparison method for the requirement",
+              "enum": [">=", "<=", ">", "<", "="],
+              "type": "string"
+            },
+            "value": {
+              "description": "Threshold value: integer 0-4 for 'level'; any number (including negative) for 'reputation'",
+              "type": "number"
+            },
             "trader": {
+              "additionalProperties": false,
               "properties": {
                 "id": {
                   "type": "string"
@@ -1172,19 +1213,9 @@
               },
               "required": ["id", "name"],
               "type": "object"
-            },
-            "value": {
-              "description": "Required trader level/loyalty",
-              "maximum": 4,
-              "minimum": 0,
-              "type": "integer"
-            },
-            "compareMethod": {
-              "description": "Comparison method for the requirement (e.g., '>=')",
-              "type": "string"
             }
           },
-          "required": ["trader", "value"],
+          "required": ["id", "requirementType", "compareMethod", "value", "trader"],
           "type": "object"
         },
         "type": "array"

--- a/src/schemas/task-override.schema.json
+++ b/src/schemas/task-override.schema.json
@@ -1160,64 +1160,7 @@
       "traderRequirements": {
         "description": "Trader requirements to start the task (loyalty level or reputation)",
         "items": {
-          "allOf": [
-            {
-              "if": {
-                "properties": {
-                  "requirementType": {
-                    "const": "level"
-                  }
-                },
-                "required": ["requirementType"]
-              },
-              "then": {
-                "properties": {
-                  "value": {
-                    "description": "Loyalty Level (LL1-LL4)",
-                    "maximum": 4,
-                    "minimum": 0,
-                    "type": "integer"
-                  }
-                }
-              }
-            }
-          ],
-          "properties": {
-            "id": {
-              "description": "Merge identity: an upstream requirement id ('<24-hex>' or the composite '<24-hex taskId>-<24-hex traderId>'), or a stable synthetic id 'overlay.<taskId>.<traderId>.<type>.<method>.<value>' for overlay-authored requirements",
-              "pattern": "^(?:[0-9a-f]{24}(?:-[0-9a-f]{24})?|overlay\\.[0-9a-f]{24}\\.[0-9a-f]{24}\\.(?:level|reputation)\\.(?:>=|<=|>|<|=)\\.-?[0-9]+(?:\\.[0-9]+)?)$",
-              "type": "string"
-            },
-            "requirementType": {
-              "description": "Semantic of the requirement: 'level' (Loyalty Level) or 'reputation' (trader rep / scav karma)",
-              "enum": ["level", "reputation"],
-              "type": "string"
-            },
-            "compareMethod": {
-              "description": "Comparison method for the requirement",
-              "enum": [">=", "<=", ">", "<", "="],
-              "type": "string"
-            },
-            "value": {
-              "description": "Threshold value: integer 0-4 for 'level'; any number (including negative) for 'reputation'",
-              "type": "number"
-            },
-            "trader": {
-              "additionalProperties": false,
-              "properties": {
-                "id": {
-                  "type": "string"
-                },
-                "name": {
-                  "type": "string"
-                }
-              },
-              "required": ["id", "name"],
-              "type": "object"
-            }
-          },
-          "required": ["id", "requirementType", "compareMethod", "value", "trader"],
-          "type": "object"
+          "$ref": "trader-requirement.schema.json"
         },
         "type": "array"
       },

--- a/src/schemas/trader-requirement.schema.json
+++ b/src/schemas/trader-requirement.schema.json
@@ -1,0 +1,62 @@
+{
+  "$id": "trader-requirement.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "requirementType": {
+            "const": "level"
+          }
+        },
+        "required": ["requirementType"]
+      },
+      "then": {
+        "properties": {
+          "value": {
+            "description": "Loyalty Level (LL1-LL4)",
+            "maximum": 4,
+            "minimum": 1,
+            "type": "integer"
+          }
+        }
+      }
+    }
+  ],
+  "properties": {
+    "id": {
+      "description": "Merge identity: an upstream requirement id ('<24-hex>' or the composite '<24-hex taskId>-<24-hex traderId>'), or a stable synthetic id 'overlay.<taskId>.<traderId>.<type>.<method>.<value>' for overlay-authored requirements",
+      "pattern": "^(?:[0-9a-f]{24}(?:-[0-9a-f]{24})?|overlay\\.[0-9a-f]{24}\\.[0-9a-f]{24}\\.(?:level|reputation)\\.(?:>=|<=|>|<|=)\\.-?[0-9]+(?:\\.[0-9]+)?)$",
+      "type": "string"
+    },
+    "requirementType": {
+      "description": "Semantic of the requirement: 'level' (Loyalty Level) or 'reputation' (trader rep / scav karma)",
+      "enum": ["level", "reputation"],
+      "type": "string"
+    },
+    "compareMethod": {
+      "description": "Comparison method for the requirement",
+      "enum": [">=", "<=", ">", "<", "="],
+      "type": "string"
+    },
+    "value": {
+      "description": "Threshold value: integer 1-4 for 'level'; any number (including negative) for 'reputation'",
+      "type": "number"
+    },
+    "trader": {
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": ["id", "name"],
+      "type": "object"
+    }
+  },
+  "required": ["id", "requirementType", "compareMethod", "value", "trader"],
+  "type": "object"
+}

--- a/src/schemas/trader-requirement.schema.json
+++ b/src/schemas/trader-requirement.schema.json
@@ -13,6 +13,9 @@
       },
       "then": {
         "properties": {
+          "compareMethod": {
+            "const": ">="
+          },
           "value": {
             "description": "Loyalty Level (LL1-LL4)",
             "maximum": 4,
@@ -25,8 +28,8 @@
   ],
   "properties": {
     "id": {
-      "description": "Merge identity: an upstream requirement id ('<24-hex>' or the composite '<24-hex taskId>-<24-hex traderId>'), or a stable synthetic id 'overlay.<taskId>.<traderId>.<type>.<method>.<value>' for overlay-authored requirements",
-      "pattern": "^(?:[0-9a-f]{24}(?:-[0-9a-f]{24})?|overlay\\.[0-9a-f]{24}\\.[0-9a-f]{24}\\.(?:level\\.(?:>=|<=|>|<|=)\\.[1-4]|reputation\\.(?:>=|<=|>|<|=)\\.-?[0-9]+(?:\\.[0-9]+)?))$",
+      "description": "Merge identity: an upstream requirement id ('<24-hex>' or the composite '<24-hex taskId>-<24-hex traderId>'), or a stable synthetic id 'overlay.<taskId>.<traderId>.<type>.<method>.<value>[.occurrence.<n>]' used for requirements without an upstream id",
+      "pattern": "^(?:[0-9a-f]{24}(?:-[0-9a-f]{24})?|overlay\\.[0-9a-f]{24}\\.[0-9a-f]{24}\\.(?:level\\.>=\\.[1-4]|reputation\\.(?:>=|<=|>|<|=)\\.-?[0-9]+(?:\\.[0-9]+)?(?:[eE][+-]?[0-9]+)?)(?:\\.occurrence\\.(?:[2-9]|[1-9][0-9]+))?)$",
       "type": "string"
     },
     "requirementType": {

--- a/src/schemas/trader-requirement.schema.json
+++ b/src/schemas/trader-requirement.schema.json
@@ -26,7 +26,7 @@
   "properties": {
     "id": {
       "description": "Merge identity: an upstream requirement id ('<24-hex>' or the composite '<24-hex taskId>-<24-hex traderId>'), or a stable synthetic id 'overlay.<taskId>.<traderId>.<type>.<method>.<value>' for overlay-authored requirements",
-      "pattern": "^(?:[0-9a-f]{24}(?:-[0-9a-f]{24})?|overlay\\.[0-9a-f]{24}\\.[0-9a-f]{24}\\.(?:level|reputation)\\.(?:>=|<=|>|<|=)\\.-?[0-9]+(?:\\.[0-9]+)?)$",
+      "pattern": "^(?:[0-9a-f]{24}(?:-[0-9a-f]{24})?|overlay\\.[0-9a-f]{24}\\.[0-9a-f]{24}\\.(?:level\\.(?:>=|<=|>|<|=)\\.[1-4]|reputation\\.(?:>=|<=|>|<|=)\\.-?[0-9]+(?:\\.[0-9]+)?))$",
       "type": "string"
     },
     "requirementType": {

--- a/tests/check-overrides.test.ts
+++ b/tests/check-overrides.test.ts
@@ -7,6 +7,7 @@ import {
   normalizeWikiLink,
   checkTaskAdditions,
   checkEditionTaskReferences,
+  countRequirementTypes,
 } from '../scripts/check-overrides.js';
 import type { TaskAddition, TaskData } from '../src/lib/index.js';
 
@@ -29,6 +30,50 @@ function createApiTask(overrides: Partial<TaskData> = {}): TaskData {
     ...overrides,
   };
 }
+
+describe('countRequirementTypes', () => {
+  it('counts level and reputation requirements separately', () => {
+    const tasks: TaskData[] = [
+      createApiTask({
+        id: 't1',
+        traderRequirements: [
+          {
+            id: 'r1',
+            requirementType: 'level',
+            compareMethod: '>=',
+            value: 2,
+            trader: { id: 'prapor', name: 'Prapor' },
+          },
+          {
+            id: 'r2',
+            requirementType: 'reputation',
+            compareMethod: '>=',
+            value: 1,
+            trader: { id: 'fence', name: 'Fence' },
+          },
+        ],
+      }),
+      createApiTask({
+        id: 't2',
+        traderRequirements: [
+          {
+            id: 'r3',
+            requirementType: 'reputation',
+            compareMethod: '<',
+            value: -1,
+            trader: { id: 'fence', name: 'Fence' },
+          },
+        ],
+      }),
+    ];
+
+    expect(countRequirementTypes(tasks)).toEqual({ level: 1, reputation: 2 });
+  });
+
+  it('returns zeros for tasks without trader requirements', () => {
+    expect(countRequirementTypes([createApiTask()])).toEqual({ level: 0, reputation: 0 });
+  });
+});
 
 describe('normalizeWikiLink', () => {
   it('normalizes scheme, host, query, fragment, and trailing slashes', () => {

--- a/tests/overlay-schema.test.ts
+++ b/tests/overlay-schema.test.ts
@@ -100,6 +100,7 @@ describe('overlay.schema.json', () => {
       'prestige-override.schema.json',
       'task-override.schema.json',
       'task-additions.schema.json',
+      'trader-requirement.schema.json',
       'story-chapter.schema.json',
       'locale-override.schema.json',
       'seasonal-perk.schema.json',

--- a/tests/tarkov-api.test.ts
+++ b/tests/tarkov-api.test.ts
@@ -301,6 +301,18 @@ describe('tarkov-api (json.tarkov.dev adapter)', () => {
                     value: 1,
                     trader: '579dc571d53a0658a154fbec',
                   },
+                  {
+                    requirementType: 'level',
+                    compareMethod: '>=',
+                    value: 2,
+                    trader: '54cb50c76803fa8b248b4571',
+                  },
+                  {
+                    requirementType: 'level',
+                    compareMethod: '>=',
+                    value: 2,
+                    trader: '54cb50c76803fa8b248b4571',
+                  },
                 ],
               },
             },
@@ -328,6 +340,8 @@ describe('tarkov-api (json.tarkov.dev adapter)', () => {
     expect(task.traderRequirements?.map((requirement) => requirement.id)).toEqual([
       'overlay.657315e1dccd301f1301416a.54cb50c76803fa8b248b4571.level.>=.2',
       'overlay.657315e1dccd301f1301416a.579dc571d53a0658a154fbec.reputation.>=.1',
+      'overlay.657315e1dccd301f1301416a.54cb50c76803fa8b248b4571.level.>=.2.occurrence.2',
+      'overlay.657315e1dccd301f1301416a.54cb50c76803fa8b248b4571.level.>=.2.occurrence.3',
     ]);
   });
 

--- a/tests/tarkov-api.test.ts
+++ b/tests/tarkov-api.test.ts
@@ -279,6 +279,58 @@ describe('tarkov-api (json.tarkov.dev adapter)', () => {
     });
   });
 
+  it('generates stable, distinct ids for id-less trader requirements', async () => {
+    mockEndpoints(
+      baseRoutes('regular', {
+        'regular/tasks': {
+          data: {
+            tasks: {
+              '657315e1dccd301f1301416a': {
+                id: '657315e1dccd301f1301416a',
+                name: 'task name',
+                traderRequirements: [
+                  {
+                    requirementType: 'level',
+                    compareMethod: '>=',
+                    value: 2,
+                    trader: '54cb50c76803fa8b248b4571',
+                  },
+                  {
+                    requirementType: 'reputation',
+                    compareMethod: '>=',
+                    value: 1,
+                    trader: '579dc571d53a0658a154fbec',
+                  },
+                ],
+              },
+            },
+          },
+        },
+        'regular/tasks_en': { data: { 'task name': 'Task' } },
+        'regular/traders': {
+          data: {
+            '54cb50c76803fa8b248b4571': {
+              id: '54cb50c76803fa8b248b4571',
+              name: 'prapor name',
+            },
+            '579dc571d53a0658a154fbec': {
+              id: '579dc571d53a0658a154fbec',
+              name: 'fence name',
+            },
+          },
+        },
+        'regular/traders_en': { data: { 'prapor name': 'Prapor', 'fence name': 'Fence' } },
+      })
+    );
+
+    const [task] = await fetchTasks();
+
+    expect(task.traderRequirements?.map((requirement) => requirement.id)).toEqual([
+      'overlay.657315e1dccd301f1301416a.54cb50c76803fa8b248b4571.level.>=.2',
+      'overlay.657315e1dccd301f1301416a.579dc571d53a0658a154fbec.reputation.>=.1',
+    ]);
+  });
+
   it('resolves requiredPrestige from the prestige array', async () => {
     mockEndpoints(
       baseRoutes('regular', {

--- a/tests/tarkov-api.test.ts
+++ b/tests/tarkov-api.test.ts
@@ -234,7 +234,15 @@ describe('tarkov-api (json.tarkov.dev adapter)', () => {
               t1: {
                 id: 't1',
                 name: 't1 name',
-                traderRequirements: [{ trader: 'tr1', value: 2, compareMethod: '>=' }],
+                traderRequirements: [
+                  {
+                    id: 'req-1',
+                    requirementType: 'level',
+                    compareMethod: '>=',
+                    value: 2,
+                    trader: 'tr1',
+                  },
+                ],
                 finishRewards: {
                   traderStanding: [{ trader: 'tr1', standing: 0.05 }],
                   items: [{ item: 'i1', count: 3 }],
@@ -256,7 +264,13 @@ describe('tarkov-api (json.tarkov.dev adapter)', () => {
     const tasks = await fetchTasks();
     const task = tasks[0];
 
-    expect(task.traderRequirements?.[0].trader).toEqual({ id: 'tr1', name: 'Prapor' });
+    expect(task.traderRequirements?.[0]).toEqual({
+      id: 'req-1',
+      requirementType: 'level',
+      compareMethod: '>=',
+      value: 2,
+      trader: { id: 'tr1', name: 'Prapor' },
+    });
     expect(task.finishRewards?.traderStanding?.[0].trader).toEqual({ id: 'tr1', name: 'Prapor' });
     expect(task.finishRewards?.items?.[0].item).toEqual({
       id: 'i1',

--- a/tests/task-validator.test.ts
+++ b/tests/task-validator.test.ts
@@ -662,6 +662,43 @@ describe('validateTaskOverride', () => {
       ).toBe(true);
     });
 
+    it('returns NEEDED when a matching override omits an API requirement', () => {
+      const apiTask = createApiTask({
+        traderRequirements: [
+          {
+            id: '6a5672392ee61bd094c49e28',
+            requirementType: 'level',
+            compareMethod: '>=',
+            value: 2,
+            trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+          },
+          {
+            id: '66dace4d03b34844877a50fc',
+            requirementType: 'reputation',
+            compareMethod: '>=',
+            value: 1,
+            trader: { id: '579dc571d53a0658a154fbec', name: 'Fence' },
+          },
+        ],
+      });
+      const override: TaskOverride = {
+        traderRequirements: [
+          {
+            id: '6a5672392ee61bd094c49e28',
+            requirementType: 'level',
+            compareMethod: '>=',
+            value: 2,
+            trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+          },
+        ],
+      };
+      const result = validateTaskOverride('test-task-id', override, [apiTask]);
+      const detail = result.details.find((d) => d.field === 'traderRequirements');
+
+      expect(detail?.status).toBe('needed');
+      expect(detail?.message).toContain('override omits 1 API requirement(s)');
+    });
+
     it('returns NEEDED when an empty override clears non-empty API requirements', () => {
       const apiTask = createApiTask({
         traderRequirements: [

--- a/tests/task-validator.test.ts
+++ b/tests/task-validator.test.ts
@@ -696,7 +696,9 @@ describe('validateTaskOverride', () => {
       const detail = result.details.find((d) => d.field === 'traderRequirements');
 
       expect(detail?.status).toBe('needed');
-      expect(detail?.message).toContain('override omits 1 API requirement(s)');
+      expect(detail?.message).toContain(
+        'override omits 1 API requirement(s) (Fence reputation >= 1)'
+      );
     });
 
     it('returns NEEDED when an empty override clears non-empty API requirements', () => {

--- a/tests/task-validator.test.ts
+++ b/tests/task-validator.test.ts
@@ -682,6 +682,43 @@ describe('validateTaskOverride', () => {
       ).toBe(true);
     });
 
+    // Upstream currently ships an id on every trader requirement (361/361 across
+    // regular, pve and pvp-season). Should it ever omit one, the override is
+    // still redundant by value: its own id (synthetic or stale upstream) cannot
+    // address an id-less upstream entry, so patch-by-id would append a duplicate
+    // requirement rather than correct anything. FIXED (i.e. "remove it") is the
+    // correct guidance; flipping to NEEDED would ask maintainers to keep an
+    // override that duplicates the requirement for consumers.
+    it('returns FIXED when the API requirement omits its id but matches semantically', () => {
+      const apiTask = createApiTask({
+        traderRequirements: [
+          {
+            id: '',
+            requirementType: 'level',
+            compareMethod: '>=',
+            value: 2,
+            trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+          },
+        ],
+      });
+      const override: TaskOverride = {
+        traderRequirements: [
+          {
+            id: 'overlay.657315e1dccd301f1301416a.54cb50c76803fa8b248b4571.level.>=.2',
+            requirementType: 'level',
+            compareMethod: '>=',
+            value: 2,
+            trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+          },
+        ],
+      };
+      const result = validateTaskOverride('test-task-id', override, [apiTask]);
+
+      expect(
+        result.details.some((d) => d.field === 'traderRequirements' && d.status === 'fixed')
+      ).toBe(true);
+    });
+
     it('returns no detail when both API and override requirements are empty', () => {
       const apiTask = createApiTask({ traderRequirements: [] });
       const override: TaskOverride = { traderRequirements: [] };

--- a/tests/task-validator.test.ts
+++ b/tests/task-validator.test.ts
@@ -572,21 +572,26 @@ describe('validateTaskOverride', () => {
   });
 
   describe('traderRequirements validation', () => {
-    it('returns FIXED when traderRequirements matches API', () => {
+    it('returns FIXED when traderRequirements matches API semantically', () => {
       const apiTask = createApiTask({
         traderRequirements: [
           {
-            trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
-            value: 2,
+            id: '6a5672392ee61bd094c49e28',
+            requirementType: 'level',
             compareMethod: '>=',
+            value: 2,
+            trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
           },
         ],
       });
       const override: TaskOverride = {
         traderRequirements: [
           {
-            trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+            id: 'overlay.abc.54cb50c76803fa8b248b4571.level.>=.2',
+            requirementType: 'level',
+            compareMethod: '>=',
             value: 2,
+            trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
           },
         ],
       };
@@ -597,21 +602,26 @@ describe('validateTaskOverride', () => {
       ).toBe(true);
     });
 
-    it('returns NEEDED when traderRequirements differs from API', () => {
+    it('returns NEEDED when requirementType differs despite matching trader+value (Fence LL1 vs rep >= 1)', () => {
       const apiTask = createApiTask({
         traderRequirements: [
           {
-            trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
-            value: 2,
+            id: '66dace4d03b34844877a50fc',
+            requirementType: 'reputation',
             compareMethod: '>=',
+            value: 1,
+            trader: { id: '579dc571d53a0658a154fbec', name: 'Fence' },
           },
         ],
       });
       const override: TaskOverride = {
         traderRequirements: [
           {
-            trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
-            value: 3,
+            id: 'overlay.abc.579dc571d53a0658a154fbec.level.>=.1',
+            requirementType: 'level',
+            compareMethod: '>=',
+            value: 1,
+            trader: { id: '579dc571d53a0658a154fbec', name: 'Fence' },
           },
         ],
       };
@@ -620,6 +630,64 @@ describe('validateTaskOverride', () => {
       expect(
         result.details.some((d) => d.field === 'traderRequirements' && d.status === 'needed')
       ).toBe(true);
+    });
+
+    it('returns NEEDED when the value differs from API', () => {
+      const apiTask = createApiTask({
+        traderRequirements: [
+          {
+            id: '6a70899e66497c811decb758',
+            requirementType: 'level',
+            compareMethod: '>=',
+            value: 3,
+            trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+          },
+        ],
+      });
+      const override: TaskOverride = {
+        traderRequirements: [
+          {
+            id: '6a70899e66497c811decb758',
+            requirementType: 'level',
+            compareMethod: '>=',
+            value: 4,
+            trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+          },
+        ],
+      };
+      const result = validateTaskOverride('test-task-id', override, [apiTask]);
+
+      expect(
+        result.details.some((d) => d.field === 'traderRequirements' && d.status === 'needed')
+      ).toBe(true);
+    });
+
+    it('returns NEEDED when an empty override clears non-empty API requirements', () => {
+      const apiTask = createApiTask({
+        traderRequirements: [
+          {
+            id: '6a5672392ee61bd094c49e28',
+            requirementType: 'level',
+            compareMethod: '>=',
+            value: 2,
+            trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' },
+          },
+        ],
+      });
+      const override: TaskOverride = { traderRequirements: [] };
+      const result = validateTaskOverride('test-task-id', override, [apiTask]);
+
+      expect(
+        result.details.some((d) => d.field === 'traderRequirements' && d.status === 'needed')
+      ).toBe(true);
+    });
+
+    it('returns no detail when both API and override requirements are empty', () => {
+      const apiTask = createApiTask({ traderRequirements: [] });
+      const override: TaskOverride = { traderRequirements: [] };
+      const result = validateTaskOverride('test-task-id', override, [apiTask]);
+
+      expect(result.details.some((d) => d.field === 'traderRequirements')).toBe(false);
     });
   });
 

--- a/tests/validate-script.test.ts
+++ b/tests/validate-script.test.ts
@@ -19,6 +19,7 @@ import {
   validateFile,
   validateLocaleEntityIds,
   validateSourceFiles,
+  validateTaskSourceFile,
   validateTraderRequirementIds,
 } from '../scripts/validate.js';
 
@@ -208,6 +209,72 @@ describe('scripts/validate helpers', () => {
     }
   });
 
+  it("rejects level requirements whose comparator is not '>='", () => {
+    const validators = initializeValidators();
+    const tempDir = mkdtempSync(join(tmpdir(), 'validate-json5-'));
+    const filePath = join(tempDir, 'tasks.json5');
+    writeFileSync(
+      filePath,
+      `{
+        'task-id': {
+          traderRequirements: [
+            {
+              id: '6a5672392ee61bd094c49e28',
+              requirementType: 'level',
+              compareMethod: '<=',
+              value: 2,
+              trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }
+            }
+          ]
+        }
+      }`,
+      'utf-8'
+    );
+
+    try {
+      const result = validateFile(filePath, 'overrides/tasks.json5', validators);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors?.some((error) => error.includes('must be equal to constant'))).toBe(
+        true
+      );
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('accepts a valid Loyalty Level requirement', () => {
+    const validators = initializeValidators();
+    const tempDir = mkdtempSync(join(tmpdir(), 'validate-json5-'));
+    const filePath = join(tempDir, 'tasks.json5');
+    writeFileSync(
+      filePath,
+      `{
+        'task-id': {
+          traderRequirements: [
+            {
+              id: '6a5672392ee61bd094c49e28',
+              requirementType: 'level',
+              compareMethod: '>=',
+              value: 4,
+              trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }
+            }
+          ]
+        }
+      }`,
+      'utf-8'
+    );
+
+    try {
+      const result = validateFile(filePath, 'overrides/tasks.json5', validators);
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toBeUndefined();
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it('rejects Loyalty Level zero', () => {
     const validators = initializeValidators();
     const tempDir = mkdtempSync(join(tmpdir(), 'validate-json5-'));
@@ -299,6 +366,136 @@ describe('scripts/validate helpers', () => {
 
       expect(result.valid).toBe(false);
       expect(result.errors?.some((error) => error.includes('must match pattern'))).toBe(true);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('runs trader requirement identity validation for matching task display paths', () => {
+    const validators = initializeValidators();
+    const tempDir = mkdtempSync(join(tmpdir(), 'validate-task-source-'));
+    const filePath = join(tempDir, 'tasks.json5');
+    writeFileSync(
+      filePath,
+      `{
+        '59674cd986f7744ab26e32f2': {
+          traderRequirements: [
+            {
+              id: 'overlay.657315e1dccd301f1301416a.54cb50c76803fa8b248b4571.level.>=.2',
+              requirementType: 'level',
+              compareMethod: '>=',
+              value: 2,
+              trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }
+            }
+          ]
+        }
+      }`,
+      'utf-8'
+    );
+
+    try {
+      const result = validateTaskSourceFile(filePath, 'overrides/tasks.json5', validators);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors?.some((error) => error.includes('synthetic id encodes task id'))).toBe(
+        true
+      );
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('accepts synthetic reputation ids with exponent-form values', () => {
+    const validators = initializeValidators();
+    const tempDir = mkdtempSync(join(tmpdir(), 'validate-json5-'));
+    const filePath = join(tempDir, 'tasks.json5');
+    writeFileSync(
+      filePath,
+      `{
+        '657315e1dccd301f1301416a': {
+          traderRequirements: [
+            {
+              id: 'overlay.657315e1dccd301f1301416a.579dc571d53a0658a154fbec.reputation.>=.1e+21',
+              requirementType: 'reputation',
+              compareMethod: '>=',
+              value: 1e+21,
+              trader: { id: '579dc571d53a0658a154fbec', name: 'Fence' }
+            }
+          ]
+        }
+      }`,
+      'utf-8'
+    );
+
+    try {
+      const result = validateTaskSourceFile(filePath, 'overrides/tasks.json5', validators);
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toBeUndefined();
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('accepts an occurrence-suffixed decimal reputation identity for a task path', () => {
+    const validators = initializeValidators();
+    const tempDir = mkdtempSync(join(tmpdir(), 'validate-task-source-'));
+    const filePath = join(tempDir, 'tasks.json5');
+    writeFileSync(
+      filePath,
+      `{
+        '657315e1dccd301f1301416a': {
+          traderRequirements: [
+            {
+              id: 'overlay.657315e1dccd301f1301416a.579dc571d53a0658a154fbec.reputation.>=.1.25.occurrence.2',
+              requirementType: 'reputation',
+              compareMethod: '>=',
+              value: 1.25,
+              trader: { id: '579dc571d53a0658a154fbec', name: 'Fence' }
+            }
+          ]
+        }
+      }`,
+      'utf-8'
+    );
+
+    try {
+      const result = validateTaskSourceFile(filePath, 'overrides/tasks.json5', validators);
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toBeUndefined();
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('skips trader requirement identity validation for non-task display paths', () => {
+    const validators = initializeValidators();
+    const tempDir = mkdtempSync(join(tmpdir(), 'validate-task-source-'));
+    const filePath = join(tempDir, 'tasks.json5');
+    writeFileSync(
+      filePath,
+      `{
+        '59674cd986f7744ab26e32f2': {
+          traderRequirements: [
+            {
+              id: 'overlay.657315e1dccd301f1301416a.54cb50c76803fa8b248b4571.level.>=.2',
+              requirementType: 'level',
+              compareMethod: '>=',
+              value: 2,
+              trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }
+            }
+          ]
+        }
+      }`,
+      'utf-8'
+    );
+
+    try {
+      const result = validateTaskSourceFile(filePath, 'overrides/not-tasks.json5', validators);
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toBeUndefined();
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }

--- a/tests/validate-script.test.ts
+++ b/tests/validate-script.test.ts
@@ -272,6 +272,38 @@ describe('scripts/validate helpers', () => {
     }
   });
 
+  it('rejects synthetic level ids with non-LL1-LL4 embedded values', () => {
+    const validators = initializeValidators();
+    const tempDir = mkdtempSync(join(tmpdir(), 'validate-json5-'));
+    const filePath = join(tempDir, 'tasks.json5');
+    writeFileSync(
+      filePath,
+      `{
+        '657315e1dccd301f1301416a': {
+          traderRequirements: [
+            {
+              id: 'overlay.657315e1dccd301f1301416a.54cb50c76803fa8b248b4571.level.>=.2.5',
+              requirementType: 'level',
+              compareMethod: '>=',
+              value: 2,
+              trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }
+            }
+          ]
+        }
+      }`,
+      'utf-8'
+    );
+
+    try {
+      const result = validateFile(filePath, 'overrides/tasks.json5', validators);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors?.some((error) => error.includes('must match pattern'))).toBe(true);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it('rejects synthetic ids whose embedded discriminator disagrees with the entry', () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'validate-req-id-'));
     const filePath = join(tempDir, 'tasks.json5');

--- a/tests/validate-script.test.ts
+++ b/tests/validate-script.test.ts
@@ -208,6 +208,70 @@ describe('scripts/validate helpers', () => {
     }
   });
 
+  it('rejects Loyalty Level zero', () => {
+    const validators = initializeValidators();
+    const tempDir = mkdtempSync(join(tmpdir(), 'validate-json5-'));
+    const filePath = join(tempDir, 'tasks.json5');
+    writeFileSync(
+      filePath,
+      `{
+        'task-id': {
+          traderRequirements: [
+            {
+              id: '6a5672392ee61bd094c49e28',
+              requirementType: 'level',
+              compareMethod: '>=',
+              value: 0,
+              trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }
+            }
+          ]
+        }
+      }`,
+      'utf-8'
+    );
+
+    try {
+      const result = validateFile(filePath, 'overrides/tasks.json5', validators);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors?.some((error) => error.includes('must be >= 1'))).toBe(true);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('accepts reputation zero', () => {
+    const validators = initializeValidators();
+    const tempDir = mkdtempSync(join(tmpdir(), 'validate-json5-'));
+    const filePath = join(tempDir, 'tasks.json5');
+    writeFileSync(
+      filePath,
+      `{
+        'task-id': {
+          traderRequirements: [
+            {
+              id: '66dace4d03b34844877a50fc',
+              requirementType: 'reputation',
+              compareMethod: '>=',
+              value: 0,
+              trader: { id: '579dc571d53a0658a154fbec', name: 'Fence' }
+            }
+          ]
+        }
+      }`,
+      'utf-8'
+    );
+
+    try {
+      const result = validateFile(filePath, 'overrides/tasks.json5', validators);
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toBeUndefined();
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it('rejects synthetic ids whose embedded discriminator disagrees with the entry', () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'validate-req-id-'));
     const filePath = join(tempDir, 'tasks.json5');

--- a/tests/validate-script.test.ts
+++ b/tests/validate-script.test.ts
@@ -125,6 +125,88 @@ describe('scripts/validate helpers', () => {
     }
   });
 
+  it('rejects trader requirement ids that match neither the upstream nor the synthetic shape', () => {
+    const validators = initializeValidators();
+    const tempDir = mkdtempSync(join(tmpdir(), 'validate-json5-'));
+    const filePath = join(tempDir, 'tasks.json5');
+    // Missing the 'overlay.' prefix, so consumers merging patch-by-id would
+    // treat it as an upstream id that does not exist.
+    writeFileSync(
+      filePath,
+      `{
+        'task-id': {
+          traderRequirements: [
+            {
+              id: '657315e1dccd301f1301416a.54cb50c76803fa8b248b4571.level.>=.1',
+              requirementType: 'level',
+              compareMethod: '>=',
+              value: 1,
+              trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }
+            }
+          ]
+        }
+      }`,
+      'utf-8'
+    );
+
+    try {
+      const result = validateFile(filePath, 'overrides/tasks.json5', validators);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors?.some((error) => error.includes('must match pattern'))).toBe(true);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('accepts upstream, composite upstream, and synthetic trader requirement ids', () => {
+    const validators = initializeValidators();
+    const tempDir = mkdtempSync(join(tmpdir(), 'validate-json5-'));
+    const filePath = join(tempDir, 'tasks.json5');
+    // Upstream serves both '<24-hex>' and composite '<taskId>-<traderId>' ids;
+    // overlay-authored entries use the synthetic 'overlay.' form.
+    writeFileSync(
+      filePath,
+      `{
+        'task-id': {
+          traderRequirements: [
+            {
+              id: '6a5672392ee61bd094c49e28',
+              requirementType: 'level',
+              compareMethod: '>=',
+              value: 2,
+              trader: { id: '54cb57776803fa99248b456e', name: 'Therapist' }
+            },
+            {
+              id: '61e6e60c5ca3b3783662be27-579dc571d53a0658a154fbec',
+              requirementType: 'reputation',
+              compareMethod: '<=',
+              value: -3,
+              trader: { id: '579dc571d53a0658a154fbec', name: 'Fence' }
+            },
+            {
+              id: 'overlay.657315e1dccd301f1301416a.54cb50c76803fa8b248b4571.level.>=.1',
+              requirementType: 'level',
+              compareMethod: '>=',
+              value: 1,
+              trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }
+            }
+          ]
+        }
+      }`,
+      'utf-8'
+    );
+
+    try {
+      const result = validateFile(filePath, 'overrides/tasks.json5', validators);
+
+      expect(result.errors).toBeUndefined();
+      expect(result.valid).toBe(true);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it('rejects locale patches for unknown local entity IDs', () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'validate-locale-'));
     const filePath = join(tempDir, 'en.json5');

--- a/tests/validate-script.test.ts
+++ b/tests/validate-script.test.ts
@@ -91,6 +91,40 @@ describe('scripts/validate helpers', () => {
     }
   });
 
+  it('rejects ambiguous trader requirements missing the semantic discriminator', () => {
+    const validators = initializeValidators();
+    const tempDir = mkdtempSync(join(tmpdir(), 'validate-json5-'));
+    const filePath = join(tempDir, 'tasks.json5');
+    // Pre-#274 reduced shape: trader + value, no id/requirementType/compareMethod.
+    writeFileSync(
+      filePath,
+      `{
+        'task-id': {
+          traderRequirements: [
+            { trader: { id: 'prapor', name: 'Prapor' }, value: 1 }
+          ]
+        }
+      }`,
+      'utf-8'
+    );
+
+    try {
+      const result = validateFile(filePath, 'overrides/tasks.json5', validators);
+
+      expect(result.valid).toBe(false);
+      expect(
+        result.errors?.some(
+          (error) =>
+            error.includes("must have required property 'requirementType'") ||
+            error.includes("must have required property 'compareMethod'") ||
+            error.includes("must have required property 'id'")
+        )
+      ).toBe(true);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it('rejects locale patches for unknown local entity IDs', () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'validate-locale-'));
     const filePath = join(tempDir, 'en.json5');

--- a/tests/validate-script.test.ts
+++ b/tests/validate-script.test.ts
@@ -19,6 +19,7 @@ import {
   validateFile,
   validateLocaleEntityIds,
   validateSourceFiles,
+  validateTraderRequirementIds,
 } from '../scripts/validate.js';
 
 describe('scripts/validate helpers', () => {
@@ -199,6 +200,126 @@ describe('scripts/validate helpers', () => {
 
     try {
       const result = validateFile(filePath, 'overrides/tasks.json5', validators);
+
+      expect(result.errors).toBeUndefined();
+      expect(result.valid).toBe(true);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects synthetic ids whose embedded discriminator disagrees with the entry', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'validate-req-id-'));
+    const filePath = join(tempDir, 'tasks.json5');
+    // id says 'level >= 2' for task 657315e1...; the entry declares reputation >= 1
+    // under a different task key.
+    writeFileSync(
+      filePath,
+      `{
+        '59674cd986f7744ab26e32f2': {
+          traderRequirements: [
+            {
+              id: 'overlay.657315e1dccd301f1301416a.54cb50c76803fa8b248b4571.level.>=.2',
+              requirementType: 'reputation',
+              compareMethod: '>=',
+              value: 1,
+              trader: { id: '579dc571d53a0658a154fbec', name: 'Fence' }
+            }
+          ]
+        }
+      }`,
+      'utf-8'
+    );
+
+    try {
+      const result = validateTraderRequirementIds(filePath, 'overrides/tasks.json5');
+
+      expect(result.valid).toBe(false);
+      // compareMethod is the only segment that agrees, so four fields mismatch.
+      expect(result.errors).toHaveLength(4);
+      for (const field of ['task id', 'trader.id', 'requirementType', 'value']) {
+        expect(result.errors?.some((error) => error.includes(field))).toBe(true);
+      }
+      expect(result.errors?.some((error) => error.includes('compareMethod'))).toBe(false);
+      expect(
+        result.errors?.[0].startsWith('/59674cd986f7744ab26e32f2/traderRequirements/0/id:')
+      ).toBe(true);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects duplicate trader requirement ids within one task', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'validate-req-id-'));
+    const filePath = join(tempDir, 'tasks.json5');
+    // Patch-by-id would collapse these two entries into one.
+    writeFileSync(
+      filePath,
+      `{
+        '59674cd986f7744ab26e32f2': {
+          traderRequirements: [
+            {
+              id: '6a5672392ee61bd094c49e28',
+              requirementType: 'level',
+              compareMethod: '>=',
+              value: 2,
+              trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }
+            },
+            {
+              id: '6a5672392ee61bd094c49e28',
+              requirementType: 'level',
+              compareMethod: '>=',
+              value: 3,
+              trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }
+            }
+          ]
+        }
+      }`,
+      'utf-8'
+    );
+
+    try {
+      const result = validateTraderRequirementIds(filePath, 'overrides/tasks.json5');
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toEqual([
+        "/59674cd986f7744ab26e32f2/traderRequirements/1/id: duplicate requirement id '6a5672392ee61bd094c49e28' within the same task",
+      ]);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('accepts synthetic ids derived from the entry they label', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'validate-req-id-'));
+    const filePath = join(tempDir, 'tasks.json5');
+    writeFileSync(
+      filePath,
+      `{
+        '657315e1dccd301f1301416a': {
+          traderRequirements: [
+            {
+              id: 'overlay.657315e1dccd301f1301416a.54cb50c76803fa8b248b4571.level.>=.1',
+              requirementType: 'level',
+              compareMethod: '>=',
+              value: 1,
+              trader: { id: '54cb50c76803fa8b248b4571', name: 'Prapor' }
+            },
+            {
+              id: 'overlay.657315e1dccd301f1301416a.579dc571d53a0658a154fbec.reputation.<=.-3',
+              requirementType: 'reputation',
+              compareMethod: '<=',
+              value: -3,
+              trader: { id: '579dc571d53a0658a154fbec', name: 'Fence' }
+            }
+          ]
+        }
+      }`,
+      'utf-8'
+    );
+
+    try {
+      const result = validateTraderRequirementIds(filePath, 'overrides/tasks.json5');
 
       expect(result.errors).toBeUndefined();
       expect(result.valid).toBe(true);


### PR DESCRIPTION
## Summary

Closes #274 — publish trader requirements in `json.tarkov.dev`'s **discriminated** shape instead of the ambiguous reduced `{ trader, value }` form.

## What changed

- **Types** (`src/lib/types.ts`): new shared `TraderRequirement` interface (`id`, `requirementType: 'level' | 'reputation'`, `compareMethod`, `value`, `trader`), used by `TaskOverride`, `TaskAddition`, and `TaskData`.
- **Adapter** (`src/lib/tarkov-api.ts`): `adaptTraderRequirement` now normalizes the upstream `id` so the merge identity survives adaptation.
- **Data** (`src/overrides/tasks.json5`): all 245 remaining LL corrections now carry an explicit `requirementType: 'level'`, `compareMethod: '>='`, and a stable merge identity:
  - **59** reuse the upstream requirement `id` (where the requirement now exists upstream).
  - **186** use deterministic synthetic ids `overlay.<taskId>.<traderId>.<type>.<method>.<value>`.
- **Removed 3 mislabeled entries** (Establish Contact, Collector, Is This a Reference?): these were authored as "Fence LL1" but are actually Fence **reputation** (scav karma) gates. Upstream now serves the correct discriminated entries (reputation `>= 4` / `>= 3` / `>= 1`) and the wiki agrees.
  - Proof: [Establish Contact](https://escapefromtarkov.fandom.com/wiki/Establish_Contact) (scav karma +4), [Collector](https://escapefromtarkov.fandom.com/wiki/Collector) (scav karma +3 + 7× LL4), [Is This a Reference?](https://escapefromtarkov.fandom.com/wiki/Is_This_a_Reference%3F) (scav karma +1).
- **Schemas** (both task schemas): require `id`/`requirementType`/`compareMethod`; `value` is integer 0–4 for `level`, any number (incl. negative) for `reputation`.
- **Validator** (`src/lib/task-validator.ts`): compares requirements by semantic identity (trader + type + method + value, ignoring `id`) so synthetic ids don't flip verdicts; an empty `[]` that clears upstream requirements is now flagged as NEEDED instead of silently passing.
- **check-overrides**: new per-mode `TRADER REQUIREMENT TYPE COUNTS` report (regular 108/12, pve 109/12, pvp-season 108/12 — matching the issue's evidence).
- **Docs**: `INTEGRATION.md` documents the canonical shape + patch-by-id merge contract (incl. clearing and a migration note); `MASTER_SAMPLES.md` updated.
- **Tests**: new cases for semantic-identity matching (incl. the Fence LL1 vs `reputation >= 1` distinction), clearing semantics, `countRequirementTypes`, and schema rejection of ambiguous entries.

## Commands run

- `npm run validate` ✅
- `npm run typecheck` ✅
- `npm test` (408 passed) ✅
- `npm run format:check` ✅
- `npm run lint:markdown` ✅
- `npm run build` ✅ (dist regenerated; reverted from the PR per repo convention — CI rebuilds on main)
- `npm run check-overrides` ✅ (live API: counts section + validator output verified)

## Notes

- Two entries (The Punisher - Part 3 `59c50c8886f7745fed3193bf`, The Huntsman Path - Controller `5d25e2d886f77442734d335e`) still patch an upstream value (overlay LL4 vs upstream LL3). Their discriminator is now explicit and `check-overrides` surfaces the value divergence for review; the value itself is unchanged from before this PR.
- The 57 "guard" entries that now reuse upstream ids show `FIXED IN API` in `check-overrides` (same as before this change — they were already redundant-by-value). Kept as deliberate guards rather than pruned here to keep the PR scoped to discriminator preservation.

## Review follow-ups (cubic)

Three findings from the cubic review were fixed on this branch; one was disputed with the underlying concern deferred to a tracked issue.

- `a62021a` **docs**: the `applyTraderRequirements` example patched by id only, so it could not express the clearing semantics documented right below it. Added the empty-array early return plus the `undefined` ("no change") vs `[]` ("clear") note. Also corrected the upstream id description — tarkov.dev serves 3 composite `<taskId>-<traderId>` ids alongside 358 plain 24-hex ones.
- `dd58f8a` **schemas**: `id` was required but unconstrained, so a malformed synthetic id passed `npm run validate`. Added a `pattern` accepting only the three shapes that exist (plain upstream, composite upstream, `overlay.` synthetic) to both task schemas. All 245 authored ids validate unchanged.
- `01efabe` **validate**: the schema pattern proves an id's shape but not its content, so `overlay.<taskId>.<traderId>.level.>=.2` could sit next to `requirementType: 'reputation'` — which breaks determinism, since regenerating the id from the fields would yield a different merge identity. `npm run validate` now cross-checks all five segments against the entry and rejects two requirements in one task sharing an id. All 186 authored synthetic ids pass unchanged.
- `43e1f7b` **disputed**: cubic asked for `traderRequirementKey` to report `NEEDED` when the API omits a requirement `id`. Declined — an override cannot address an id-less upstream entry, so keeping it would append a duplicate requirement under patch-by-id; `FIXED` ("remove it") is the correct guidance. Also not reachable today: 361/361 live trader requirements carry an `id`. The behaviour is now pinned by a regression test and documented at the call site. The legitimate part — no signal if upstream ever ships id-less requirements — is tracked in #276.

Additional commands run for these commits: `npm run validate`, `npm run typecheck`, `npm test` (414 passed), `npm run format:check`, `npm run lint:markdown`, `npm run fallow:check`, `npm audit --audit-level=high`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tarkovtracker-org/tarkov-data-overlay/pull/275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


